### PR TITLE
Deterministic bytecode

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,3 +7,7 @@ libs = ["lib"]
 optimizer = true
 optimizer_runs = 200
 via_ir = true
+retries = 2
+evm_version = "cancun"
+cbor_metadata = false
+bytecode_hash = "none"


### PR DESCRIPTION
#  Summary

  This PR updates the Foundry configuration to ensure deterministic bytecode generation across different build environments.

#  Changes

  - Added cbor_metadata = false to disable CBOR metadata encoding in bytecode
  - Set bytecode_hash = "none" to exclude build metadata hashes
  - Specified evm_version = "cancun" for consistent EVM target
  - Added retries = 2 for build reliability

#  Impact

  These changes ensure that contract bytecode remains consistent across different machines and build times, which is crucial for:
  - Verifying deployed contracts match source code
  - Reproducible builds in CI/CD pipelines
  - Multi-party contract verification scenarios
