### PR TITLE
chore: migrate from CODEOWNERS to auto-request-review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global code owners - these users will be requested for review on all PRs
-* @carlosfebres @re1ro @nknavkal @fish-sammy

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,19 @@
+reviewers:
+  defaults:
+    - repository-owners
+  groups:
+    repository-owners:
+      - carlosfebres
+      - re1ro
+      - nknavkal
+      - fish-sammy
+files:
+  '**':
+    - repository-owners
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - DO NOT REVIEW
+  enable_group_assignment: false
+  number_of_reviewers: 1
+  last_files_match_only: false

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,0 +1,17 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.13.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml
+          use_local: true

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -14,4 +14,3 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/reviewers.yml
-          use_local: true


### PR DESCRIPTION
## Summary

This PR migrates from GitHub's native CODEOWNERS to the [necojackarc/auto-request-review](https://github.com/necojackarc/auto-request-review) GitHub Action.

## Reviewer Mapping

| Group | Members |
|---|---|
| repository-owners | carlosfebres, re1ro, nknavkal, fish-sammy |

Configuration: 1 reviewer randomly assigned per PR.

## Changes
- Added `.github/workflows/request-review.yml` — workflow that triggers on PR open/ready/reopen
- Added `.github/reviewers.yml` — reviewer group configuration
- Removed `.github/CODEOWNERS` (if present)

## Testing
1. Open a draft PR → confirm no reviewer is requested (respects `ignore_draft: true`)
2. Mark PR as ready for review → confirm 1 reviewer is auto-assigned from the group
3. Open a new PR directly → confirm 1 reviewer is auto-assigned
