### PR TITLE
syncing solc compiler

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,7 +14,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.26',
+        version: '0.8.27',
         settings: {
           viaIR: true,
           optimizer: {


### PR DESCRIPTION
setting the hardhat compiler version to match the foundry version of 0.8.27