### PR TITLE
Fix: Add Hyperprover address as one of the allowed provers

### DIFF
--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -111,9 +111,15 @@ contract Deploy is Script {
 
         // Deploy HyperProver - using a code block to manage variable lifetimes
         {
+            address hyperProverPreviewAddr = create3Deployer.deployedAddress(
+                0x00, // Bytecode isn't used to determine the deployed address
+                ctx.deployer,
+                ctx.hyperProverSalt
+            );
+
             // Initialize provers array properly with inbox address
             address[] memory provers = new address[](1);
-            provers[0] = ctx.inbox;
+            provers[0] = hyperProverPreviewAddr;
 
             ctx.hyperProverConstructorArgs = abi.encode(
                 ctx.mailbox,


### PR DESCRIPTION
This pull request modifies the deployment script for the `HyperProver` contract to improve how the `provers` array is initialized. The most important change involves using a precomputed deployed address for the `hyperProverPreviewAddr` instead of directly assigning the inbox address.

### Deployment improvements:
* [`scripts/Deploy.s.sol`](diffhunk://#diff-5e8c563035f6c91020388063417af14ab9abea6bee923af6c0fa8ff39d4fbdb6R114-R122): Added a new variable `hyperProverPreviewAddr` to compute the deployed address using the `create3Deployer.deployedAddress` function. This address is then used to initialize the `provers` array, replacing the direct assignment of `ctx.inbox`.