### PR TITLE
Fix: assign destination chain t1 prover address

### DIFF
--- a/contracts/prover/t1Prover.sol
+++ b/contracts/prover/t1Prover.sol
@@ -46,9 +46,10 @@ contract T1Prover is BaseProver, Semver {
     //errors
     error IntentNotFufilled();
 
-    constructor(address _inbox, uint32 _localDomain, address _xChainReader) BaseProver(_inbox) {
+    constructor(address _inbox, uint32 _localDomain, address _xChainReader, address _prover) BaseProver(_inbox) {
         LOCAL_DOMAIN = _localDomain;
         X_CHAIN_READER = IT1XChainReader(_xChainReader);
+        PROVER = _prover;
     }
 
     function requestIntentProof(


### PR DESCRIPTION
## Summary
Add new `_prover` param to constructor and assign to immutable `PROVER` address.

## Motivation
`PROVER` was never assigned a value. This address is necessary for calling `requestIntentProofBatch` which targets the `T1Prover` contract on the opposite chain.