### PR TITLE
refactor: simplify ILayerZeroEndpointV2 to minimal interface

### DIFF
--- a/contracts/interfaces/layerzero/ILayerZeroEndpointV2.sol
+++ b/contracts/interfaces/layerzero/ILayerZeroEndpointV2.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {SetConfigParam} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";
-
 /**
  * @title ILayerZeroEndpointV2
- * @notice Interface for LayerZero V2 endpoint contract
- * @dev Defines the core messaging functions for cross-chain communication
+ * @notice Minimal interface for LayerZero V2 endpoint contract
+ * @dev Only includes functions actually used by LayerZeroProver
  */
 interface ILayerZeroEndpointV2 {
     /**
-     * @notice Struct containing messaging parameters for LayerZero
-     * @param dstEid Destination endpoint ID
+     * @notice Struct containing messaging fee information
      * @param nativeFee Native fee amount to send
      * @param lzTokenFee LayerZero token fee amount
      */
@@ -71,61 +68,8 @@ interface ILayerZeroEndpointV2 {
     ) external view returns (MessagingFee memory fee);
 
     /**
-     * @notice Set configuration for a specific endpoint and config type
-     * @param _oapp Address of the OAPP contract
-     * @param _lib Address of the message library
-     * @param _params Configuration parameters
-     */
-    function setConfig(
-        address _oapp,
-        address _lib,
-        SetConfigParam[] calldata _params
-    ) external;
-
-    /**
      * @notice Set delegate for message handling
      * @param delegate Address of the delegate
      */
     function setDelegate(address delegate) external;
-
-    /**
-     * @notice Set the send library for a specific OAPP and endpoint
-     * @param _oapp Address of the OAPP (Omnichain Application) contract
-     * @param _eid Endpoint ID of the destination chain
-     * @param _newLib Address of the new send library to use
-     */
-    function setSendLibrary(
-        address _oapp,
-        uint32 _eid,
-        address _newLib
-    ) external;
-
-    /**
-     * @notice Set the receive library for a specific OAPP and endpoint
-     * @param _oapp Address of the OAPP (Omnichain Application) contract
-     * @param _eid Endpoint ID of the source chain
-     * @param _newLib Address of the new receive library to use
-     * @param _gracePeriod Grace period before the library change takes effect
-     */
-    function setReceiveLibrary(
-        address _oapp,
-        uint32 _eid,
-        address _newLib,
-        uint256 _gracePeriod
-    ) external;
-
-    /**
-     * @notice Get configuration for a specific OAPP, library, endpoint and config type
-     * @param _oapp Address of the OAPP contract
-     * @param _lib Address of the message library
-     * @param _eid Endpoint ID of the target chain
-     * @param _configType Type of configuration to retrieve
-     * @return config The configuration data as bytes
-     */
-    function getConfig(
-        address _oapp,
-        address _lib,
-        uint32 _eid,
-        uint32 _configType
-    ) external view returns (bytes memory config);
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,4 +4,3 @@ forge-std/=lib/forge-std/src/
 @hyperlane-xyz/core/=node_modules/@hyperlane-xyz/core/
 @eth-optimism/contracts-bedrock/=node_modules/@eth-optimism/contracts-bedrock/
 @metalayer/contracts/=node_modules/@metalayer/contracts/
-@layerzerolabs/lz-evm-protocol-v2/=node_modules/@layerzerolabs/lz-evm-protocol-v2/


### PR DESCRIPTION
Stripped down `ILayerZeroEndpointV2` interface to only include functions actually used by `LayerZeroProver`, removing unnecessary dependencies and bloat