### PR TITLE
exit on deploy fail so we dont publish npm with fake contract addresses

### DIFF
--- a/scripts/MultiDeploy.sh
+++ b/scripts/MultiDeploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#Exit immediately if a command exits with a non-zero status.
+set -e
 
 # Load environment variables from .env safely
 if [ -f .env ]; then


### PR DESCRIPTION
this prevents us from publishing a package that lacks a required contract deploy(which happened) and caused a crash in the solver