### PR TITLE
Fix EOA ETH sends

### DIFF
--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -201,20 +201,22 @@ contract Inbox is IInbox, Eco7683DestinationSettler, Semver {
 
         for (uint256 i = 0; i < _route.calls.length; ++i) {
             Call memory call = _route.calls[i];
-            if (call.target.code.length == 0 && call.data.length > 0) {
-                // no code at this address
-                revert CallToEOA(call.target);
-            }
-
-            try
-                IERC165(call.target).supportsInterface(IPROVER_INTERFACE_ID)
-            returns (bool isProverCall) {
-                if (isProverCall) {
-                    // call to prover
-                    revert CallToProver();
+            if (call.target.code.length == 0) {
+                if (call.data.length > 0) {
+                    // no code at this address
+                    revert CallToEOA(call.target);
                 }
-            } catch {
-                // If target doesn't support ERC-165, continue.
+            } else {
+                try
+                    IERC165(call.target).supportsInterface(IPROVER_INTERFACE_ID)
+                returns (bool isProverCall) {
+                    if (isProverCall) {
+                        // call to prover
+                        revert CallToProver();
+                    }
+                } catch {
+                    // If target doesn't support ERC-165, continue.
+                }
             }
 
             (bool success, bytes memory result) = call.target.call{


### PR DESCRIPTION
This PR fixes a bug in the Inbox contract where fulfilling intents to externally owned accounts (EOAs) would fail. The issue occurred because the contract attempted to call a function on the target address and decode the result as a bool. However, when the target was an EOA, the call returned empty data, which caused a decoding failure.

### Fix
- Added a check to ensure the validation logic is only executed if the target address is a contract.
- EOAs now bypass the function call and are handled safely.

### Additional changes
- Added a unit test to verify ETH transfers to EOAs succeed, ensuring this edge case is properly covered.