### PR TITLE
Fix the "Is prover called" validation during fulfillments

### DIFF
--- a/contracts/test/TestUSDT.sol
+++ b/contracts/test/TestUSDT.sol
@@ -1,0 +1,24 @@
+/* -*- c-basic-offset: 4 -*- */
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+contract TestUSDT is ERC20, ERC165 {
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) ERC20(name_, symbol_) {}
+
+    function mint(address recipient, uint256 amount) public {
+        _mint(recipient, amount);
+    }
+
+    function transferPayable(
+        address recipient,
+        uint256 amount
+    ) public payable returns (bool) {
+        return transfer(recipient, amount);
+    }
+}

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -116,7 +116,11 @@ describe('HyperProver Test', (): void => {
       await expect(
         hyperProver
           .connect(owner)
-          .handle(12345, ethers.sha256('0x'), ethers.sha256('0x')),
+          .handle(
+            12345,
+            ethers.zeroPadValue(owner.address, 32),
+            ethers.sha256('0x'),
+          ),
       ).to.be.revertedWithCustomError(hyperProver, 'UnauthorizedIncomingProof')
     })
 

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -1,7 +1,7 @@
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { TestERC20, Inbox, TestProver } from '../typechain-types'
+import { TestERC20, TestUSDT, Inbox, TestProver } from '../typechain-types'
 import {
   time,
   loadFixture,
@@ -21,6 +21,7 @@ import {
 describe('Inbox Test', (): void => {
   let inbox: Inbox
   let erc20: TestERC20
+  let erc20Usdt: TestUSDT
   let owner: SignerWithAddress
   let solver: SignerWithAddress
   let dstAddr: SignerWithAddress
@@ -41,6 +42,7 @@ describe('Inbox Test', (): void => {
   async function deployInboxFixture(): Promise<{
     inbox: Inbox
     erc20: TestERC20
+    erc20Usdt: TestUSDT
     owner: SignerWithAddress
     solver: SignerWithAddress
     dstAddr: SignerWithAddress
@@ -50,13 +52,16 @@ describe('Inbox Test', (): void => {
     const inbox = await inboxFactory.deploy()
     // deploy ERC20 test
     const erc20Factory = await ethers.getContractFactory('TestERC20')
+    const testUSDTFactory = await ethers.getContractFactory('TestUSDT')
     const erc20 = await erc20Factory.deploy('eco', 'eco')
+    const erc20Usdt = await testUSDTFactory.deploy('eco', 'eco')
     await erc20.mint(solver.address, mintAmount)
     await erc20.mint(owner.address, mintAmount)
 
     return {
       inbox,
       erc20,
+      erc20Usdt,
       owner,
       solver,
       dstAddr,
@@ -120,7 +125,7 @@ describe('Inbox Test', (): void => {
     }
   }
   beforeEach(async (): Promise<void> => {
-    ;({ inbox, erc20, owner, solver, dstAddr } =
+    ;({ inbox, erc20, erc20Usdt, owner, solver, dstAddr } =
       await loadFixture(deployInboxFixture))
     ;({ route, reward, rewardHash, intentHash } = await createIntentData(
       mintAmount,
@@ -272,6 +277,31 @@ describe('Inbox Test', (): void => {
             ethers.ZeroAddress,
           ),
       ).to.be.revertedWithCustomError(inbox, 'CallToProver')
+    })
+    it('should continue if any of the targets supports EIP165 and returns false', async () => {
+      const _route = {
+        ...route,
+        calls: [
+          {
+            target: await erc20Usdt.getAddress(),
+            data: '0x',
+            value: 0,
+          },
+        ],
+      }
+      const _intentHash = hashIntent({ route: _route, reward }).intentHash
+      await erc20.connect(solver).approve(await inbox.getAddress(), mintAmount)
+      await expect(
+        inbox
+          .connect(solver)
+          .fulfill(
+            _route,
+            rewardHash,
+            dstAddr.address,
+            _intentHash,
+            ethers.ZeroAddress,
+          ),
+      ).to.not.be.revertedWithCustomError(inbox, 'CallToProver')
     })
     it('should revert if one of the targets is an EOA', async () => {
       await erc20.connect(solver).approve(await inbox.getAddress(), mintAmount)


### PR DESCRIPTION
This pull request introduces updates to the `Inbox` contract. To validate that the provers are not called in the routes, the `isProverCall` function was used as the returned value, which is actually a boolean indicating whether the call was successful. This PR fixes this.

This PR adds a new `TestUSDT` contract and extends test coverage for the `Inbox` contract. The most significant changes include refactoring how the `Inbox` contract checks for interface support, implementing a new test ERC-20 token (`TestUSDT`), and adding test cases to validate the latest functionality.

### Updates to `Inbox` contract:

* Refactored the interface detection mechanism to use `IERC165` with a `try-catch` block, improving compatibility with contracts that do not implement ERC-165. This ensures that calls to contracts without ERC-165 support do not revert unexpectedly.
* Simplified the initialization of the `IPROVER_INTERFACE_ID` constant by directly using `type(IProver).interfaceId`. 

### Addition of `TestUSDT` contract:

* Introduced a new `TestUSDT` contract inheriting from `ERC20` and `ERC165`. This is to validate that tokens using `ERC165` can be used for routes.

### Enhancements to `Inbox` test suite:

* Added `TestUSDT` to the `Inbox` test setup, deploying it alongside the existing test ERC-20 token (`TestERC20`).
* Added a new test case to verify that the `Inbox` contract continues execution when a target supports ERC-165 but returns `false` for the `IPROVER_INTERFACE_ID`. This ensures the `Inbox` contract handles such cases gracefully. 

### Minor test improvement:

* Updated the `HyperProver` test to use `ethers.zeroPadValue` for generating padded addresses, ensuring better compatibility and correctness.