### PR TITLE
Intent compressor contract

### DIFF
--- a/contracts/compressor/IntentCompressor.sol
+++ b/contracts/compressor/IntentCompressor.sol
@@ -78,6 +78,15 @@ contract IntentCompressor {
         bytes32 routeHash = keccak256(abi.encode(route));
         bytes32 intentHash = keccak256(abi.encodePacked(routeHash, rewardHash));
 
+        require(
+            route.tokens.length == 1,
+            "Cannot fulfill intent multiple tokens"
+        );
+
+        // Approve route token
+        TokenAmount memory routeToken = route.tokens[0];
+        IERC20(routeToken.token).approve(address(INBOX), routeToken.amount);
+
         if (encodedFulfillment.proveType == 1) {
             return
                 INBOX.fulfillHyperBatched(

--- a/contracts/compressor/IntentCompressor.sol
+++ b/contracts/compressor/IntentCompressor.sol
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.10;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {IInbox} from "../interfaces/IInbox.sol";
+import {IIntentSource} from "../interfaces/IIntentSource.sol";
+import {Intent, Call, TokenAmount, Route, Reward} from "../types/Intent.sol";
+
+struct EncodedIntent {
+    uint8 sourceChainIndex;
+    uint8 destinationChainIndex;
+    // Reward token
+    uint8 rewardTokenIndex;
+    uint48 rewardAmount;
+    // Route token
+    uint8 routeTokenIndex;
+    uint48 routeAmount;
+    // Expiry duration
+    uint24 expiryDuration;
+}
+
+struct EncodedFulfillment {
+    uint8 sourceChainIndex;
+    uint8 destinationChainIndex;
+    // Reward token
+    uint8 routeTokenIndex;
+    uint48 routeAmount;
+    // Prove type (INSTANT = 0, BATCH = 1)
+    uint8 proveType;
+    // Claimant
+    address claimant;
+}
+
+contract IntentCompressor {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Thrown when the vault has insufficient token allowance for reward funding
+     * @param token The token address
+     * @param spender The spender address
+     * @param amount The amount of tokens required
+     */
+    error InsufficientTokenAllowance(
+        address token,
+        address spender,
+        uint256 amount
+    );
+
+    address public immutable PROVER;
+    IInbox public immutable INBOX;
+    IIntentSource public immutable INTENT_SOURCE;
+
+    constructor(address _intentSource, address _inbox, address _prover) {
+        INBOX = IInbox(_inbox);
+        INTENT_SOURCE = IIntentSource(_intentSource);
+        PROVER = _prover;
+    }
+
+    function fulfill(
+        bytes32 payload,
+        bytes32 rewardHash,
+        bytes32 routeSalt
+    ) external returns (bytes[] memory) {
+        EncodedFulfillment memory encodedFulfillment = decodeFulfillPayload(
+            payload
+        );
+
+        Route memory route = _constructRoute(
+            routeSalt,
+            encodedFulfillment.sourceChainIndex,
+            encodedFulfillment.destinationChainIndex,
+            encodedFulfillment.routeTokenIndex,
+            encodedFulfillment.routeAmount
+        );
+
+        bytes32 routeHash = keccak256(abi.encode(route));
+        bytes32 intentHash = keccak256(abi.encodePacked(routeHash, rewardHash));
+
+        if (encodedFulfillment.proveType == 1) {
+            return
+                INBOX.fulfillHyperBatched(
+                    route,
+                    rewardHash,
+                    encodedFulfillment.claimant,
+                    intentHash,
+                    PROVER
+                );
+        } else {
+            return
+                INBOX.fulfillHyperInstant(
+                    route,
+                    rewardHash,
+                    encodedFulfillment.claimant,
+                    intentHash,
+                    PROVER
+                );
+        }
+    }
+
+    function publishTransferIntentAndFund(
+        bytes32 payload
+    ) external returns (bytes32 intentHash) {
+        EncodedIntent memory encodedIntent = decodePublishPayload(payload);
+        Intent memory intent = _constructIntent(encodedIntent);
+
+        _fundIntent(intent);
+
+        return INTENT_SOURCE.publishAndFund(intent, false);
+    }
+
+    // ======================== Public Functions ========================
+
+    function getChainIds() public pure returns (uint16[6] memory) {
+        return [1, 10, 137, 8453, 5000, 42161];
+    }
+
+    function getTokens() public pure returns (address[15] memory) {
+        return [
+            // Ethereum
+            0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
+            0xdAC17F958D2ee523a2206206994597C13D831ec7, // USDT
+            // Optimism
+            0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85, // USDC
+            0x94b008aA00579c1307B0EF2c499aD98a8ce58e58, // USDT
+            0x7F5c764cBc14f9669B88837ca1490cCa17c31607, // USDC.e
+            // Polygon
+            0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359, // USDC
+            0xc2132D05D31c914a87C6611C10748AEb04B58e8F, // USDT
+            0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174, // USDC.e
+            // Base
+            0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913, // USDC
+            0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA, // USDbC
+            // Mantle
+            0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE, // USDT
+            0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9, // USDC
+            // Arbitrum
+            0xaf88d065e77c8cC2239327C5EDb3A432268e5831, // USDC
+            0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8, // USDC.e
+            0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9 // USDT
+        ];
+    }
+
+    function decodePublishPayload(
+        bytes32 payload
+    ) public pure returns (EncodedIntent memory) {
+        return
+            EncodedIntent({
+                sourceChainIndex: uint8(payload[0]), // uint8
+                destinationChainIndex: uint8(payload[1]), // uint8
+                rewardTokenIndex: uint8(payload[2]), // uint8
+                // Reads bytes 3 to 8 and converts them to uint48
+                rewardAmount: uint48(_extractUint(payload, 3, 8)), // uint48
+                routeTokenIndex: uint8(payload[9]), // uint8
+                // Reads bytes 10 to 15 and converts them to uint48
+                routeAmount: uint48(_extractUint(payload, 10, 15)), // uint48
+                expiryDuration: uint24(_extractUint(payload, 16, 18)) // uint24
+            });
+    }
+
+    function decodeFulfillPayload(
+        bytes32 payload
+    ) public pure returns (EncodedFulfillment memory) {
+        return
+            EncodedFulfillment({
+                sourceChainIndex: uint8(payload[0]), // uint8
+                destinationChainIndex: uint8(payload[1]), // uint8
+                routeTokenIndex: uint8(payload[2]), // uint8
+                // Reads bytes 10 to 15 and converts them to uint48
+                routeAmount: uint48(_extractUint(payload, 3, 8)), // uint48
+                proveType: uint8(payload[9]),
+                claimant: address(uint160(_extractUint(payload, 10, 29))) // uint48
+            });
+    }
+
+    // ======================== Internal Functions ========================
+
+    function _fundIntent(Intent memory intent) internal {
+        address funder = msg.sender;
+        TokenAmount[] memory tokens = intent.reward.tokens;
+
+        // Get vault address from intent
+        address vault = INTENT_SOURCE.intentVaultAddress(intent);
+
+        // Cache tokens length
+        uint256 rewardsLength = tokens.length;
+
+        // Iterate through each token in the reward structure
+        for (uint256 i; i < rewardsLength; ++i) {
+            // Get token address and required amount for current reward
+            address token = tokens[i].token;
+            uint256 amount = tokens[i].amount;
+            uint256 balance = IERC20(token).balanceOf(vault);
+
+            // Only proceed if vault needs more tokens and we have permission to transfer them
+            if (amount > balance) {
+                // Calculate how many more tokens the vault needs to be fully funded
+                uint256 remainingAmount = amount - balance;
+
+                // Check how many tokens this contract is allowed to transfer from funding source
+                uint256 allowance = IERC20(token).allowance(
+                    funder,
+                    address(this)
+                );
+
+                // Check if allowance is sufficient to fund intent
+                if (allowance < remainingAmount) {
+                    revert InsufficientTokenAllowance(
+                        token,
+                        funder,
+                        remainingAmount
+                    );
+                }
+
+                // Transfer tokens from funding source to vault using safe transfer
+                IERC20(token).safeTransferFrom(funder, vault, remainingAmount);
+            }
+        }
+    }
+
+    function _constructIntent(
+        EncodedIntent memory encodedIntent
+    ) internal view returns (Intent memory) {
+        Route memory route = _constructRoute(
+            _randomBytes32(),
+            encodedIntent.sourceChainIndex,
+            encodedIntent.destinationChainIndex,
+            encodedIntent.routeTokenIndex,
+            encodedIntent.routeAmount
+        );
+
+        Reward memory reward = _constructReward(
+            encodedIntent.rewardTokenIndex,
+            encodedIntent.rewardAmount,
+            encodedIntent.expiryDuration
+        );
+
+        return Intent({route: route, reward: reward});
+    }
+
+    function _constructReward(
+        uint8 rewardTokenIndex,
+        uint48 rewardAmount,
+        uint24 expiryDuration
+    ) internal view returns (Reward memory) {
+        TokenAmount memory rewardToken = TokenAmount({
+            token: getTokens()[rewardTokenIndex],
+            amount: rewardAmount
+        });
+
+        TokenAmount[] memory rewardTokens;
+        rewardTokens[0] = rewardToken;
+
+        return
+            Reward({
+                nativeValue: 0,
+                prover: PROVER,
+                creator: msg.sender,
+                tokens: rewardTokens,
+                deadline: block.timestamp + expiryDuration
+            });
+    }
+
+    function _constructRoute(
+        bytes32 salt,
+        uint8 sourceChainIndex,
+        uint8 destinationChainIndex,
+        uint8 routeTokenIndex,
+        uint256 routeAmount
+    ) internal view returns (Route memory) {
+        address routeTokenTarget = getTokens()[routeTokenIndex];
+
+        Call memory routeCallTransfer = Call({
+            target: routeTokenTarget,
+            value: 0,
+            data: abi.encodeCall(IERC20.transfer, (msg.sender, routeAmount))
+        });
+
+        TokenAmount memory routeToken = TokenAmount({
+            token: routeTokenTarget,
+            amount: routeAmount
+        });
+
+        TokenAmount[] memory routeTokens;
+        routeTokens[0] = routeToken;
+
+        Call[] memory routeCalls;
+        routeCalls[0] = routeCallTransfer;
+
+        return
+            Route({
+                inbox: address(INBOX),
+                salt: salt,
+                source: getChainIds()[sourceChainIndex],
+                destination: getChainIds()[destinationChainIndex],
+                calls: routeCalls,
+                tokens: routeTokens
+            });
+    }
+
+    // ======================== Private Functions ========================
+
+    function _randomBytes32() private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(block.timestamp, block.prevrandao, msg.sender)
+            );
+    }
+
+    function _extractUint(
+        bytes32 data,
+        uint8 start,
+        uint8 end
+    ) private pure returns (uint256) {
+        require(start < end, "range has to be greater than zero");
+        require(end <= 32, "Out of bounds");
+
+        uint256 length = end - start + 1;
+        uint256 result;
+        for (uint8 i = 0; i < length; i++) {
+            result |= uint256(uint8(data[start + i])) << ((length - 1 - i) * 8);
+        }
+        return result;
+    }
+}

--- a/test/IntentCompressor.spec.ts
+++ b/test/IntentCompressor.spec.ts
@@ -1,0 +1,195 @@
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import {
+  TestERC20,
+  IntentSource,
+  TestProver,
+  Inbox,
+  IntentCompressor,
+} from '../typechain-types'
+import { time, loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { keccak256, BytesLike, ZeroAddress } from 'ethers'
+import { encodeIdentifier, encodeTransfer } from '../utils/encode'
+import {
+  intentVaultAddress,
+  Call,
+  TokenAmount,
+  Route,
+  Reward,
+  Intent,
+} from '../utils/intent'
+import { decode } from 'punycode'
+import { EncodedFulfillmentStruct, EncodedIntentStruct } from '../typechain-types/contracts/compressor/IntentCompressor'
+
+describe('Intent Compressor Test', (): void => {
+  let intentSource: IntentSource
+  let prover: TestProver
+  let compressor: IntentCompressor
+  let inbox: Inbox
+  let tokenA: TestERC20
+  let tokenB: TestERC20
+  let creator: SignerWithAddress
+  let claimant: SignerWithAddress
+  let otherPerson: SignerWithAddress
+  const mintAmount: number = 1000
+
+  let route: Route
+  let reward: Reward
+  let intent: Intent
+
+  enum ChainIdIndex {
+    ETHEREUM,
+    OPTIMISM,
+    POLYGON,
+    BASE,
+    MANTLE,
+    ARBITRUM,
+  }
+
+  enum TokenIndex {
+    ETH_USDC,
+    ETH_USDT,
+    OP_USDC,
+    OP_USDT,
+    OP_USDCe,
+    POL_USDC,
+    POL_USDT,
+    POL_USDCe,
+    BASE_USDC,
+    BASE_USDbC,
+    MNT_USDC,
+    MNT_USDT,
+    ARB_USDC,
+    ARB_USDT,
+    ARB_USDCe,
+  }
+
+
+  const createIntentData: EncodedIntentStruct = {
+    sourceChainIndex: ChainIdIndex.BASE,
+    destinationChainIndex: ChainIdIndex.OPTIMISM,
+    rewardTokenIndex: TokenIndex.BASE_USDC,
+    rewardAmount: (2n ** 48n) - 1n, // 1.01 MM
+    routeTokenIndex: TokenIndex.OP_USDC,
+    routeAmount: (2n ** 48n) - 1n, // 1 MM,
+    expiryDuration: (2n ** 24n) - 1n
+  }
+
+
+  let fulfillData: EncodedFulfillmentStruct;
+
+  async function deploySourceFixture(): Promise<{
+    intentSource: IntentSource
+    prover: TestProver
+    compressor: IntentCompressor
+    tokenA: TestERC20
+    tokenB: TestERC20
+    creator: SignerWithAddress
+    claimant: SignerWithAddress
+    otherPerson: SignerWithAddress
+  }> {
+    const [creator, owner, claimant, otherPerson] = await ethers.getSigners()
+    // deploy prover
+    prover = await (await ethers.getContractFactory('TestProver')).deploy()
+
+    const intentSourceFactory = await ethers.getContractFactory('IntentSource')
+    const intentSource = await intentSourceFactory.deploy() as IntentSource
+    inbox = await (
+      await ethers.getContractFactory('Inbox')
+    ).deploy(owner.address, false, [owner.address])
+
+    compressor = await (
+      await ethers.getContractFactory('IntentCompressor')
+    ).deploy(await intentSource.getAddress(), await inbox.getAddress(), await prover.getAddress())
+
+    // deploy ERC20 test
+    const erc20Factory = await ethers.getContractFactory('TestERC20')
+    const tokenA = await erc20Factory.deploy('A', 'A')
+    const tokenB = await erc20Factory.deploy('B', 'B')
+
+    fulfillData = {
+      sourceChainIndex: ChainIdIndex.BASE,
+      destinationChainIndex: ChainIdIndex.OPTIMISM,
+      routeTokenIndex: TokenIndex.OP_USDC,
+      routeAmount: (2n ** 48n) - 1n, // 1 MM,
+      claimant: claimant.address,
+      proveType: 1,
+    }
+
+    return {
+      intentSource,
+      compressor,
+      prover,
+      tokenA,
+      tokenB,
+      creator,
+      claimant,
+      otherPerson,
+    }
+  }
+
+  async function mintAndApprove() {
+    await tokenA.connect(creator).mint(creator.address, mintAmount)
+    await tokenB.connect(creator).mint(creator.address, mintAmount * 2)
+
+    await tokenA.connect(creator).approve(intentSource, mintAmount)
+    await tokenB.connect(creator).approve(intentSource, mintAmount * 2)
+  }
+
+  function encodeIntentPayload(data: EncodedIntentStruct) {
+    const packed = ethers.solidityPacked(
+      ['uint8', 'uint8', 'uint8', 'uint48', 'uint8', 'uint48', 'uint24'],
+      [data.sourceChainIndex, data.destinationChainIndex, data.rewardTokenIndex, data.rewardAmount, data.routeTokenIndex, data.routeAmount, data.expiryDuration]
+    )
+    return ethers.zeroPadBytes(packed, 32);
+  }
+
+
+  function encodeFulfillPayload(data: EncodedFulfillmentStruct) {
+    const packed = ethers.solidityPacked(
+      ['uint8', 'uint8', 'uint8', 'uint48', 'uint8', 'address'],
+      [data.sourceChainIndex, data.destinationChainIndex, data.routeTokenIndex, data.routeAmount, data.proveType, data.claimant]
+    )
+    return ethers.zeroPadBytes(packed, 32);
+  }
+
+  beforeEach(async (): Promise<void> => {
+    ; ({ intentSource, compressor, prover, tokenA, tokenB, creator, claimant, otherPerson } =
+      await loadFixture(deploySourceFixture))
+
+    // fund the creator and approve it to create an intent
+    await mintAndApprove()
+  })
+
+  describe('intent creation', async () => {
+    it('check encoded intent publish', async () => {
+      const payload = encodeIntentPayload(createIntentData);
+      const decodedIntent = await compressor.decodePublishPayload(payload);
+
+      expect(decodedIntent[0]).to.eq(createIntentData.sourceChainIndex)
+      expect(decodedIntent[1]).to.eq(createIntentData.destinationChainIndex)
+      expect(decodedIntent[2]).to.eq(createIntentData.rewardTokenIndex)
+      expect(decodedIntent[3]).to.eq(createIntentData.rewardAmount)
+      expect(decodedIntent[4]).to.eq(createIntentData.routeTokenIndex)
+      expect(decodedIntent[5]).to.eq(createIntentData.routeAmount)
+      expect(decodedIntent[6]).to.eq(createIntentData.expiryDuration)
+    })
+
+  })
+
+  describe('fulfill', async () => {
+    it('check encoded fulfill', async () => {
+      const payload = encodeFulfillPayload(fulfillData);
+      const decodedIntent = await compressor.decodeFulfillPayload(payload);
+
+      expect(decodedIntent[0]).to.eq(fulfillData.sourceChainIndex)
+      expect(decodedIntent[1]).to.eq(fulfillData.destinationChainIndex)
+      expect(decodedIntent[2]).to.eq(fulfillData.routeTokenIndex)
+      expect(decodedIntent[3]).to.eq(fulfillData.routeAmount)
+      expect(decodedIntent[4]).to.eq(fulfillData.proveType)
+      expect(decodedIntent[5]).to.eq(fulfillData.claimant)
+    })
+
+  })
+})


### PR DESCRIPTION
# Sky-blue project 🌞 
## WIP
This is still a work in progress, and a couple of things are missing, like gas optimization, organizing, renamaing amount others.

# Summary
This contract reduces transaction call data and fees by compressing simple transfer intents and fulfillment.

This contract is immutable, meaning if more chains, tokens, or eco protocol contracts are needed, a new instance of the contract will have to be deployed with the new addresses.

## Compressing Intent Creations
This contract only supports one type of intent, a simple transfer intent. This type of intent takes a single token as a reward and a single token for the route, doing a `transfer` of the full token amount to a recipient.

Some values are already defined in the Compress contract, and depending on their nature, others are calculated on the fly. 

The salt has to be a random bytes32. We're using a simple algorithm to calculate it, which can be predetermined, but there isn't a security risk if it happens.

**Using this contract, the payload to create an intent is compressed from 29 storage slots ([sample tx](https://optimistic.etherscan.io/tx/0x4be63b29106dced5d4933ed7577582523b1d83d062132321b53ea9f0dcdcb41f)) to a single storage slot (bytes32) 🙂** 

The payload is a `bytes32` string derived from the following struct after using `abi.encodePacked`:
```solidity
struct EncodedIntent {
    uint8 sourceChainIndex;
    uint8 destinationChainIndex;
    // Reward token
    uint8 rewardTokenIndex;
    uint48 rewardAmount;
    // Route token
    uint8 routeTokenIndex;
    uint48 routeAmount;
    // Expiry duration
    uint24 expiryDuration;
}
```

## Compressing fulfillment

Using the same approach as publishing intents, fulfillment cannot calculate values on the fly since the data has to match the intent exactly. Values like the salt and the reward hash cannot be compressed.

The fulfill function is expected to be called using `DELEGATECALL` to access the wallet's funds.

**Using this contract, the payload to fulfill an intent is compressed from ~30 storage slots ([sample tx](https://optimistic.etherscan.io/tx/0x3e056fc634d9ddb2dbaf8f17e4a150ef523054cce330fd0826de9b1b5fac5310)) and two batched calls (including approval) to one call and three storage slot (3 bytes32) 🙂** 

The payload is a `bytes32` string derived from the following struct after using `abi.encodePacked`:
```solidity
struct EncodedFulfillment {
    uint8 sourceChainIndex;
    uint8 destinationChainIndex;
    // Reward token
    uint8 routeTokenIndex;
    uint48 routeAmount;
    // Prove type (INSTANT = 0, BATCH = 1)
    uint8 proveType;
    // Claimant
    address claimant;
}
```
