### PR TITLE
feat: add ERC20 gateway deposit variant and approval-based intent creation

### DIFF
--- a/contracts/deposit/BaseDepositAddress.sol
+++ b/contracts/deposit/BaseDepositAddress.sol
@@ -33,6 +33,7 @@ abstract contract BaseDepositAddress is ReentrancyGuard {
     error OnlyFactory();
     error InvalidDestinationAddress();
     error InvalidDepositor();
+    error InvalidFunder();
     error ZeroAmount();
 
     // ============ External Functions ============
@@ -71,6 +72,33 @@ abstract contract BaseDepositAddress is ReentrancyGuard {
         // Get balance of source token held by this contract
         uint256 amount = IERC20(sourceToken).balanceOf(address(this));
         if (amount == 0) revert ZeroAmount();
+
+        // Execute variant-specific intent creation
+        intentHash = _executeIntent(amount);
+
+        return intentHash;
+    }
+
+    /**
+     * @notice Create a cross-chain intent funded via ERC-20 approval
+     * @dev Pulls tokens from funder using transferFrom (requires prior approval to this contract),
+     *      then delegates to variant-specific intent execution. Uses min(allowance, balance) as amount.
+     * @param funder Address that approved this contract to spend their tokens
+     * @return intentHash Hash of the created intent
+     */
+    function createIntentWithApproval(address funder) external nonReentrant returns (bytes32 intentHash) {
+        if (!initialized) revert NotInitialized();
+        if (funder == address(0)) revert InvalidFunder();
+
+        address sourceToken = _getSourceToken();
+
+        // Use the lesser of allowance and funder's actual balance
+        uint256 allowance = IERC20(sourceToken).allowance(funder, address(this));
+        uint256 balance = IERC20(sourceToken).balanceOf(funder);
+        uint256 amount = allowance < balance ? allowance : balance;
+        if (amount == 0) revert ZeroAmount();
+
+        IERC20(sourceToken).safeTransferFrom(funder, address(this), amount);
 
         // Execute variant-specific intent creation
         intentHash = _executeIntent(amount);

--- a/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {BaseDepositAddress} from "./BaseDepositAddress.sol";
+import {Portal} from "../Portal.sol";
+import {Intent, Route, Reward, TokenAmount, Call} from "../types/Intent.sol";
+import {DepositFactory_CCTPMint_GatewayERC20 as DepositFactory} from "./DepositFactory_CCTPMint_GatewayERC20.sol";
+
+/**
+ * @title DepositAddress_CCTPMint_GatewayERC20
+ * @notice Minimal proxy contract that constructs two Intent structs for CCTP+Gateway transfers to ERC20 destinations
+ * @dev Creates TWO intents to bridge USDC from source chain to a destination via CCTP, then deposit into Gateway:
+ *      Intent 2 (published first): Gateway deposit on destination — receives CCTP-bridged USDC and deposits into Gateway
+ *      Intent 1 (published and funded second): CCTP burn on source chain — burns USDC and mints to Intent 2's vault
+ *      Each DepositAddress is specific to one user's destination address.
+ *      Deployed via CREATE2 by DepositFactory_CCTPMint_GatewayERC20 for deterministic addressing.
+ *      Unlike the Arc variant, USDC is a standard ERC20 on the destination (no decimal scaling needed).
+ *
+ * @dev Intent Call Flow:
+ *      Intent 1: Solver calls TokenMessengerV2.depositForBurn to burn USDC on source chain via CCTP,
+ *                minting to Intent 2's vault on the destination.
+ *      Intent 2: Solver approves Gateway for USDC and calls Gateway.depositFor to credit the user.
+ */
+contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
+
+    // ============ Constants ============
+
+    /// @notice Denominator for fee basis point calculations
+    uint256 private constant FEE_DENOMINATOR = 100_000;
+
+    // ============ Immutables ============
+
+    /// @notice Reference to the factory that deployed this contract
+    DepositFactory private immutable FACTORY;
+
+    // ============ Constructor ============
+
+    /**
+     * @notice Sets the factory reference (called by factory during deployment)
+     */
+    constructor() {
+        FACTORY = DepositFactory(msg.sender);
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @notice Get the factory address that deployed this contract
+     * @dev Implementation of abstract function from BaseDepositAddress
+     * @return Address of the factory contract
+     */
+    function _factory() internal view override returns (address) {
+        return address(FACTORY);
+    }
+
+    /**
+     * @notice Get the source token address for this deposit
+     * @dev Implementation of abstract function from BaseDepositAddress
+     * @return Address of the source token
+     */
+    function _getSourceToken() internal view override returns (address) {
+        (address sourceToken, , , , , , , , , , ) = FACTORY.getConfiguration();
+        return sourceToken;
+    }
+
+    /**
+     * @notice Execute variant-specific intent creation logic
+     * @dev Creates TWO intents:
+     *      1. Gateway deposit intent on destination (published first to obtain vault address)
+     *      2. CCTP burn intent on source chain (funded with deposited USDC, mints to Intent 2's vault)
+     * @param amount Amount of tokens to bridge
+     * @return intentHash Hash of the CCTP burn intent (Intent 1)
+     */
+    function _executeIntent(uint256 amount) internal override returns (bytes32 intentHash) {
+        // Get configuration from factory
+        (
+            address sourceToken,
+            address portalAddress,
+            address proverAddress,
+            uint64 deadlineDuration,
+            uint32 destinationDomain,
+            address cctpTokenMessenger,
+            uint64 destinationChainId,
+            address destinationProverAddress,
+            address destinationUsdc,
+            address gatewayAddress,
+            uint256 maxFeeBps
+        ) = FACTORY.getConfiguration();
+
+        // Generate unique salt (same for both intents)
+        bytes32 salt = keccak256(
+            abi.encodePacked(address(this), destinationAddress, block.timestamp)
+        );
+
+        // Calculate deadline (same for both intents)
+        uint64 deadline = uint64(block.timestamp + deadlineDuration);
+
+        // Compute CCTP fast-deposit fee (rounded up) and net amount received on destination
+        uint256 maxFee = (amount * maxFeeBps + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+        uint256 netAmount = amount - maxFee;
+
+        // ---- Step 1: Construct and publish Intent 2 (Gateway deposit on destination) ----
+        Intent memory intent2 = _constructGatewayIntent(
+            destinationChainId,
+            portalAddress,
+            destinationProverAddress,
+            destinationUsdc,
+            gatewayAddress,
+            netAmount,
+            salt,
+            deadline
+        );
+
+        // Publish Intent 2 and get its vault address
+        Portal portalContract = Portal(portalAddress);
+        (, address vault2) = portalContract.publish(intent2);
+
+        // ---- Step 2: Construct, fund, and publish Intent 1 (CCTP burn on source chain) ----
+        Intent memory intent1 = _constructCCTPIntent(
+            sourceToken,
+            portalAddress,
+            proverAddress,
+            cctpTokenMessenger,
+            destinationDomain,
+            vault2,
+            amount,
+            maxFee,
+            salt,
+            deadline
+        );
+
+        // Approve Portal to spend tokens and publish+fund Intent 1
+        IERC20(sourceToken).approve(portalAddress, amount);
+        (intentHash, ) = portalContract.publishAndFund(intent1, false);
+
+        return intentHash;
+    }
+
+    /**
+     * @notice Construct the Gateway deposit intent (Intent 2) for destination chain
+     * @dev This intent is fulfilled on the destination: solver approves Gateway for USDC and calls depositFor.
+     *      Unlike the Arc variant, USDC is a standard ERC20 on the destination so no decimal scaling is needed.
+     *      route.tokens and reward.tokens contain the ERC20 USDC amounts directly.
+     * @param destinationChainId Destination chain ID
+     * @param portalAddress Portal address (same on all chains)
+     * @param destinationProverAddress LocalProver address on destination chain
+     * @param destinationUsdc USDC ERC20 address on destination chain
+     * @param gatewayAddress Gateway contract address on destination chain
+     * @param netAmount Amount of USDC after CCTP fee deduction (6 decimals)
+     * @param salt Unique salt for the intent
+     * @param deadline Deadline timestamp for the intent
+     * @return intent Complete Intent struct for the Gateway deposit
+     */
+    function _constructGatewayIntent(
+        uint64 destinationChainId,
+        address portalAddress,
+        address destinationProverAddress,
+        address destinationUsdc,
+        address gatewayAddress,
+        uint256 netAmount,
+        bytes32 salt,
+        uint64 deadline
+    ) internal view returns (Intent memory intent) {
+        // Route tokens: ERC20 USDC on destination (no native amount needed)
+        TokenAmount[] memory routeTokens = new TokenAmount[](1);
+        routeTokens[0] = TokenAmount({token: destinationUsdc, amount: netAmount});
+
+        // Route calls: approve Gateway + depositFor (both use destination USDC amounts)
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: destinationUsdc,
+            data: abi.encodeWithSignature(
+                "approve(address,uint256)",
+                gatewayAddress,
+                netAmount
+            ),
+            value: 0
+        });
+        calls[1] = Call({
+            target: gatewayAddress,
+            data: abi.encodeWithSignature(
+                "depositFor(address,address,uint256)",
+                destinationUsdc,
+                address(uint160(uint256(destinationAddress))),
+                netAmount
+            ),
+            value: 0
+        });
+
+        // Construct route
+        Route memory route = Route({
+            salt: salt,
+            deadline: deadline,
+            portal: portalAddress,
+            nativeAmount: 0,
+            tokens: routeTokens,
+            calls: calls
+        });
+
+        // Reward tokens: ERC20 USDC on destination
+        TokenAmount[] memory rewardTokens = new TokenAmount[](1);
+        rewardTokens[0] = TokenAmount({token: destinationUsdc, amount: netAmount});
+
+        // Construct reward
+        Reward memory reward = Reward({
+            deadline: deadline,
+            creator: depositor,
+            prover: destinationProverAddress,
+            nativeAmount: 0,
+            tokens: rewardTokens
+        });
+
+        // Combine into Intent
+        intent = Intent({
+            destination: destinationChainId,
+            route: route,
+            reward: reward
+        });
+    }
+
+    /**
+     * @notice Construct the CCTP burn intent (Intent 1) for source chain
+     * @dev This intent is fulfilled locally: solver calls TokenMessengerV2.depositForBurn
+     *      to burn USDC and mint to Intent 2's vault on the destination
+     * @param sourceToken Source USDC token address
+     * @param portalAddress Portal address on source chain
+     * @param proverAddress LocalProver address on source chain
+     * @param cctpTokenMessenger CCTP TokenMessengerV2 address
+     * @param destinationDomain CCTP destination domain ID
+     * @param vault2 Intent 2's vault address (CCTP mintRecipient)
+     * @param amount Amount of USDC (6 decimals)
+     * @param maxFee Maximum CCTP fast-deposit fee (deducted on destination)
+     * @param salt Unique salt for the intent
+     * @param deadline Deadline timestamp for the intent
+     * @return intent Complete Intent struct for the CCTP burn
+     */
+    function _constructCCTPIntent(
+        address sourceToken,
+        address portalAddress,
+        address proverAddress,
+        address cctpTokenMessenger,
+        uint32 destinationDomain,
+        address vault2,
+        uint256 amount,
+        uint256 maxFee,
+        bytes32 salt,
+        uint64 deadline
+    ) internal view returns (Intent memory intent) {
+        // Use current chain ID for local intent
+        uint64 destChain = uint64(block.chainid);
+
+        // Route tokens: source USDC
+        TokenAmount[] memory routeTokens = new TokenAmount[](1);
+        routeTokens[0] = TokenAmount({token: sourceToken, amount: amount});
+
+        // Route calls: approve TokenMessenger + CCTP depositForBurn
+        Call[] memory calls = new Call[](2);
+        calls[0] = Call({
+            target: sourceToken,
+            data: abi.encodeWithSignature(
+                "approve(address,uint256)",
+                cctpTokenMessenger,
+                amount
+            ),
+            value: 0
+        });
+        calls[1] = Call({
+            target: cctpTokenMessenger,
+            data: abi.encodeWithSignature(
+                "depositForBurn(uint256,uint32,bytes32,address,bytes32,uint256,uint32)",
+                amount,
+                destinationDomain,
+                bytes32(uint256(uint160(vault2))), // mintRecipient = Intent 2 vault
+                sourceToken,
+                bytes32(0), // destinationCaller (anyone)
+                maxFee, // maxFee for CCTP fast-deposit
+                0 // minFinalityThreshold (fast finality)
+            ),
+            value: 0
+        });
+
+        // Construct route
+        Route memory route = Route({
+            salt: salt,
+            deadline: deadline,
+            portal: portalAddress,
+            nativeAmount: 0,
+            tokens: routeTokens,
+            calls: calls
+        });
+
+        // Reward tokens: source USDC
+        TokenAmount[] memory rewardTokens = new TokenAmount[](1);
+        rewardTokens[0] = TokenAmount({token: sourceToken, amount: amount});
+
+        // Construct reward
+        Reward memory reward = Reward({
+            deadline: deadline,
+            creator: depositor,
+            prover: proverAddress,
+            nativeAmount: 0,
+            tokens: rewardTokens
+        });
+
+        // Combine into Intent
+        intent = Intent({
+            destination: destChain,
+            route: route,
+            reward: reward
+        });
+    }
+}

--- a/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
@@ -34,6 +34,11 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
     /// @notice Reference to the factory that deployed this contract
     DepositFactory private immutable FACTORY;
 
+    // ============ Errors ============
+
+    /// @notice Reverted when the deposited balance is at or below the configured Eco-protocol flat fee
+    error AmountBelowFlatFee();
+
     // ============ Constructor ============
 
     /**
@@ -60,7 +65,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
      * @return Address of the source token
      */
     function _getSourceToken() internal view override returns (address) {
-        (address sourceToken, , , , , , , , , , ) = FACTORY.getConfiguration();
+        (address sourceToken, , , , , , , , , , , ) = FACTORY.getConfiguration();
         return sourceToken;
     }
 
@@ -85,7 +90,8 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             address destinationProverAddress,
             address destinationUsdc,
             address gatewayAddress,
-            uint256 maxFeeBps
+            uint256 maxFeeBps,
+            uint256 flatFee
         ) = FACTORY.getConfiguration();
 
         // Generate unique salt (same for both intents)
@@ -96,12 +102,18 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
         // Calculate deadline (same for both intents)
         uint64 deadline = uint64(block.timestamp + deadlineDuration);
 
-        // Compute CCTP fast-deposit fee (rounded up) and net amount received on destination
-        uint256 maxFee = (amount * maxFeeBps + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
-        uint256 netAmount = amount - maxFee;
+        // Apply Eco-protocol flat fee on intent1 + compute CCTP maxFee/netAmount in one helper.
+        // routeAmount = amount - flatFee  (intent1's route + CCTP burn input)
+        // netAmount   = routeAmount - maxFee (intent2's reward and route; what arrives post-CCTP)
+        (uint256 routeAmount, uint256 maxFee, uint256 netAmount) =
+            _computeFees(amount, flatFee, maxFeeBps);
 
         // ---- Step 1: Construct and publish Intent 2 (Gateway deposit on destination) ----
-        Intent memory intent2 = _constructGatewayIntent(
+        // Hoisted into a helper so `_executeIntent` keeps its local-variable count below the
+        // 16-stack-slot Yul limit imposed by the 12-field config + fee locals.
+        Portal portalContract = Portal(portalAddress);
+        address vault2 = _publishGatewayIntent(
+            portalContract,
             destinationChainId,
             portalAddress,
             destinationProverAddress,
@@ -112,11 +124,9 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             deadline
         );
 
-        // Publish Intent 2 and get its vault address
-        Portal portalContract = Portal(portalAddress);
-        (, address vault2) = portalContract.publish(intent2);
-
         // ---- Step 2: Construct, fund, and publish Intent 1 (CCTP burn on source chain) ----
+        // Intent 1 reward equals `amount` (full deposited balance, pulled by Portal during publishAndFund),
+        // while the route obligation drops by `flatFee` so the solver's bridging input is `routeAmount`.
         Intent memory intent1 = _constructCCTPIntent(
             sourceToken,
             portalAddress,
@@ -125,12 +135,13 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             destinationDomain,
             vault2,
             amount,
+            routeAmount,
             maxFee,
             salt,
             deadline
         );
 
-        // Approve Portal to spend tokens and publish+fund Intent 1
+        // Approve Portal to spend the full reward amount; Portal pulls reward tokens during publishAndFund
         IERC20(sourceToken).approve(portalAddress, amount);
         (intentHash, ) = portalContract.publishAndFund(intent1, false);
 
@@ -138,16 +149,72 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
     }
 
     /**
+     * @notice Compute the flat-fee-adjusted route amount plus CCTP maxFee in a single helper
+     * @dev Reverts with `AmountBelowFlatFee` if `amount <= flatFee`.
+     *      `maxFee` rounds up so the user never overpays Circle's CCTP fast-deposit fee.
+     * @param amount Full deposit amount
+     * @param flatFee Eco-protocol flat fee subtracted from intent1's route
+     * @param maxFeeBps CCTP fast-deposit fee in basis points (denominator: FEE_DENOMINATOR)
+     * @return routeAmount amount - flatFee (intent1's route amount, also the CCTP burn input)
+     * @return maxFee CCTP fast-deposit fee, computed on routeAmount, rounded up
+     * @return netAmount routeAmount - maxFee (intent2's reward and route amount; what arrives post-CCTP)
+     */
+    function _computeFees(
+        uint256 amount,
+        uint256 flatFee,
+        uint256 maxFeeBps
+    )
+        private
+        pure
+        returns (uint256 routeAmount, uint256 maxFee, uint256 netAmount)
+    {
+        if (amount <= flatFee) revert AmountBelowFlatFee();
+        routeAmount = amount - flatFee;
+        maxFee = (routeAmount * maxFeeBps + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+        netAmount = routeAmount - maxFee;
+    }
+
+    /**
+     * @notice Construct Intent 2 (Gateway deposit on destination) and publish it via the Portal
+     * @dev Returning only the vault address keeps `_executeIntent`'s local-variable count low
+     *      (12 config fields + fee locals would otherwise tip the 16-slot Yul limit).
+     * @param netAmount Intent2 reward and route amount (= routeAmount - maxFee, post-CCTP)
+     */
+    function _publishGatewayIntent(
+        Portal portalContract,
+        uint64 destinationChainId,
+        address portalAddress,
+        address destinationProverAddress,
+        address destinationUsdc,
+        address gatewayAddress,
+        uint256 netAmount,
+        bytes32 salt,
+        uint64 deadline
+    ) private returns (address vault2) {
+        Intent memory intent2 = _constructGatewayIntent(
+            destinationChainId,
+            portalAddress,
+            destinationProverAddress,
+            destinationUsdc,
+            gatewayAddress,
+            netAmount,
+            salt,
+            deadline
+        );
+        (, vault2) = portalContract.publish(intent2);
+    }
+
+    /**
      * @notice Construct the Gateway deposit intent (Intent 2) for destination chain
      * @dev This intent is fulfilled on the destination: solver approves Gateway for USDC and calls depositFor.
      *      Unlike the Arc variant, USDC is a standard ERC20 on the destination so no decimal scaling is needed.
-     *      route.tokens and reward.tokens contain the ERC20 USDC amounts directly.
+     *      Intent2 reward and route are symmetric (both equal `netAmount`); the flat fee is taken on intent1 only.
      * @param destinationChainId Destination chain ID
      * @param portalAddress Portal address (same on all chains)
      * @param destinationProverAddress LocalProver address on destination chain
      * @param destinationUsdc USDC ERC20 address on destination chain
      * @param gatewayAddress Gateway contract address on destination chain
-     * @param netAmount Amount of USDC after CCTP fee deduction (6 decimals)
+     * @param netAmount Reward and route amount (= routeAmount - CCTP maxFee)
      * @param salt Unique salt for the intent
      * @param deadline Deadline timestamp for the intent
      * @return intent Complete Intent struct for the Gateway deposit
@@ -166,7 +233,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
         TokenAmount[] memory routeTokens = new TokenAmount[](1);
         routeTokens[0] = TokenAmount({token: destinationUsdc, amount: netAmount});
 
-        // Route calls: approve Gateway + depositFor (both use destination USDC amounts)
+        // Route calls: approve Gateway + depositFor (both denominated in netAmount)
         Call[] memory calls = new Call[](2);
         calls[0] = Call({
             target: destinationUsdc,
@@ -198,7 +265,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             calls: calls
         });
 
-        // Reward tokens: ERC20 USDC on destination
+        // Reward tokens: ERC20 USDC on destination (full netAmount; solver collects this)
         TokenAmount[] memory rewardTokens = new TokenAmount[](1);
         rewardTokens[0] = TokenAmount({token: destinationUsdc, amount: netAmount});
 
@@ -222,15 +289,19 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
     /**
      * @notice Construct the CCTP burn intent (Intent 1) for source chain
      * @dev This intent is fulfilled locally: solver calls TokenMessengerV2.depositForBurn
-     *      to burn USDC and mint to Intent 2's vault on the destination
+     *      to burn USDC and mint to Intent 2's vault on the destination.
+     *      `rewardAmount` and `routeAmount` differ by the Eco-protocol `flatFee`:
+     *      the Portal pulls `rewardAmount` from this contract during publishAndFund (solver collects it),
+     *      while the solver bridges only `routeAmount` via CCTP. The delta is solver profit.
      * @param sourceToken Source USDC token address
      * @param portalAddress Portal address on source chain
      * @param proverAddress LocalProver address on source chain
      * @param cctpTokenMessenger CCTP TokenMessengerV2 address
      * @param destinationDomain CCTP destination domain ID
      * @param vault2 Intent 2's vault address (CCTP mintRecipient)
-     * @param amount Amount of USDC (6 decimals)
-     * @param maxFee Maximum CCTP fast-deposit fee (deducted on destination)
+     * @param rewardAmount Amount the Portal pulls from this contract as the intent reward (full deposit)
+     * @param routeAmount Amount the solver bridges via CCTP (rewardAmount - flatFee)
+     * @param maxFee Maximum CCTP fast-deposit fee (deducted on destination, computed on routeAmount)
      * @param salt Unique salt for the intent
      * @param deadline Deadline timestamp for the intent
      * @return intent Complete Intent struct for the CCTP burn
@@ -242,7 +313,8 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
         address cctpTokenMessenger,
         uint32 destinationDomain,
         address vault2,
-        uint256 amount,
+        uint256 rewardAmount,
+        uint256 routeAmount,
         uint256 maxFee,
         bytes32 salt,
         uint64 deadline
@@ -250,18 +322,18 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
         // Use current chain ID for local intent
         uint64 destChain = uint64(block.chainid);
 
-        // Route tokens: source USDC
+        // Route tokens: source USDC (solver's bridging obligation, post-flatFee)
         TokenAmount[] memory routeTokens = new TokenAmount[](1);
-        routeTokens[0] = TokenAmount({token: sourceToken, amount: amount});
+        routeTokens[0] = TokenAmount({token: sourceToken, amount: routeAmount});
 
-        // Route calls: approve TokenMessenger + CCTP depositForBurn
+        // Route calls: approve TokenMessenger + CCTP depositForBurn (both denominated in routeAmount)
         Call[] memory calls = new Call[](2);
         calls[0] = Call({
             target: sourceToken,
             data: abi.encodeWithSignature(
                 "approve(address,uint256)",
                 cctpTokenMessenger,
-                amount
+                routeAmount
             ),
             value: 0
         });
@@ -269,12 +341,12 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             target: cctpTokenMessenger,
             data: abi.encodeWithSignature(
                 "depositForBurn(uint256,uint32,bytes32,address,bytes32,uint256,uint32)",
-                amount,
+                routeAmount,
                 destinationDomain,
                 bytes32(uint256(uint160(vault2))), // mintRecipient = Intent 2 vault
                 sourceToken,
                 bytes32(0), // destinationCaller (anyone)
-                maxFee, // maxFee for CCTP fast-deposit
+                maxFee, // maxFee for CCTP fast-deposit (computed on routeAmount)
                 0 // minFinalityThreshold (fast finality)
             ),
             value: 0
@@ -290,9 +362,9 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             calls: calls
         });
 
-        // Reward tokens: source USDC
+        // Reward tokens: source USDC (full deposit; solver collects this from Portal)
         TokenAmount[] memory rewardTokens = new TokenAmount[](1);
-        rewardTokens[0] = TokenAmount({token: sourceToken, amount: amount});
+        rewardTokens[0] = TokenAmount({token: sourceToken, amount: rewardAmount});
 
         // Construct reward
         Reward memory reward = Reward({

--- a/contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {BaseDepositFactory} from "./BaseDepositFactory.sol";
+import {DepositAddress_CCTPMint_GatewayERC20} from "./DepositAddress_CCTPMint_GatewayERC20.sol";
+
+/**
+ * @title DepositFactory_CCTPMint_GatewayERC20
+ * @notice Factory contract for deploying deterministic deposit addresses for CCTP+Gateway transfers to ERC20 destinations
+ * @dev Deploys deposit addresses which create TWO intents:
+ *      1. A CCTP burn intent on the source chain that bridges USDC to the destination via depositForBurn
+ *      2. A Gateway deposit intent on the destination that deposits USDC into the Gateway for the user
+ *      Uses CREATE2 for deterministic address generation based on user's destination address.
+ *      Unlike the Arc variant, the destination chain treats USDC as a standard ERC20 (not native token).
+ *
+ * @dev Prover Configuration:
+ *      This factory should be configured with a LocalProver address for the source chain,
+ *      and a DESTINATION_PROVER_ADDRESS for the destination chain.
+ */
+contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
+    // ============ Immutable Configuration ============
+
+    /// @notice Source token address (USDC ERC20 on source chain)
+    address public immutable SOURCE_TOKEN;
+
+    /// @notice Portal contract address on source chain
+    address public immutable PORTAL_ADDRESS;
+
+    /// @notice LocalProver contract address on source chain
+    address public immutable PROVER_ADDRESS;
+
+    /// @notice Intent deadline duration in seconds for both intents
+    uint64 public immutable INTENT_DEADLINE_DURATION;
+
+    /// @notice CCTP destination domain ID for the destination chain
+    uint32 public immutable DESTINATION_DOMAIN;
+
+    /// @notice CCTP TokenMessengerV2 contract address on source chain
+    address public immutable CCTP_TOKEN_MESSENGER;
+
+    /// @notice Destination chain ID
+    uint64 public immutable DESTINATION_CHAIN_ID;
+
+    /// @notice LocalProver contract address on destination chain
+    address public immutable DESTINATION_PROVER_ADDRESS;
+
+    /// @notice USDC ERC20 address on destination chain
+    address public immutable DESTINATION_USDC;
+
+    /// @notice Gateway contract address on destination chain
+    address public immutable GATEWAY_ADDRESS;
+
+    /// @notice Maximum fee in basis points for CCTP fast-deposit (denominator: 100_000)
+    uint256 public immutable MAX_FEE_BPS;
+
+    /// @notice Denominator for fee basis point calculations
+    uint256 public constant FEE_DENOMINATOR = 100_000;
+
+    // ============ Errors ============
+
+    error InvalidCCTPTokenMessenger();
+    error InvalidDestinationChainId();
+    error InvalidDestinationProverAddress();
+    error InvalidDestinationUsdc();
+    error InvalidGatewayAddress();
+
+    // ============ Constructor ============
+
+    /**
+     * @notice Initialize the factory with route configuration
+     * @param _sourceToken Source token address (USDC on source chain)
+     * @param _portalAddress Portal contract address on source chain
+     * @param _proverAddress LocalProver contract address on source chain
+     * @param _intentDeadlineDuration Deadline duration for intents in seconds
+     * @param _destinationDomain CCTP destination domain ID for the destination chain
+     * @param _cctpTokenMessenger CCTP TokenMessengerV2 contract address on source chain
+     * @param _destinationChainId Destination chain ID
+     * @param _destinationProverAddress LocalProver contract address on destination chain
+     * @param _destinationUsdc USDC ERC20 address on destination chain
+     * @param _gatewayAddress Gateway contract address on destination chain
+     * @param _maxFeeBps Maximum fee in basis points for CCTP fast-deposit (denominator: 100_000, e.g. 13 = 1.3 bps)
+     */
+    constructor(
+        address _sourceToken,
+        address _portalAddress,
+        address _proverAddress,
+        uint64 _intentDeadlineDuration,
+        uint32 _destinationDomain,
+        address _cctpTokenMessenger,
+        uint64 _destinationChainId,
+        address _destinationProverAddress,
+        address _destinationUsdc,
+        address _gatewayAddress,
+        uint256 _maxFeeBps
+    ) BaseDepositFactory(address(new DepositAddress_CCTPMint_GatewayERC20())) {
+        // Validation
+        // Note: _destinationDomain is intentionally not validated because CCTP domain 0
+        // is valid (it represents Ethereum mainnet), so all uint32 values are acceptable.
+        if (_sourceToken == address(0)) revert InvalidSourceToken();
+        if (_portalAddress == address(0)) revert InvalidPortalAddress();
+        if (_proverAddress == address(0)) revert InvalidProverAddress();
+        if (_intentDeadlineDuration == 0) revert InvalidDeadlineDuration();
+        if (_cctpTokenMessenger == address(0)) revert InvalidCCTPTokenMessenger();
+        if (_destinationChainId == 0) revert InvalidDestinationChainId();
+        if (_destinationProverAddress == address(0)) revert InvalidDestinationProverAddress();
+        if (_destinationUsdc == address(0)) revert InvalidDestinationUsdc();
+        if (_gatewayAddress == address(0)) revert InvalidGatewayAddress();
+
+        // Store configuration
+        SOURCE_TOKEN = _sourceToken;
+        PORTAL_ADDRESS = _portalAddress;
+        PROVER_ADDRESS = _proverAddress;
+        INTENT_DEADLINE_DURATION = _intentDeadlineDuration;
+        DESTINATION_DOMAIN = _destinationDomain;
+        CCTP_TOKEN_MESSENGER = _cctpTokenMessenger;
+        DESTINATION_CHAIN_ID = _destinationChainId;
+        DESTINATION_PROVER_ADDRESS = _destinationProverAddress;
+        DESTINATION_USDC = _destinationUsdc;
+        GATEWAY_ADDRESS = _gatewayAddress;
+        MAX_FEE_BPS = _maxFeeBps;
+    }
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Get complete factory configuration
+     * @return sourceToken Source token address (USDC on source chain)
+     * @return portalAddress Portal address on source chain
+     * @return proverAddress LocalProver address on source chain
+     * @return intentDeadlineDuration Deadline duration in seconds
+     * @return destinationDomain CCTP destination domain ID
+     * @return cctpTokenMessenger CCTP TokenMessengerV2 address on source chain
+     * @return destinationChainId Destination chain ID
+     * @return destinationProverAddress LocalProver address on destination chain
+     * @return destinationUsdc USDC ERC20 address on destination chain
+     * @return gatewayAddress Gateway address on destination chain
+     * @return maxFeeBps Maximum fee in basis points for CCTP fast-deposit
+     */
+    function getConfiguration()
+        external
+        view
+        returns (
+            address sourceToken,
+            address portalAddress,
+            address proverAddress,
+            uint64 intentDeadlineDuration,
+            uint32 destinationDomain,
+            address cctpTokenMessenger,
+            uint64 destinationChainId,
+            address destinationProverAddress,
+            address destinationUsdc,
+            address gatewayAddress,
+            uint256 maxFeeBps
+        )
+    {
+        return (
+            SOURCE_TOKEN,
+            PORTAL_ADDRESS,
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            MAX_FEE_BPS
+        );
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @notice Initialize the deployed deposit contract
+     * @dev Implementation of abstract function from BaseDepositFactory
+     * @param deployed Address of the newly deployed contract
+     * @param destinationAddress User's destination address on target chain
+     * @param depositor Address to receive refunds if intent fails
+     */
+    function _initializeDeployedContract(
+        address deployed,
+        address destinationAddress,
+        address depositor
+    ) internal override {
+        // Convert EVM address to bytes32 for universal destination address format
+        bytes32 destinationBytes32 = bytes32(uint256(uint160(destinationAddress)));
+        DepositAddress_CCTPMint_GatewayERC20(deployed).initialize(destinationBytes32, depositor);
+    }
+}

--- a/contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol
@@ -53,6 +53,9 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
     /// @notice Maximum fee in basis points for CCTP fast-deposit (denominator: 100_000)
     uint256 public immutable MAX_FEE_BPS;
 
+    /// @notice Flat Eco-protocol fee subtracted from intent1 route (denominated in source-token base units, e.g. USDC 6dp). Becomes solver profit.
+    uint256 public immutable FLAT_FEE;
+
     /// @notice Denominator for fee basis point calculations
     uint256 public constant FEE_DENOMINATOR = 100_000;
 
@@ -78,7 +81,14 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
      * @param _destinationProverAddress LocalProver contract address on destination chain
      * @param _destinationUsdc USDC ERC20 address on destination chain
      * @param _gatewayAddress Gateway contract address on destination chain
-     * @param _maxFeeBps Maximum fee in basis points for CCTP fast-deposit (denominator: 100_000, e.g. 13 = 1.3 bps)
+     * @param _maxFeeBps Maximum fee in basis points for CCTP fast-deposit (denominator: 100_000, e.g. 13 = 1.3 bps).
+     *                   Intentionally unvalidated; the deployer is responsible for setting a sane value.
+     *                   Values >= FEE_DENOMINATOR will cause `_executeIntent` to revert (netAmount underflow);
+     *                   extremely large values combined with a large deposit can overflow `routeAmount * _maxFeeBps`.
+     * @param _flatFee Flat Eco-protocol fee subtracted from intent1 route (source-token base units). Solver collects this as profit.
+     *                 `_flatFee = 0` is a supported initial-deployment configuration (preserves pre-feature behavior).
+     *                 Intentionally unvalidated; the deployer is responsible for setting a value below the smallest
+     *                 expected deposit to keep the `AmountBelowFlatFee` revert path unreachable in normal operation.
      */
     constructor(
         address _sourceToken,
@@ -91,7 +101,8 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
         address _destinationProverAddress,
         address _destinationUsdc,
         address _gatewayAddress,
-        uint256 _maxFeeBps
+        uint256 _maxFeeBps,
+        uint256 _flatFee
     ) BaseDepositFactory(address(new DepositAddress_CCTPMint_GatewayERC20())) {
         // Validation
         // Note: _destinationDomain is intentionally not validated because CCTP domain 0
@@ -118,6 +129,7 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
         DESTINATION_USDC = _destinationUsdc;
         GATEWAY_ADDRESS = _gatewayAddress;
         MAX_FEE_BPS = _maxFeeBps;
+        FLAT_FEE = _flatFee;
     }
 
     // ============ External Functions ============
@@ -135,6 +147,7 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
      * @return destinationUsdc USDC ERC20 address on destination chain
      * @return gatewayAddress Gateway address on destination chain
      * @return maxFeeBps Maximum fee in basis points for CCTP fast-deposit
+     * @return flatFee Flat Eco-protocol fee subtracted from intent1 route (source-token base units)
      */
     function getConfiguration()
         external
@@ -150,7 +163,8 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
             address destinationProverAddress,
             address destinationUsdc,
             address gatewayAddress,
-            uint256 maxFeeBps
+            uint256 maxFeeBps,
+            uint256 flatFee
         )
     {
         return (
@@ -164,7 +178,8 @@ contract DepositFactory_CCTPMint_GatewayERC20 is BaseDepositFactory {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            MAX_FEE_BPS
+            MAX_FEE_BPS,
+            FLAT_FEE
         );
     }
 

--- a/scripts/DeployGatewayERC20Factory.s.sol
+++ b/scripts/DeployGatewayERC20Factory.s.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+
+import {ICreate3Deployer} from "../contracts/tools/ICreate3Deployer.sol";
+import {DepositFactory_CCTPMint_GatewayERC20} from "../contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol";
+
+/**
+ * @title DeployGatewayERC20Factory
+ * @notice Deploys DepositFactory_CCTPMint_GatewayERC20 to multiple chains using CREATE3
+ *         for deterministic same-address deployment despite different constructor args per chain.
+ *
+ * @dev Usage:
+ *      PRIVATE_KEY=0x... SALT=0x... SOURCE_TOKEN=0x... forge script \
+ *        scripts/DeployGatewayERC20Factory.s.sol --rpc-url <RPC_URL> --broadcast --slow
+ *
+ *      To predict the address without deploying:
+ *      PRIVATE_KEY=0x... SALT=0x... forge script \
+ *        scripts/DeployGatewayERC20Factory.s.sol --sig "predictAddress()" --rpc-url <RPC_URL>
+ */
+contract DeployGatewayERC20Factory is Script {
+    ICreate3Deployer constant create3Deployer =
+        ICreate3Deployer(0xC6BAd1EbAF366288dA6FB5689119eDd695a66814);
+
+    // ── Shared (same on all chains) ──────────────────────────────────
+    address constant PORTAL_ADDRESS = 0x399Dbd5DF04f83103F77A58cBa2B7c4d3cdede97;
+    address constant LOCAL_PROVER = 0x929aB8DeC1c1C383391A4271218be5d867a3Bb6e;
+    address constant CCTP_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+    uint64  constant INTENT_DEADLINE_DURATION = 14400; // 4 hours
+
+    // ── Destination: Polygon ─────────────────────────────────────────
+    uint32  constant DESTINATION_DOMAIN = 7;       // CCTP domain for Polygon
+    uint64  constant DESTINATION_CHAIN_ID = 137;
+    address constant DESTINATION_PROVER = 0x929aB8DeC1c1C383391A4271218be5d867a3Bb6e;
+    address constant DESTINATION_USDC = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;
+    address constant GATEWAY_ADDRESS = 0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE;
+    uint256 constant MAX_FEE_BPS = 13; // 1.3 bps
+
+    function run() external {
+        address sourceToken = vm.envAddress("SOURCE_TOKEN");
+        bytes32 rootSalt = vm.envBytes32("SALT");
+        address deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+
+        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V2");
+
+        // Build creation bytecode (creationCode + abi-encoded constructor args)
+        bytes memory bytecode = abi.encodePacked(
+            type(DepositFactory_CCTPMint_GatewayERC20).creationCode,
+            abi.encode(
+                sourceToken,
+                PORTAL_ADDRESS,
+                LOCAL_PROVER,
+                INTENT_DEADLINE_DURATION,
+                DESTINATION_DOMAIN,
+                CCTP_TOKEN_MESSENGER,
+                DESTINATION_CHAIN_ID,
+                DESTINATION_PROVER,
+                DESTINATION_USDC,
+                GATEWAY_ADDRESS,
+                MAX_FEE_BPS
+            )
+        );
+
+        // Predict address (same on every chain — CREATE3 ignores bytecode)
+        address predicted = create3Deployer.deployedAddress(
+            bytes(""), // bytecode not used for address prediction in CREATE3
+            deployer,
+            salt
+        );
+
+        console.log("Chain ID       :", block.chainid);
+        console.log("Source Token   :", sourceToken);
+        console.log("Predicted addr :", predicted);
+
+        // Check if already deployed
+        if (predicted.code.length > 0) {
+            console.log("Already deployed at:", predicted);
+            return;
+        }
+
+        vm.startBroadcast(deployer);
+
+        address deployed = create3Deployer.deploy(bytecode, salt);
+        require(deployed == predicted, "Address mismatch");
+        require(deployed.code.length > 0, "Deployment failed");
+
+        vm.stopBroadcast();
+
+        console.log("Deployed at    :", deployed);
+
+        // Verify configuration
+        DepositFactory_CCTPMint_GatewayERC20 factory = DepositFactory_CCTPMint_GatewayERC20(deployed);
+        (
+            address _sourceToken,
+            address _portalAddress,
+            ,
+            ,
+            ,
+            ,
+            uint64 _destChainId,
+            ,
+            ,
+            address _gateway,
+        ) = factory.getConfiguration();
+
+        require(_sourceToken == sourceToken, "sourceToken mismatch");
+        require(_portalAddress == PORTAL_ADDRESS, "portal mismatch");
+        require(_destChainId == DESTINATION_CHAIN_ID, "destChainId mismatch");
+        require(_gateway == GATEWAY_ADDRESS, "gateway mismatch");
+
+        console.log("Configuration verified");
+    }
+
+    /// @notice Predict the factory address without deploying (dry-run)
+    function predictAddress() external {
+        bytes32 rootSalt = vm.envBytes32("SALT");
+        address deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V2");
+
+        address predicted = create3Deployer.deployedAddress(
+            bytes(""),
+            deployer,
+            salt
+        );
+
+        console.log("Predicted factory address:", predicted);
+        console.log("Already deployed:", predicted.code.length > 0);
+    }
+
+    function _contractSalt(
+        bytes32 rootSalt,
+        string memory contractName
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(rootSalt, keccak256(abi.encodePacked(contractName))));
+    }
+}

--- a/scripts/DeployGatewayERC20Factory.s.sol
+++ b/scripts/DeployGatewayERC20Factory.s.sol
@@ -37,13 +37,18 @@ contract DeployGatewayERC20Factory is Script {
     address constant DESTINATION_USDC = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;
     address constant GATEWAY_ADDRESS = 0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE;
     uint256 constant MAX_FEE_BPS = 13; // 1.3 bps
+    uint256 constant FLAT_FEE = 0; // Eco-protocol flat fee on intent1 (source-token base units; zero for initial production deployment)
 
     function run() external {
         address sourceToken = vm.envAddress("SOURCE_TOKEN");
         bytes32 rootSalt = vm.envBytes32("SALT");
         address deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
 
-        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V2");
+        // V3 salt bump: V2 predates the flat fee. V3 introduces FLAT_FEE in the constructor
+        // signature. CREATE3 derives the address from (deployer, salt) only, so we MUST bump
+        // the salt to deploy the new ABI to a fresh address; otherwise mainnet chains would
+        // mix pre-flatFee and post-flatFee factories under the same address.
+        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V3");
 
         // Build creation bytecode (creationCode + abi-encoded constructor args)
         bytes memory bytecode = abi.encodePacked(
@@ -59,7 +64,8 @@ contract DeployGatewayERC20Factory is Script {
                 DESTINATION_PROVER,
                 DESTINATION_USDC,
                 GATEWAY_ADDRESS,
-                MAX_FEE_BPS
+                MAX_FEE_BPS,
+                FLAT_FEE
             )
         );
 
@@ -103,13 +109,17 @@ contract DeployGatewayERC20Factory is Script {
             ,
             ,
             address _gateway,
+            ,
+            uint256 _flatFee
         ) = factory.getConfiguration();
 
         require(_sourceToken == sourceToken, "sourceToken mismatch");
         require(_portalAddress == PORTAL_ADDRESS, "portal mismatch");
         require(_destChainId == DESTINATION_CHAIN_ID, "destChainId mismatch");
         require(_gateway == GATEWAY_ADDRESS, "gateway mismatch");
+        require(_flatFee == FLAT_FEE, "flatFee mismatch");
 
+        console.log("Flat Fee:", _flatFee);
         console.log("Configuration verified");
     }
 
@@ -117,7 +127,7 @@ contract DeployGatewayERC20Factory is Script {
     function predictAddress() external {
         bytes32 rootSalt = vm.envBytes32("SALT");
         address deployer = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
-        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V2");
+        bytes32 salt = _contractSalt(rootSalt, "GATEWAY_ERC20_FACTORY_V3");
 
         address predicted = create3Deployer.deployedAddress(
             bytes(""),

--- a/scripts/deployGatewayERC20Factories.sh
+++ b/scripts/deployGatewayERC20Factories.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# deployGatewayERC20Factories.sh
+#
+# Deploys DepositFactory_CCTPMint_GatewayERC20 to Base, Optimism, and Arbitrum
+# using CREATE3 for deterministic same-address deployment.
+#
+# Environment variables (required):
+#   PRIVATE_KEY   - Deployer private key
+#   SALT          - Root salt for CREATE3 (bytes32 hex)
+#
+# Optional:
+#   ALCHEMY_API_KEY - For Alchemy RPC URLs (default RPCs used otherwise)
+#
+# Usage:
+#   PRIVATE_KEY=0x... SALT=0x... ./scripts/deployGatewayERC20Factories.sh
+#   PRIVATE_KEY=0x... SALT=0x... ./scripts/deployGatewayERC20Factories.sh --predict  # dry-run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load .env if present
+if [ -f "$ROOT_DIR/.env" ]; then
+    set -a
+    source "$ROOT_DIR/.env"
+    set +a
+fi
+
+# Validate required env vars
+: "${PRIVATE_KEY:?PRIVATE_KEY is required}"
+: "${SALT:?SALT is required}"
+
+# USDC addresses per source chain
+declare -A USDC_ADDRESSES=(
+    [8453]="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"   # Base
+    [10]="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"      # Optimism
+    [42161]="0xaf88d065e77c8cC2239327C5EDb3A432268e5831"    # Arbitrum
+)
+
+# RPC URLs (override with env vars if needed)
+declare -A RPC_URLS
+RPC_URLS[8453]="${BASE_RPC_URL:-https://mainnet.base.org}"
+RPC_URLS[10]="${OPTIMISM_RPC_URL:-https://mainnet.optimism.io}"
+RPC_URLS[42161]="${ARBITRUM_RPC_URL:-https://arb1.arbitrum.io/rpc}"
+
+CHAIN_NAMES=([8453]="Base" [10]="Optimism" [42161]="Arbitrum")
+CHAIN_IDS=(8453 10 42161)
+
+# Check for --predict flag
+PREDICT_ONLY=false
+if [[ "${1:-}" == "--predict" ]]; then
+    PREDICT_ONLY=true
+fi
+
+echo "══════════════════════════════════════════════════════════════"
+echo "  Deploy DepositFactory_CCTPMint_GatewayERC20 (→ Polygon)"
+echo "══════════════════════════════════════════════════════════════"
+echo ""
+echo "  Salt: $SALT"
+echo "  Chains: Base (8453), Optimism (10), Arbitrum (42161)"
+echo "  Destination: Polygon (137)"
+echo ""
+
+if $PREDICT_ONLY; then
+    echo "  Mode: PREDICT ONLY (dry-run)"
+    echo ""
+
+    # Just predict on one chain (address is same on all)
+    CHAIN_ID="${CHAIN_IDS[0]}"
+    SOURCE_TOKEN="${USDC_ADDRESSES[$CHAIN_ID]}" \
+    SALT="$SALT" \
+    PRIVATE_KEY="$PRIVATE_KEY" \
+    forge script "$ROOT_DIR/scripts/DeployGatewayERC20Factory.s.sol" \
+        --sig "predictAddress()" \
+        --rpc-url "${RPC_URLS[$CHAIN_ID]}" \
+        2>&1
+
+    exit 0
+fi
+
+echo "  Mode: DEPLOY (broadcast)"
+echo ""
+
+DEPLOYED_ADDRESSES=()
+
+for CHAIN_ID in "${CHAIN_IDS[@]}"; do
+    CHAIN_NAME="${CHAIN_NAMES[$CHAIN_ID]}"
+    SOURCE_TOKEN="${USDC_ADDRESSES[$CHAIN_ID]}"
+    RPC_URL="${RPC_URLS[$CHAIN_ID]}"
+
+    echo "──────────────────────────────────────────────────────────────"
+    echo "  Deploying to $CHAIN_NAME ($CHAIN_ID)"
+    echo "  Source Token (USDC): $SOURCE_TOKEN"
+    echo "  RPC: $RPC_URL"
+    echo "──────────────────────────────────────────────────────────────"
+
+    SOURCE_TOKEN="$SOURCE_TOKEN" \
+    SALT="$SALT" \
+    PRIVATE_KEY="$PRIVATE_KEY" \
+    forge script "$ROOT_DIR/scripts/DeployGatewayERC20Factory.s.sol" \
+        --rpc-url "$RPC_URL" \
+        --broadcast \
+        --slow \
+        2>&1
+
+    echo ""
+    echo "  ✓ $CHAIN_NAME deployment complete"
+    echo ""
+done
+
+echo "══════════════════════════════════════════════════════════════"
+echo "  All deployments complete!"
+echo "══════════════════════════════════════════════════════════════"

--- a/scripts/deployGatewayERC20Factories.sh
+++ b/scripts/deployGatewayERC20Factories.sh
@@ -2,51 +2,101 @@
 #
 # deployGatewayERC20Factories.sh
 #
-# Deploys DepositFactory_CCTPMint_GatewayERC20 to Base, Optimism, and Arbitrum
-# using CREATE3 for deterministic same-address deployment.
+# Deploys DepositFactory_CCTPMint_GatewayERC20 to Eco-supported CCTP source
+# chains using CREATE3 for deterministic same-address deployment.
+#
+# Salt: GATEWAY_ERC20_FACTORY_V3 (bumped from V2 to ship the FLAT_FEE ABI to a fresh address
+#       on every chain — the V2 factories on Base/Optimism/Arbitrum predate flatFee).
+# V2 already deployed on: Base (8453), Optimism (10), Arbitrum (42161).
+# V3 default targets: Ethereum (1), Optimism (10), Arbitrum (42161), Unichain (130),
+#                     Sonic (146), World Chain (480), HyperEVM (999), Base (8453).
+#
+# Destination chain: Polygon PoS (137).
 #
 # Environment variables (required):
 #   PRIVATE_KEY   - Deployer private key
 #   SALT          - Root salt for CREATE3 (bytes32 hex)
 #
 # Optional:
-#   ALCHEMY_API_KEY - For Alchemy RPC URLs (default RPCs used otherwise)
+#   CHAIN_IDS     - Space-separated override, e.g. CHAIN_IDS="1 130"
+#   <NAME>_RPC_URL - Per-chain RPC override (ETHEREUM_RPC_URL, UNICHAIN_RPC_URL, ...)
 #
 # Usage:
 #   PRIVATE_KEY=0x... SALT=0x... ./scripts/deployGatewayERC20Factories.sh
 #   PRIVATE_KEY=0x... SALT=0x... ./scripts/deployGatewayERC20Factories.sh --predict  # dry-run
+#   PRIVATE_KEY=0x... SALT=0x... CHAIN_IDS="1 130" ./scripts/deployGatewayERC20Factories.sh
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Load .env if present
+# Load .env if present. Caller-provided env vars take precedence over .env values.
+_CALLER_CHAIN_IDS="${CHAIN_IDS:-}"
 if [ -f "$ROOT_DIR/.env" ]; then
     set -a
+    # shellcheck disable=SC1091
     source "$ROOT_DIR/.env"
     set +a
 fi
+if [ -n "$_CALLER_CHAIN_IDS" ]; then
+    CHAIN_IDS="$_CALLER_CHAIN_IDS"
+fi
+unset _CALLER_CHAIN_IDS
 
 # Validate required env vars
 : "${PRIVATE_KEY:?PRIVATE_KEY is required}"
 : "${SALT:?SALT is required}"
 
-# USDC addresses per source chain
-declare -A USDC_ADDRESSES=(
-    [8453]="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"   # Base
-    [10]="0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"      # Optimism
-    [42161]="0xaf88d065e77c8cC2239327C5EDb3A432268e5831"    # Arbitrum
-)
+# Per-chain config lookups (case-based for bash 3.2 compatibility on macOS).
+# USDC addresses sourced from developers.circle.com/stablecoins/usdc-contract-addresses.
+chain_name() {
+    case "$1" in
+        1)     echo "Ethereum" ;;
+        10)    echo "Optimism" ;;
+        130)   echo "Unichain" ;;
+        146)   echo "Sonic" ;;
+        480)   echo "World Chain" ;;
+        999)   echo "HyperEVM" ;;
+        8453)  echo "Base" ;;
+        42161) echo "Arbitrum" ;;
+        *)     return 1 ;;
+    esac
+}
 
-# RPC URLs (override with env vars if needed)
-declare -A RPC_URLS
-RPC_URLS[8453]="${BASE_RPC_URL:-https://mainnet.base.org}"
-RPC_URLS[10]="${OPTIMISM_RPC_URL:-https://mainnet.optimism.io}"
-RPC_URLS[42161]="${ARBITRUM_RPC_URL:-https://arb1.arbitrum.io/rpc}"
+usdc_address() {
+    case "$1" in
+        1)     echo "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" ;;
+        10)    echo "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85" ;;
+        130)   echo "0x078D782b760474a361dDA0AF3839290b0EF57AD6" ;;
+        146)   echo "0x29219dd400f2Bf60E5a23d13be72b486d4038894" ;;
+        480)   echo "0x79A02482A880bCe3F13E09da970dC34dB4cD24D1" ;;
+        999)   echo "0xb88339CB7199b77E23DB6E890353E22632Ba630f" ;;
+        8453)  echo "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" ;;
+        42161) echo "0xaf88d065e77c8cC2239327C5EDb3A432268e5831" ;;
+        *)     return 1 ;;
+    esac
+}
 
-CHAIN_NAMES=([8453]="Base" [10]="Optimism" [42161]="Arbitrum")
-CHAIN_IDS=(8453 10 42161)
+rpc_url() {
+    case "$1" in
+        1)     echo "${ETHEREUM_RPC_URL:-https://ethereum.publicnode.com}" ;;
+        10)    echo "${OPTIMISM_RPC_URL:-https://mainnet.optimism.io}" ;;
+        130)   echo "${UNICHAIN_RPC_URL:-https://mainnet.unichain.org}" ;;
+        146)   echo "${SONIC_RPC_URL:-https://rpc.soniclabs.com}" ;;
+        480)   echo "${WORLDCHAIN_RPC_URL:-https://worldchain-mainnet.g.alchemy.com/public}" ;;
+        999)   echo "${HYPEREVM_RPC_URL:-https://rpc.hyperliquid.xyz/evm}" ;;
+        8453)  echo "${BASE_RPC_URL:-https://mainnet.base.org}" ;;
+        42161) echo "${ARBITRUM_RPC_URL:-https://arb1.arbitrum.io/rpc}" ;;
+        *)     return 1 ;;
+    esac
+}
+
+# Default: deploy to chains that don't already have the factory.
+# Base, Optimism, and Arbitrum are already deployed — pass CHAIN_IDS="8453 10 42161"
+# to re-run on those, or override entirely: CHAIN_IDS="1 130" ./scripts/...
+DEFAULT_CHAIN_IDS="1 130 146 480 999"
+read -r -a CHAIN_IDS <<< "${CHAIN_IDS:-$DEFAULT_CHAIN_IDS}"
 
 # Check for --predict flag
 PREDICT_ONLY=false
@@ -59,7 +109,11 @@ echo "  Deploy DepositFactory_CCTPMint_GatewayERC20 (→ Polygon)"
 echo "══════════════════════════════════════════════════════════════"
 echo ""
 echo "  Salt: $SALT"
-echo "  Chains: Base (8453), Optimism (10), Arbitrum (42161)"
+printf "  Chains: "
+for CID in "${CHAIN_IDS[@]}"; do
+    printf "%s (%s)  " "$(chain_name "$CID")" "$CID"
+done
+printf "\n"
 echo "  Destination: Polygon (137)"
 echo ""
 
@@ -69,12 +123,12 @@ if $PREDICT_ONLY; then
 
     # Just predict on one chain (address is same on all)
     CHAIN_ID="${CHAIN_IDS[0]}"
-    SOURCE_TOKEN="${USDC_ADDRESSES[$CHAIN_ID]}" \
+    SOURCE_TOKEN="$(usdc_address "$CHAIN_ID")" \
     SALT="$SALT" \
     PRIVATE_KEY="$PRIVATE_KEY" \
     forge script "$ROOT_DIR/scripts/DeployGatewayERC20Factory.s.sol" \
         --sig "predictAddress()" \
-        --rpc-url "${RPC_URLS[$CHAIN_ID]}" \
+        --rpc-url "$(rpc_url "$CHAIN_ID")" \
         2>&1
 
     exit 0
@@ -83,12 +137,10 @@ fi
 echo "  Mode: DEPLOY (broadcast)"
 echo ""
 
-DEPLOYED_ADDRESSES=()
-
 for CHAIN_ID in "${CHAIN_IDS[@]}"; do
-    CHAIN_NAME="${CHAIN_NAMES[$CHAIN_ID]}"
-    SOURCE_TOKEN="${USDC_ADDRESSES[$CHAIN_ID]}"
-    RPC_URL="${RPC_URLS[$CHAIN_ID]}"
+    CHAIN_NAME="$(chain_name "$CHAIN_ID")"
+    SOURCE_TOKEN="$(usdc_address "$CHAIN_ID")"
+    RPC_URL="$(rpc_url "$CHAIN_ID")"
 
     echo "──────────────────────────────────────────────────────────────"
     echo "  Deploying to $CHAIN_NAME ($CHAIN_ID)"

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -768,6 +768,199 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
         assertTrue(intentHash != bytes32(0));
     }
 
+    // ============ createIntentWithApproval Tests ============
+
+    function test_createIntentWithApproval_revertsIfNotInitialized() public {
+        DepositAddress_CCTPMint_GatewayERC20 uninit = new DepositAddress_CCTPMint_GatewayERC20();
+
+        vm.expectRevert(BaseDepositAddress.NotInitialized.selector);
+        uninit.createIntentWithApproval(DEPOSITOR);
+    }
+
+    function test_createIntentWithApproval_revertsIfFunderIsZero() public {
+        vm.expectRevert(BaseDepositAddress.InvalidFunder.selector);
+        depositAddress.createIntentWithApproval(address(0));
+    }
+
+    function test_createIntentWithApproval_revertsIfNoApproval() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+        // No approval given
+
+        vm.expectRevert(BaseDepositAddress.ZeroAmount.selector);
+        depositAddress.createIntentWithApproval(DEPOSITOR);
+    }
+
+    function test_createIntentWithApproval_succeeds() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        bytes32 intentHash = depositAddress.createIntentWithApproval(DEPOSITOR);
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    function test_createIntentWithApproval_usesFullAllowance() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        depositAddress.createIntentWithApproval(DEPOSITOR);
+
+        // Full allowance used, balance should be zero
+        assertEq(token.balanceOf(DEPOSITOR), 0);
+    }
+
+    function test_createIntentWithApproval_cappedByBalance() public {
+        uint256 balance = 5_000 * 1e6;
+        uint256 allowance = 10_000 * 1e6;
+
+        token.mint(DEPOSITOR, balance);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), allowance);
+
+        bytes32 intentHash = depositAddress.createIntentWithApproval(DEPOSITOR);
+        assertTrue(intentHash != bytes32(0));
+
+        // Only balance was transferred, not the full allowance
+        assertEq(token.balanceOf(DEPOSITOR), 0);
+    }
+
+    function test_createIntentWithApproval_drainsToContract() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        depositAddress.createIntentWithApproval(DEPOSITOR);
+
+        // Funder drained, deposit address also drained (tokens forwarded to portal vault)
+        assertEq(token.balanceOf(DEPOSITOR), 0);
+        assertEq(token.balanceOf(address(depositAddress)), 0);
+    }
+
+    function test_createIntentWithApproval_emitsTwoIntentPublishedEvents() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntentWithApproval(DEPOSITOR);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 intentPublishedCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                intentPublishedCount++;
+            }
+        }
+
+        assertEq(intentPublishedCount, 2, "Should emit exactly two IntentPublished events");
+    }
+
+    function test_createIntentWithApproval_intentIsFunded() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        bytes32 intentHash = depositAddress.createIntentWithApproval(DEPOSITOR);
+
+        IIntentSource.Status status = portal.getRewardStatus(intentHash);
+        assertEq(
+            uint256(status),
+            uint256(IIntentSource.Status.Funded),
+            "Intent should be funded"
+        );
+    }
+
+    function test_createIntentWithApproval_permissionless() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        // Called by ATTACKER, not DEPOSITOR — should still work
+        vm.prank(ATTACKER);
+        bytes32 intentHash = depositAddress.createIntentWithApproval(DEPOSITOR);
+
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    function test_createIntentWithApproval_integration_fullFlow() public {
+        address intUser = address(0xAAAA);
+        address intDepositor = address(0xBBBB);
+
+        // 1. Deploy deposit contract
+        address deployed = factory.deploy(intUser, intDepositor);
+        DepositAddress_CCTPMint_GatewayERC20 da = DepositAddress_CCTPMint_GatewayERC20(deployed);
+
+        // 2. Funder gets tokens and approves deposit address
+        uint256 depositAmount = 10_000 * 1e6;
+        token.mint(intDepositor, depositAmount);
+
+        vm.prank(intDepositor);
+        token.approve(deployed, depositAmount);
+
+        // 3. Create intent with approval
+        vm.recordLogs();
+        bytes32 intentHash = da.createIntentWithApproval(intDepositor);
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertTrue(intentHash != bytes32(0));
+
+        // 4. Verify tokens moved
+        assertEq(token.balanceOf(intDepositor), 0);
+        assertEq(token.balanceOf(deployed), 0);
+
+        // 5. Verify intent was funded
+        IIntentSource.Status status = portal.getRewardStatus(intentHash);
+        assertEq(
+            uint256(status),
+            uint256(IIntentSource.Status.Funded),
+            "Intent should be funded"
+        );
+
+        // 6. Verify two IntentPublished events
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 intentPublishedCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                intentPublishedCount++;
+            }
+        }
+        assertEq(intentPublishedCount, 2, "Should have emitted two IntentPublished events");
+    }
+
+    function testFuzz_createIntentWithApproval_succeeds(uint256 amount) public {
+        vm.assume(amount >= 100_000 && amount <= type(uint128).max);
+
+        token.mint(DEPOSITOR, amount);
+
+        vm.prank(DEPOSITOR);
+        token.approve(address(depositAddress), amount);
+
+        bytes32 intentHash = depositAddress.createIntentWithApproval(DEPOSITOR);
+        assertTrue(intentHash != bytes32(0));
+    }
+
     // ============ Helpers ============
 
     /// @dev Slices bytes from the given offset to the end

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -1,0 +1,782 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {DepositFactory_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol";
+import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol";
+import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
+import {Portal} from "../../contracts/Portal.sol";
+import {Intent, Route, Reward, TokenAmount, Call} from "../../contracts/types/Intent.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {TestERC20} from "../../contracts/test/TestERC20.sol";
+
+contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
+    DepositFactory_CCTPMint_GatewayERC20 public factory;
+    DepositAddress_CCTPMint_GatewayERC20 public depositAddress;
+    Portal public portal;
+    TestERC20 public token;
+
+    // Configuration parameters
+    address constant PROVER_ADDRESS = address(0x9ABC);
+    uint64 constant INTENT_DEADLINE_DURATION = 7 days;
+    uint32 constant DESTINATION_DOMAIN = 7;
+    address constant CCTP_TOKEN_MESSENGER = address(0xABCD);
+    uint64 constant DESTINATION_CHAIN_ID = 137;
+    address constant DESTINATION_PROVER_ADDRESS = address(0xBBBB);
+    address constant DESTINATION_USDC = address(0xCCCC);
+    address constant GATEWAY_ADDRESS = address(0xDDDD);
+
+    // Test user addresses
+    address constant USER_DESTINATION = address(0x1111);
+    address constant DEPOSITOR = address(0x3333);
+    address constant ATTACKER = address(0x6666);
+
+    uint256 private constant MAX_FEE_BPS = 13;
+    uint256 private constant FEE_DENOMINATOR = 100_000;
+
+    function setUp() public {
+        token = new TestERC20("Test USDC", "USDC");
+        portal = new Portal();
+
+        factory = new DepositFactory_CCTPMint_GatewayERC20(
+            address(token),
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            MAX_FEE_BPS
+        );
+
+        address deployed = factory.deploy(USER_DESTINATION, DEPOSITOR);
+        depositAddress = DepositAddress_CCTPMint_GatewayERC20(deployed);
+    }
+
+    // ============ Initialization Tests ============
+
+    function test_initialize_setsDestinationAddress() public view {
+        assertEq(depositAddress.destinationAddress(), bytes32(uint256(uint160(USER_DESTINATION))));
+    }
+
+    function test_initialize_setsDepositor() public view {
+        assertEq(depositAddress.depositor(), DEPOSITOR);
+    }
+
+    function test_initialize_revertsIfAlreadyInitialized() public {
+        vm.expectRevert(BaseDepositAddress.AlreadyInitialized.selector);
+        depositAddress.initialize(bytes32(uint256(uint160(USER_DESTINATION))), DEPOSITOR);
+    }
+
+    function test_initialize_revertsIfNotCalledByFactory() public {
+        DepositAddress_CCTPMint_GatewayERC20 implementation = new DepositAddress_CCTPMint_GatewayERC20();
+
+        vm.prank(ATTACKER);
+        vm.expectRevert(BaseDepositAddress.OnlyFactory.selector);
+        implementation.initialize(bytes32(uint256(uint160(USER_DESTINATION))), DEPOSITOR);
+    }
+
+    function test_initialize_revertsIfDepositorIsZero() public {
+        vm.expectRevert(BaseDepositAddress.InvalidDepositor.selector);
+        factory.deploy(USER_DESTINATION, address(0));
+    }
+
+    function test_initialize_revertsIfDestinationAddressIsZero() public {
+        vm.expectRevert(BaseDepositAddress.InvalidDestinationAddress.selector);
+        factory.deploy(address(0), DEPOSITOR);
+    }
+
+    // ============ createIntent Basic Tests ============
+
+    function test_createIntent_revertsIfNotInitialized() public {
+        DepositAddress_CCTPMint_GatewayERC20 uninit = new DepositAddress_CCTPMint_GatewayERC20();
+
+        vm.expectRevert(BaseDepositAddress.NotInitialized.selector);
+        uninit.createIntent();
+    }
+
+    function test_createIntent_revertsIfZeroBalance() public {
+        vm.expectRevert(BaseDepositAddress.ZeroAmount.selector);
+        depositAddress.createIntent();
+    }
+
+    function test_createIntent_succeeds() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        bytes32 intentHash = depositAddress.createIntent();
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    function test_createIntent_drainsBalance() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        depositAddress.createIntent();
+
+        assertEq(token.balanceOf(address(depositAddress)), 0);
+    }
+
+    function test_createIntent_permissionless() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.prank(ATTACKER);
+        bytes32 intentHash = depositAddress.createIntent();
+
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    function test_createIntent_multipleCallsSucceed() public {
+        uint256 amount1 = 10_000 * 1e6;
+        uint256 amount2 = 5_000 * 1e6;
+
+        token.mint(address(depositAddress), amount1);
+        bytes32 intentHash1 = depositAddress.createIntent();
+
+        vm.warp(block.timestamp + 1);
+        token.mint(address(depositAddress), amount2);
+        bytes32 intentHash2 = depositAddress.createIntent();
+
+        assertTrue(intentHash1 != bytes32(0));
+        assertTrue(intentHash2 != bytes32(0));
+        assertTrue(intentHash1 != intentHash2);
+    }
+
+    // ============ Two-Intent Structure Tests ============
+
+    function test_createIntent_emitsTwoIntentPublishedEvents() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 intentPublishedCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                intentPublishedCount++;
+            }
+        }
+
+        assertEq(intentPublishedCount, 2, "Should emit exactly two IntentPublished events");
+    }
+
+    function test_createIntent_intent2_isPublishedFirst() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Find the two IntentPublished events
+        uint64 firstDestination;
+        uint64 secondDestination;
+        uint256 eventIdx = 0;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                (uint64 destination, , , , ) = abi.decode(
+                    logs[i].data,
+                    (uint64, bytes, uint64, uint256, TokenAmount[])
+                );
+
+                if (eventIdx == 0) {
+                    firstDestination = destination;
+                } else {
+                    secondDestination = destination;
+                }
+                eventIdx++;
+            }
+        }
+
+        // Intent 2 (Gateway deposit on destination) is published first
+        assertEq(firstDestination, DESTINATION_CHAIN_ID, "First event should be Intent 2 targeting destination chain");
+        // Intent 1 (CCTP burn on source chain) is published second
+        assertEq(secondDestination, uint64(block.chainid), "Second event should be Intent 1 targeting source chain");
+    }
+
+    function test_createIntent_intent2_hasCorrectStructure() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Find the first IntentPublished event (Intent 2 - Gateway deposit on destination)
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                // Indexed fields
+                address creator = address(uint160(uint256(logs[i].topics[2])));
+                address proverAddr = address(uint160(uint256(logs[i].topics[3])));
+
+                // Non-indexed fields
+                (
+                    uint64 destination,
+                    bytes memory routeBytes,
+                    , // rewardDeadline (verified in separate test)
+                    uint256 rewardNativeAmount,
+                    TokenAmount[] memory rewardTokens
+                ) = abi.decode(
+                    logs[i].data,
+                    (uint64, bytes, uint64, uint256, TokenAmount[])
+                );
+
+                // Verify Intent 2 targets destination chain
+                assertEq(destination, DESTINATION_CHAIN_ID, "Intent 2 destination should be destination chain");
+                assertEq(creator, DEPOSITOR, "Intent 2 creator should be depositor");
+                assertEq(proverAddr, DESTINATION_PROVER_ADDRESS, "Intent 2 prover should be destination prover");
+
+                // Compute expected net amount after CCTP fee deduction (rounded up)
+                uint256 maxFee = (amount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+                uint256 netAmount = amount - maxFee;
+
+                // Verify route
+                Route memory route = abi.decode(routeBytes, (Route));
+                assertEq(route.portal, address(portal), "Intent 2 route portal should be portal");
+                assertEq(route.nativeAmount, 0, "Intent 2 route nativeAmount should be 0 (ERC20 destination)");
+                assertEq(route.tokens.length, 1, "Intent 2 route should have one token (destination USDC)");
+                assertEq(route.tokens[0].token, DESTINATION_USDC, "Intent 2 route token should be destination USDC");
+                assertEq(route.tokens[0].amount, netAmount, "Intent 2 route token amount should be net amount");
+                assertEq(route.calls.length, 2, "Intent 2 route should have two calls (approve + depositFor)");
+
+                // Verify call 0: approve Gateway for USDC (net amount)
+                assertEq(route.calls[0].target, DESTINATION_USDC, "Call 0 target should be DESTINATION_USDC");
+                assertEq(route.calls[0].value, 0, "Call 0 value should be 0");
+
+                bytes memory expectedApproveData = abi.encodeWithSignature(
+                    "approve(address,uint256)",
+                    GATEWAY_ADDRESS,
+                    netAmount
+                );
+                assertEq(route.calls[0].data, expectedApproveData, "Call 0 data should encode approve with net amount");
+
+                // Verify call 1: Gateway.depositFor (net amount)
+                assertEq(route.calls[1].target, GATEWAY_ADDRESS, "Call 1 target should be Gateway");
+                assertEq(route.calls[1].value, 0, "Call 1 value should be 0");
+
+                bytes memory expectedDepositForData = abi.encodeWithSignature(
+                    "depositFor(address,address,uint256)",
+                    DESTINATION_USDC,
+                    address(uint160(uint256(bytes32(uint256(uint160(USER_DESTINATION)))))),
+                    netAmount
+                );
+                assertEq(route.calls[1].data, expectedDepositForData, "Call 1 data should encode depositFor with net amount");
+
+                // Verify reward
+                assertEq(rewardNativeAmount, 0, "Intent 2 reward nativeAmount should be 0 (ERC20 destination)");
+                assertEq(rewardTokens.length, 1, "Intent 2 reward should have one token (destination USDC)");
+                assertEq(rewardTokens[0].token, DESTINATION_USDC, "Intent 2 reward token should be destination USDC");
+                assertEq(rewardTokens[0].amount, netAmount, "Intent 2 reward token amount should be net amount");
+
+                break;
+            }
+        }
+    }
+
+    function test_createIntent_intent1_hasCorrectStructure() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Find the second IntentPublished event (Intent 1 - CCTP burn on source chain)
+        uint256 eventIdx = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                if (eventIdx == 1) {
+                    // This is the second IntentPublished event (Intent 1)
+
+                    // Indexed fields
+                    address creator = address(uint160(uint256(logs[i].topics[2])));
+                    address proverAddr = address(uint160(uint256(logs[i].topics[3])));
+
+                    // Non-indexed fields
+                    (
+                        uint64 destination,
+                        bytes memory routeBytes,
+                        , // rewardDeadline (verified in separate test)
+                        uint256 rewardNativeAmount,
+                        TokenAmount[] memory rewardTokens
+                    ) = abi.decode(
+                        logs[i].data,
+                        (uint64, bytes, uint64, uint256, TokenAmount[])
+                    );
+
+                    // Verify Intent 1 targets source chain
+                    assertEq(destination, uint64(block.chainid), "Intent 1 destination should be source chain");
+                    assertEq(creator, DEPOSITOR, "Intent 1 creator should be depositor");
+                    assertEq(proverAddr, PROVER_ADDRESS, "Intent 1 prover should be source chain prover");
+
+                    // Verify route
+                    Route memory route = abi.decode(routeBytes, (Route));
+                    assertEq(route.portal, address(portal), "Intent 1 route portal should be portal");
+                    assertEq(route.nativeAmount, 0, "Intent 1 route should have no native amount");
+                    assertEq(route.tokens.length, 1, "Intent 1 route should have one token");
+                    assertEq(route.tokens[0].token, address(token), "Intent 1 route token should be source USDC");
+                    assertEq(route.tokens[0].amount, amount, "Intent 1 route token amount should match deposit");
+                    assertEq(route.calls.length, 2, "Intent 1 route should have two calls (approve + CCTP depositForBurn)");
+
+                    // Verify approve call (calls[0])
+                    assertEq(route.calls[0].target, address(token), "Call 0 target should be source token (approve)");
+                    assertEq(route.calls[0].value, 0, "Approve call should have no value");
+
+                    // Verify CCTP depositForBurn call (calls[1])
+                    assertEq(route.calls[1].target, CCTP_TOKEN_MESSENGER, "Call 1 target should be TokenMessenger");
+                    assertEq(route.calls[1].value, 0, "CCTP call should have no value");
+
+                    // Verify reward
+                    assertEq(rewardNativeAmount, 0, "Intent 1 reward should have no native amount");
+                    assertEq(rewardTokens.length, 1, "Intent 1 reward should have one token");
+                    assertEq(rewardTokens[0].token, address(token), "Intent 1 reward token should be source USDC");
+                    assertEq(rewardTokens[0].amount, amount, "Intent 1 reward amount should match deposit");
+
+                    break;
+                }
+                eventIdx++;
+            }
+        }
+    }
+
+    function test_createIntent_intent1_cctpCallData_isCorrect() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 eventIdx = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                if (eventIdx == 1) {
+                    // Intent 1: verify CCTP call
+                    (
+                        ,
+                        bytes memory routeBytes,
+                        ,
+                        ,
+                    ) = abi.decode(
+                        logs[i].data,
+                        (uint64, bytes, uint64, uint256, TokenAmount[])
+                    );
+
+                    Route memory route = abi.decode(routeBytes, (Route));
+
+                    // Decode the CCTP depositForBurn call data (calls[1], after approve)
+                    // Expected signature: depositForBurn(uint256,uint32,bytes32,address,bytes32,uint256,uint32)
+                    bytes memory callData = route.calls[1].data;
+
+                    // Skip the 4-byte selector and decode the parameters
+                    bytes4 selector = bytes4(callData);
+                    assertEq(
+                        selector,
+                        bytes4(keccak256("depositForBurn(uint256,uint32,bytes32,address,bytes32,uint256,uint32)")),
+                        "CCTP call should use depositForBurn selector"
+                    );
+
+                    // Decode parameters after the selector
+                    (
+                        uint256 cctpAmount,
+                        uint32 destDomain,
+                        bytes32 mintRecipient,
+                        address burnToken,
+                        bytes32 destinationCaller,
+                        uint256 maxFee,
+                        uint32 minFinalityThreshold
+                    ) = abi.decode(
+                        _sliceBytes(callData, 4),
+                        (uint256, uint32, bytes32, address, bytes32, uint256, uint32)
+                    );
+
+                    uint256 expectedMaxFee = (amount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+                    assertEq(cctpAmount, amount, "CCTP amount should match deposit");
+                    assertEq(destDomain, DESTINATION_DOMAIN, "CCTP destination domain should match");
+                    assertEq(burnToken, address(token), "CCTP burn token should be source USDC");
+                    assertEq(destinationCaller, bytes32(0), "CCTP destination caller should be zero (anyone)");
+                    assertEq(maxFee, expectedMaxFee, "CCTP maxFee should be 1.3 bps of amount");
+                    assertEq(minFinalityThreshold, 0, "CCTP minFinalityThreshold should be 0 (fast finality)");
+
+                    // mintRecipient should be vault2 encoded as bytes32
+                    // We can verify it is non-zero (vault addresses are always non-zero)
+                    assertTrue(mintRecipient != bytes32(0), "mintRecipient should not be zero");
+
+                    break;
+                }
+                eventIdx++;
+            }
+        }
+    }
+
+    function test_createIntent_mintRecipient_matchesIntent2Vault() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Collect Intent 2's hash and decode Intent 1's mintRecipient
+        bytes32 intent2Hash;
+        bytes32 mintRecipient;
+        uint256 eventIdx = 0;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                if (eventIdx == 0) {
+                    // Intent 2 event -- grab the intent hash from topics
+                    intent2Hash = logs[i].topics[1];
+                }
+                if (eventIdx == 1) {
+                    // Intent 1 event -- decode route to get CCTP call's mintRecipient
+                    (
+                        ,
+                        bytes memory routeBytes,
+                        ,
+                        ,
+                    ) = abi.decode(
+                        logs[i].data,
+                        (uint64, bytes, uint64, uint256, TokenAmount[])
+                    );
+
+                    Route memory route = abi.decode(routeBytes, (Route));
+                    bytes memory callData = route.calls[1].data; // calls[1] = depositForBurn (after approve)
+
+                    // Decode the third parameter (mintRecipient) from the CCTP call
+                    (
+                        ,
+                        ,
+                        mintRecipient,
+                        ,
+                        ,
+                        ,
+                    ) = abi.decode(
+                        _sliceBytes(callData, 4),
+                        (uint256, uint32, bytes32, address, bytes32, uint256, uint32)
+                    );
+                }
+                eventIdx++;
+            }
+        }
+
+        // Verify that the address encoded in mintRecipient is non-zero and represents an address
+        address vault2Address = address(uint160(uint256(mintRecipient)));
+        assertTrue(vault2Address != address(0), "Intent 2 vault address should not be zero");
+
+        // The vault2 should be consistent with what portal would predict for intent2Hash
+        assertEq(mintRecipient, bytes32(uint256(uint160(vault2Address))), "mintRecipient should be properly encoded vault2 address");
+    }
+
+    function test_createIntent_bothIntentsUseSameSalt() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        bytes32 salt1;
+        bytes32 salt2;
+        uint256 eventIdx = 0;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                (
+                    ,
+                    bytes memory routeBytes,
+                    ,
+                    ,
+                ) = abi.decode(
+                    logs[i].data,
+                    (uint64, bytes, uint64, uint256, TokenAmount[])
+                );
+
+                Route memory route = abi.decode(routeBytes, (Route));
+
+                if (eventIdx == 0) {
+                    salt2 = route.salt; // Intent 2 is first
+                } else {
+                    salt1 = route.salt; // Intent 1 is second
+                }
+                eventIdx++;
+            }
+        }
+
+        assertEq(salt1, salt2, "Both intents should use the same salt");
+    }
+
+    function test_createIntent_bothIntentsUseSameDeadline() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint64 rewardDeadline1;
+        uint64 rewardDeadline2;
+        uint64 routeDeadline1;
+        uint64 routeDeadline2;
+        uint256 eventIdx = 0;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                (
+                    ,
+                    bytes memory routeBytes,
+                    uint64 rewardDeadline,
+                    ,
+                ) = abi.decode(
+                    logs[i].data,
+                    (uint64, bytes, uint64, uint256, TokenAmount[])
+                );
+
+                Route memory route = abi.decode(routeBytes, (Route));
+
+                if (eventIdx == 0) {
+                    rewardDeadline2 = rewardDeadline;
+                    routeDeadline2 = route.deadline;
+                } else {
+                    rewardDeadline1 = rewardDeadline;
+                    routeDeadline1 = route.deadline;
+                }
+                eventIdx++;
+            }
+        }
+
+        assertEq(rewardDeadline1, rewardDeadline2, "Both intents should have same reward deadline");
+        assertEq(routeDeadline1, routeDeadline2, "Both intents should have same route deadline");
+        assertEq(rewardDeadline1, uint64(block.timestamp + INTENT_DEADLINE_DURATION), "Deadline should be current time + duration");
+    }
+
+    function test_createIntent_intent1_isFunded() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        bytes32 intentHash = depositAddress.createIntent();
+
+        IIntentSource.Status status = portal.getRewardStatus(intentHash);
+        assertEq(
+            uint256(status),
+            uint256(IIntentSource.Status.Funded),
+            "Intent 1 should be funded"
+        );
+    }
+
+    // ============ Integration Tests ============
+    // Note: setUp already deploys a deposit address for USER_DESTINATION/DEPOSITOR,
+    // so integration tests use different addresses to avoid CREATE2 collisions.
+
+    address constant INTEGRATION_USER = address(0x7777);
+    address constant INTEGRATION_DEPOSITOR = address(0x8888);
+
+    function test_integration_fullFlow() public {
+        // 1. Get deposit address before deployment
+        address depositAddr = factory.getDepositAddress(INTEGRATION_USER, INTEGRATION_DEPOSITOR);
+        assertFalse(factory.isDeployed(INTEGRATION_USER, INTEGRATION_DEPOSITOR));
+
+        // 2. User sends tokens to deposit address
+        uint256 depositAmount = 10_000 * 1e6;
+        token.mint(depositAddr, depositAmount);
+        assertEq(token.balanceOf(depositAddr), depositAmount);
+
+        // 3. Deploy deposit contract
+        address deployed = factory.deploy(INTEGRATION_USER, INTEGRATION_DEPOSITOR);
+        assertEq(deployed, depositAddr);
+        assertTrue(factory.isDeployed(INTEGRATION_USER, INTEGRATION_DEPOSITOR));
+
+        DepositAddress_CCTPMint_GatewayERC20 da = DepositAddress_CCTPMint_GatewayERC20(deployed);
+        assertEq(da.destinationAddress(), bytes32(uint256(uint160(INTEGRATION_USER))));
+        assertEq(da.depositor(), INTEGRATION_DEPOSITOR);
+
+        // 4. Create intent
+        vm.recordLogs();
+        bytes32 intentHash = da.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertTrue(intentHash != bytes32(0));
+
+        // 5. Verify tokens moved from deposit address
+        assertEq(token.balanceOf(depositAddr), 0);
+
+        // 6. Verify intent was funded
+        IIntentSource.Status status = portal.getRewardStatus(intentHash);
+        assertEq(
+            uint256(status),
+            uint256(IIntentSource.Status.Funded),
+            "Intent should be funded"
+        );
+
+        // 7. Verify two IntentPublished events were emitted
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 intentPublishedCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                intentPublishedCount++;
+            }
+        }
+        assertEq(intentPublishedCount, 2, "Should have emitted two IntentPublished events");
+    }
+
+    function test_integration_deterministicAddressingWorks() public {
+        address intUser = address(0x9991);
+        address intDepositor = address(0x9992);
+
+        address predicted = factory.getDepositAddress(intUser, intDepositor);
+
+        uint256 amount = 10_000 * 1e6;
+        token.mint(predicted, amount);
+        assertEq(token.balanceOf(predicted), amount);
+
+        address deployed = factory.deploy(intUser, intDepositor);
+        assertEq(deployed, predicted);
+        assertEq(token.balanceOf(deployed), amount);
+
+        DepositAddress_CCTPMint_GatewayERC20 da = DepositAddress_CCTPMint_GatewayERC20(deployed);
+        bytes32 intentHash = da.createIntent();
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    function test_integration_multipleDeposits() public {
+        address intUser = address(0x9993);
+        address intDepositor = address(0x9994);
+
+        address deployed = factory.deploy(intUser, intDepositor);
+        DepositAddress_CCTPMint_GatewayERC20 da = DepositAddress_CCTPMint_GatewayERC20(deployed);
+
+        // First deposit
+        uint256 amount1 = 10_000 * 1e6;
+        token.mint(deployed, amount1);
+        bytes32 intentHash1 = da.createIntent();
+        assertEq(token.balanceOf(deployed), 0);
+
+        // Second deposit (new block.timestamp to avoid salt collision)
+        vm.warp(block.timestamp + 1);
+        uint256 amount2 = 5_000 * 1e6;
+        token.mint(deployed, amount2);
+        bytes32 intentHash2 = da.createIntent();
+        assertEq(token.balanceOf(deployed), 0);
+
+        assertTrue(intentHash1 != intentHash2, "Intent hashes should differ");
+
+        assertEq(
+            uint256(portal.getRewardStatus(intentHash1)),
+            uint256(IIntentSource.Status.Funded)
+        );
+        assertEq(
+            uint256(portal.getRewardStatus(intentHash2)),
+            uint256(IIntentSource.Status.Funded)
+        );
+    }
+
+    function test_integration_differentUsersGetDifferentAddresses() public {
+        address user1 = address(0x9995);
+        address depositor1 = address(0x9996);
+        address user2 = address(0x9997);
+        address depositor2 = address(0x9998);
+
+        address deployed1 = factory.deploy(user1, depositor1);
+        address deployed2 = factory.deploy(user2, depositor2);
+
+        assertTrue(deployed1 != deployed2);
+
+        uint256 amount = 10_000 * 1e6;
+
+        token.mint(deployed1, amount);
+        bytes32 intentHash1 = DepositAddress_CCTPMint_GatewayERC20(deployed1).createIntent();
+
+        vm.warp(block.timestamp + 1);
+        token.mint(deployed2, amount);
+        bytes32 intentHash2 = DepositAddress_CCTPMint_GatewayERC20(deployed2).createIntent();
+
+        assertTrue(intentHash1 != bytes32(0));
+        assertTrue(intentHash2 != bytes32(0));
+        assertTrue(intentHash1 != intentHash2);
+    }
+
+    function test_integration_gasEstimation() public {
+        address intUser = address(0x9999);
+        address intDepositor = address(0x9990);
+
+        uint256 gasBefore = gasleft();
+        address deployed = factory.deploy(intUser, intDepositor);
+        uint256 deployGas = gasBefore - gasleft();
+
+        token.mint(deployed, 10_000 * 1e6);
+        gasBefore = gasleft();
+        DepositAddress_CCTPMint_GatewayERC20(deployed).createIntent();
+        uint256 createIntentGas = gasBefore - gasleft();
+
+        assertTrue(deployGas > 0);
+        assertTrue(createIntentGas > 0);
+        assertTrue(deployGas < 500_000, "Deploy gas should be under 500k for minimal proxy");
+        assertTrue(createIntentGas < 1_000_000, "CreateIntent gas should be under 1M for dual-intent creation");
+    }
+
+    // ============ Fuzz Tests ============
+
+    function testFuzz_createIntent_succeeds(uint256 amount) public {
+        vm.assume(amount >= 100_000 && amount <= type(uint128).max);
+
+        token.mint(address(depositAddress), amount);
+        bytes32 intentHash = depositAddress.createIntent();
+
+        assertTrue(intentHash != bytes32(0));
+    }
+
+    // ============ Helpers ============
+
+    /// @dev Slices bytes from the given offset to the end
+    function _sliceBytes(bytes memory data, uint256 offset) internal pure returns (bytes memory) {
+        require(offset <= data.length, "offset out of bounds");
+        bytes memory result = new bytes(data.length - offset);
+        for (uint256 i = 0; i < result.length; i++) {
+            result[i] = data[i + offset];
+        }
+        return result;
+    }
+}

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -34,6 +34,7 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
 
     uint256 private constant MAX_FEE_BPS = 13;
     uint256 private constant FEE_DENOMINATOR = 100_000;
+    uint256 private constant FLAT_FEE = 500_000;
 
     function setUp() public {
         token = new TestERC20("Test USDC", "USDC");
@@ -50,7 +51,8 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            MAX_FEE_BPS
+            MAX_FEE_BPS,
+            FLAT_FEE
         );
 
         address deployed = factory.deploy(USER_DESTINATION, DEPOSITOR);
@@ -246,20 +248,21 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                 assertEq(creator, DEPOSITOR, "Intent 2 creator should be depositor");
                 assertEq(proverAddr, DESTINATION_PROVER_ADDRESS, "Intent 2 prover should be destination prover");
 
-                // Compute expected net amount after CCTP fee deduction (rounded up)
-                uint256 maxFee = (amount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
-                uint256 netAmount = amount - maxFee;
+                // Compute expected fee math: flatFee on intent1 route, CCTP maxFee on routeAmount.
+                uint256 routeAmount = amount - FLAT_FEE;
+                uint256 maxFee = (routeAmount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+                uint256 netAmount = routeAmount - maxFee;
 
-                // Verify route
+                // Verify route — uses netAmount (intent2 is symmetric: reward == route == netAmount)
                 Route memory route = abi.decode(routeBytes, (Route));
                 assertEq(route.portal, address(portal), "Intent 2 route portal should be portal");
                 assertEq(route.nativeAmount, 0, "Intent 2 route nativeAmount should be 0 (ERC20 destination)");
                 assertEq(route.tokens.length, 1, "Intent 2 route should have one token (destination USDC)");
                 assertEq(route.tokens[0].token, DESTINATION_USDC, "Intent 2 route token should be destination USDC");
-                assertEq(route.tokens[0].amount, netAmount, "Intent 2 route token amount should be net amount");
+                assertEq(route.tokens[0].amount, netAmount, "Intent 2 route token amount should be netAmount");
                 assertEq(route.calls.length, 2, "Intent 2 route should have two calls (approve + depositFor)");
 
-                // Verify call 0: approve Gateway for USDC (net amount)
+                // Verify call 0: approve Gateway for USDC (netAmount)
                 assertEq(route.calls[0].target, DESTINATION_USDC, "Call 0 target should be DESTINATION_USDC");
                 assertEq(route.calls[0].value, 0, "Call 0 value should be 0");
 
@@ -268,9 +271,9 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                     GATEWAY_ADDRESS,
                     netAmount
                 );
-                assertEq(route.calls[0].data, expectedApproveData, "Call 0 data should encode approve with net amount");
+                assertEq(route.calls[0].data, expectedApproveData, "Call 0 data should encode approve with netAmount");
 
-                // Verify call 1: Gateway.depositFor (net amount)
+                // Verify call 1: Gateway.depositFor (netAmount)
                 assertEq(route.calls[1].target, GATEWAY_ADDRESS, "Call 1 target should be Gateway");
                 assertEq(route.calls[1].value, 0, "Call 1 value should be 0");
 
@@ -280,13 +283,13 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                     address(uint160(uint256(bytes32(uint256(uint160(USER_DESTINATION)))))),
                     netAmount
                 );
-                assertEq(route.calls[1].data, expectedDepositForData, "Call 1 data should encode depositFor with net amount");
+                assertEq(route.calls[1].data, expectedDepositForData, "Call 1 data should encode depositFor with netAmount");
 
-                // Verify reward
+                // Verify reward — equals netAmount (intent2 reward and route are symmetric)
                 assertEq(rewardNativeAmount, 0, "Intent 2 reward nativeAmount should be 0 (ERC20 destination)");
                 assertEq(rewardTokens.length, 1, "Intent 2 reward should have one token (destination USDC)");
                 assertEq(rewardTokens[0].token, DESTINATION_USDC, "Intent 2 reward token should be destination USDC");
-                assertEq(rewardTokens[0].amount, netAmount, "Intent 2 reward token amount should be net amount");
+                assertEq(rewardTokens[0].amount, netAmount, "Intent 2 reward token amount should be netAmount");
 
                 break;
             }
@@ -333,13 +336,16 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                     assertEq(creator, DEPOSITOR, "Intent 1 creator should be depositor");
                     assertEq(proverAddr, PROVER_ADDRESS, "Intent 1 prover should be source chain prover");
 
+                    // Compute expected route amount after flat fee
+                    uint256 routeAmount = amount - FLAT_FEE;
+
                     // Verify route
                     Route memory route = abi.decode(routeBytes, (Route));
                     assertEq(route.portal, address(portal), "Intent 1 route portal should be portal");
                     assertEq(route.nativeAmount, 0, "Intent 1 route should have no native amount");
                     assertEq(route.tokens.length, 1, "Intent 1 route should have one token");
                     assertEq(route.tokens[0].token, address(token), "Intent 1 route token should be source USDC");
-                    assertEq(route.tokens[0].amount, amount, "Intent 1 route token amount should match deposit");
+                    assertEq(route.tokens[0].amount, routeAmount, "Intent 1 route token amount should equal amount minus flat fee");
                     assertEq(route.calls.length, 2, "Intent 1 route should have two calls (approve + CCTP depositForBurn)");
 
                     // Verify approve call (calls[0])
@@ -350,11 +356,11 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                     assertEq(route.calls[1].target, CCTP_TOKEN_MESSENGER, "Call 1 target should be TokenMessenger");
                     assertEq(route.calls[1].value, 0, "CCTP call should have no value");
 
-                    // Verify reward
+                    // Verify reward (full deposit; flat fee delta vs route is solver profit)
                     assertEq(rewardNativeAmount, 0, "Intent 1 reward should have no native amount");
                     assertEq(rewardTokens.length, 1, "Intent 1 reward should have one token");
                     assertEq(rewardTokens[0].token, address(token), "Intent 1 reward token should be source USDC");
-                    assertEq(rewardTokens[0].amount, amount, "Intent 1 reward amount should match deposit");
+                    assertEq(rewardTokens[0].amount, amount, "Intent 1 reward amount should match full deposit");
 
                     break;
                 }
@@ -418,12 +424,13 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
                         (uint256, uint32, bytes32, address, bytes32, uint256, uint32)
                     );
 
-                    uint256 expectedMaxFee = (amount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
-                    assertEq(cctpAmount, amount, "CCTP amount should match deposit");
+                    uint256 expectedRouteAmount = amount - FLAT_FEE;
+                    uint256 expectedMaxFee = (expectedRouteAmount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+                    assertEq(cctpAmount, expectedRouteAmount, "CCTP amount should equal deposit minus flat fee (routeAmount)");
                     assertEq(destDomain, DESTINATION_DOMAIN, "CCTP destination domain should match");
                     assertEq(burnToken, address(token), "CCTP burn token should be source USDC");
                     assertEq(destinationCaller, bytes32(0), "CCTP destination caller should be zero (anyone)");
-                    assertEq(maxFee, expectedMaxFee, "CCTP maxFee should be 1.3 bps of amount");
+                    assertEq(maxFee, expectedMaxFee, "CCTP maxFee should be 1.3 bps of routeAmount");
                     assertEq(minFinalityThreshold, 0, "CCTP minFinalityThreshold should be 0 (fast finality)");
 
                     // mintRecipient should be vault2 encoded as bytes32
@@ -604,6 +611,218 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
         );
     }
 
+    // ============ Flat Fee Tests ============
+
+    function test_createIntent_intent1_rewardRouteDelta_equalsFlatFee() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Intent 1 is the second IntentPublished event
+        uint256 eventIdx = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                if (eventIdx == 1) {
+                    (
+                        ,
+                        bytes memory routeBytes,
+                        ,
+                        ,
+                        TokenAmount[] memory rewardTokens
+                    ) = abi.decode(
+                        logs[i].data,
+                        (uint64, bytes, uint64, uint256, TokenAmount[])
+                    );
+
+                    Route memory route = abi.decode(routeBytes, (Route));
+
+                    // flat fee == reward - route on intent1 (Eco-protocol margin / solver profit)
+                    assertEq(
+                        rewardTokens[0].amount - route.tokens[0].amount,
+                        FLAT_FEE,
+                        "intent1.reward - intent1.route should equal FLAT_FEE"
+                    );
+                    assertEq(rewardTokens[0].amount, amount, "intent1.reward should equal full deposit");
+                    assertEq(route.tokens[0].amount, amount - FLAT_FEE, "intent1.route should equal amount - FLAT_FEE");
+
+                    break;
+                }
+                eventIdx++;
+            }
+        }
+    }
+
+    function test_createIntent_revertsWhenAmountEqualsFlatFee() public {
+        token.mint(address(depositAddress), FLAT_FEE);
+
+        vm.expectRevert(DepositAddress_CCTPMint_GatewayERC20.AmountBelowFlatFee.selector);
+        depositAddress.createIntent();
+    }
+
+    function test_createIntent_revertsWhenAmountBelowFlatFee() public {
+        token.mint(address(depositAddress), FLAT_FEE - 1);
+
+        vm.expectRevert(DepositAddress_CCTPMint_GatewayERC20.AmountBelowFlatFee.selector);
+        depositAddress.createIntent();
+    }
+
+    function test_createIntent_intent1_approveCallEncodesRouteAmount() public {
+        uint256 amount = 10_000 * 1e6;
+        token.mint(address(depositAddress), amount);
+
+        vm.recordLogs();
+        depositAddress.createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        // Intent 1 is the second IntentPublished event
+        uint256 eventIdx = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                if (eventIdx == 1) {
+                    (
+                        ,
+                        bytes memory routeBytes,
+                        ,
+                        ,
+                    ) = abi.decode(
+                        logs[i].data,
+                        (uint64, bytes, uint64, uint256, TokenAmount[])
+                    );
+
+                    Route memory route = abi.decode(routeBytes, (Route));
+                    uint256 expectedRouteAmount = amount - FLAT_FEE;
+
+                    // calls[0] is the approve(TokenMessenger, routeAmount) — must NOT use full amount
+                    bytes memory expectedApproveData = abi.encodeWithSignature(
+                        "approve(address,uint256)",
+                        CCTP_TOKEN_MESSENGER,
+                        expectedRouteAmount
+                    );
+                    assertEq(
+                        route.calls[0].data,
+                        expectedApproveData,
+                        "Intent 1 calls[0] must encode approve(TokenMessenger, routeAmount)"
+                    );
+
+                    break;
+                }
+                eventIdx++;
+            }
+        }
+    }
+
+    /// @notice The deposit contract's IERC20.approve(portal, amount) call before publishAndFund
+    ///         MUST grant the FULL deposit amount (= reward), not routeAmount; otherwise the
+    ///         Portal cannot pull reward tokens during publishAndFund.
+    function test_createIntent_portalAllowanceCoversFullRewardAmount() public {
+        uint256 amount = 10_000 * 1e6;
+
+        // Stage tokens at amount + 1 so that after publishAndFund pulls `amount`, the deposit
+        // contract still holds 1 token. The remaining allowance must equal the original
+        // `amount` minus what the Portal actually pulled (which itself must be `amount`).
+        // We instead inspect the allowance set BEFORE publishAndFund consumes it by using
+        // the Portal's recorded behavior: after createIntent, `allowance(deposit, portal)`
+        // is consumed down to 0 if approve(portal, amount) and Portal pulls exactly `amount`.
+        token.mint(address(depositAddress), amount);
+
+        depositAddress.createIntent();
+
+        // After Portal pulls reward tokens equal to `amount`, the post-call allowance is 0.
+        // If the contract had instead approved `routeAmount`, Portal's pull of `amount` would
+        // have reverted with ERC20InsufficientAllowance — so the simple fact that this test
+        // reaches this line proves the approve covered at least `amount`.
+        assertEq(
+            token.allowance(address(depositAddress), address(portal)),
+            0,
+            "Allowance should be exactly consumed to zero after Portal pulls full reward amount"
+        );
+        assertEq(
+            token.balanceOf(address(depositAddress)),
+            0,
+            "Full reward amount should have been pulled by Portal"
+        );
+    }
+
+    /// @notice Regression: with the flat fee = 0, the dual-intent flow must behave exactly as the
+    ///         pre-feature implementation (intent1.reward == intent1.route == amount; intent2
+    ///         reward == route == netAmount; no AmountBelowFlatFee revert path).
+    function test_createIntent_zeroFlatFee_preservesPreFeatureBehavior() public {
+        // Deploy a fresh factory/clone with flat fee = 0
+        DepositFactory_CCTPMint_GatewayERC20 zeroFeeFactory = new DepositFactory_CCTPMint_GatewayERC20(
+            address(token),
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            MAX_FEE_BPS,
+            0 // FLAT_FEE = 0
+        );
+
+        address user = address(0xA1A1);
+        address depositorAddr = address(0xA2A2);
+        address deposit = zeroFeeFactory.deploy(user, depositorAddr);
+
+        uint256 amount = 10_000 * 1e6;
+        token.mint(deposit, amount);
+
+        vm.recordLogs();
+        DepositAddress_CCTPMint_GatewayERC20(deposit).createIntent();
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        bytes32 intentPublishedSig = keccak256(
+            "IntentPublished(bytes32,uint64,bytes,address,address,uint64,uint256,(address,uint256)[])"
+        );
+
+        uint256 expectedMaxFee = (amount * MAX_FEE_BPS + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+        uint256 expectedNetAmount = amount - expectedMaxFee;
+
+        uint256 eventIdx = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == intentPublishedSig) {
+                (
+                    ,
+                    bytes memory routeBytes,
+                    ,
+                    ,
+                    TokenAmount[] memory rewardTokens
+                ) = abi.decode(
+                    logs[i].data,
+                    (uint64, bytes, uint64, uint256, TokenAmount[])
+                );
+                Route memory route = abi.decode(routeBytes, (Route));
+
+                if (eventIdx == 0) {
+                    // Intent 2 — reward == route == netAmount (intent2 is always symmetric)
+                    assertEq(rewardTokens[0].amount, expectedNetAmount, "Intent2 reward (zeroFlat) should equal pre-feature netAmount");
+                    assertEq(route.tokens[0].amount, expectedNetAmount, "Intent2 route (zeroFlat) should equal pre-feature netAmount");
+                    assertEq(rewardTokens[0].amount, route.tokens[0].amount, "Intent2 should always be symmetric");
+                } else {
+                    // Intent 1 — reward == route == amount when flat fee = 0
+                    assertEq(rewardTokens[0].amount, amount, "Intent1 reward (zeroFlat) should equal full amount");
+                    assertEq(route.tokens[0].amount, amount, "Intent1 route (zeroFlat) should equal full amount (no flat fee)");
+                }
+                eventIdx++;
+            }
+        }
+        assertEq(eventIdx, 2, "Should have observed exactly two IntentPublished events");
+    }
+
     // ============ Integration Tests ============
     // Note: setUp already deploys a deposit address for USER_DESTINATION/DEPOSITOR,
     // so integration tests use different addresses to avoid CREATE2 collisions.
@@ -760,7 +979,9 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
     // ============ Fuzz Tests ============
 
     function testFuzz_createIntent_succeeds(uint256 amount) public {
-        vm.assume(amount >= 100_000 && amount <= type(uint128).max);
+        // Amount must exceed the flat fee plus enough headroom for the CCTP fast-deposit fee
+        // to leave a positive netAmount.
+        vm.assume(amount > FLAT_FEE + 1_000_000 && amount <= type(uint128).max);
 
         token.mint(address(depositAddress), amount);
         bytes32 intentHash = depositAddress.createIntent();
@@ -950,7 +1171,9 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
     }
 
     function testFuzz_createIntentWithApproval_succeeds(uint256 amount) public {
-        vm.assume(amount >= 100_000 && amount <= type(uint128).max);
+        // Amount must exceed the flat fee plus enough headroom for the CCTP fast-deposit fee
+        // to leave a positive netAmount.
+        vm.assume(amount > FLAT_FEE + 1_000_000 && amount <= type(uint128).max);
 
         token.mint(DEPOSITOR, amount);
 

--- a/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {DepositFactory_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositFactory_CCTPMint_GatewayERC20.sol";
+import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol";
+import {BaseDepositFactory} from "../../contracts/deposit/BaseDepositFactory.sol";
+import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
+import {Portal} from "../../contracts/Portal.sol";
+
+contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
+    DepositFactory_CCTPMint_GatewayERC20 public factory;
+    Portal public portal;
+
+    // Configuration parameters
+    address constant SOURCE_TOKEN = address(0x1234);
+    address constant PROVER_ADDRESS = address(0x9ABC);
+    uint64 constant INTENT_DEADLINE_DURATION = 7 days;
+    uint32 constant DESTINATION_DOMAIN = 7; // Polygon CCTP domain
+    address constant CCTP_TOKEN_MESSENGER = address(0xABCD);
+    uint64 constant DESTINATION_CHAIN_ID = 137;
+    address constant DESTINATION_PROVER_ADDRESS = address(0xBBBB);
+    address constant DESTINATION_USDC = address(0xCCCC);
+    address constant GATEWAY_ADDRESS = address(0xDDDD);
+
+    // Test user addresses
+    address constant USER_DESTINATION_1 = address(0x1111);
+    address constant USER_DESTINATION_2 = address(0x2222);
+    address constant DEPOSITOR_1 = address(0x3333);
+    address constant DEPOSITOR_2 = address(0x4444);
+
+    function setUp() public {
+        portal = new Portal();
+
+        factory = new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    // ============ Constructor Tests ============
+
+    function test_constructor_setsConfigurationCorrectly() public view {
+        (
+            address sourceToken,
+            address portalAddress,
+            address proverAddress,
+            uint64 deadlineDuration,
+            uint32 destinationDomain,
+            address cctpTokenMessenger,
+            uint64 destinationChainId,
+            address destinationProverAddress,
+            address destinationUsdc,
+            address gatewayAddress,
+            uint256 maxFeeBps
+        ) = factory.getConfiguration();
+
+        assertEq(sourceToken, SOURCE_TOKEN);
+        assertEq(portalAddress, address(portal));
+        assertEq(proverAddress, PROVER_ADDRESS);
+        assertEq(deadlineDuration, INTENT_DEADLINE_DURATION);
+        assertEq(destinationDomain, DESTINATION_DOMAIN);
+        assertEq(cctpTokenMessenger, CCTP_TOKEN_MESSENGER);
+        assertEq(destinationChainId, DESTINATION_CHAIN_ID);
+        assertEq(destinationProverAddress, DESTINATION_PROVER_ADDRESS);
+        assertEq(destinationUsdc, DESTINATION_USDC);
+        assertEq(gatewayAddress, GATEWAY_ADDRESS);
+        assertEq(maxFeeBps, 13);
+    }
+
+    function test_constructor_deploysImplementation() public view {
+        address implementation = factory.DEPOSIT_IMPLEMENTATION();
+        assertTrue(implementation != address(0));
+        assertTrue(implementation.code.length > 0);
+    }
+
+    function test_constructor_revertsOnInvalidSourceToken() public {
+        vm.expectRevert(BaseDepositFactory.InvalidSourceToken.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            address(0), // Invalid
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidPortalAddress() public {
+        vm.expectRevert(BaseDepositFactory.InvalidPortalAddress.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(0), // Invalid
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidProverAddress() public {
+        vm.expectRevert(BaseDepositFactory.InvalidProverAddress.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            address(0), // Invalid
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidDeadlineDuration() public {
+        vm.expectRevert(BaseDepositFactory.InvalidDeadlineDuration.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            0, // Invalid
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidCCTPTokenMessenger() public {
+        vm.expectRevert(DepositFactory_CCTPMint_GatewayERC20.InvalidCCTPTokenMessenger.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            address(0), // Invalid
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidDestinationChainId() public {
+        vm.expectRevert(DepositFactory_CCTPMint_GatewayERC20.InvalidDestinationChainId.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            0, // Invalid
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidDestinationProverAddress() public {
+        vm.expectRevert(DepositFactory_CCTPMint_GatewayERC20.InvalidDestinationProverAddress.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            address(0), // Invalid
+            DESTINATION_USDC,
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidDestinationUsdc() public {
+        vm.expectRevert(DepositFactory_CCTPMint_GatewayERC20.InvalidDestinationUsdc.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            address(0), // Invalid
+            GATEWAY_ADDRESS,
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    function test_constructor_revertsOnInvalidGatewayAddress() public {
+        vm.expectRevert(DepositFactory_CCTPMint_GatewayERC20.InvalidGatewayAddress.selector);
+        new DepositFactory_CCTPMint_GatewayERC20(
+            SOURCE_TOKEN,
+            address(portal),
+            PROVER_ADDRESS,
+            INTENT_DEADLINE_DURATION,
+            DESTINATION_DOMAIN,
+            CCTP_TOKEN_MESSENGER,
+            DESTINATION_CHAIN_ID,
+            DESTINATION_PROVER_ADDRESS,
+            DESTINATION_USDC,
+            address(0), // Invalid
+            13 // 1.3 bps CCTP fast-deposit fee
+        );
+    }
+
+    // ============ getDepositAddress Tests ============
+
+    function test_getDepositAddress_returnsDeterministicAddress() public view {
+        address predicted = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        assertTrue(predicted != address(0));
+    }
+
+    function test_getDepositAddress_sameAddressForSameParams() public view {
+        address predicted1 = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        address predicted2 = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        assertEq(predicted1, predicted2);
+    }
+
+    function test_getDepositAddress_differentAddressForDifferentDestination()
+        public
+        view
+    {
+        address predicted1 = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        address predicted2 = factory.getDepositAddress(USER_DESTINATION_2, DEPOSITOR_1);
+        assertTrue(predicted1 != predicted2);
+    }
+
+    function test_getDepositAddress_differentAddressForDifferentDepositor()
+        public
+        view
+    {
+        address predicted1 = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        address predicted2 = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_2);
+        assertTrue(predicted1 != predicted2);
+    }
+
+    // ============ deploy Tests ============
+
+    function test_deploy_createsContractAtPredictedAddress() public {
+        address predicted = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+        address deployed = factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+
+        assertEq(deployed, predicted);
+        assertTrue(deployed.code.length > 0);
+    }
+
+    function test_deploy_initializesDepositAddress() public {
+        address deployed = factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+        DepositAddress_CCTPMint_GatewayERC20 depositAddress = DepositAddress_CCTPMint_GatewayERC20(deployed);
+
+        assertEq(depositAddress.destinationAddress(), bytes32(uint256(uint160(USER_DESTINATION_1))));
+        assertEq(depositAddress.depositor(), DEPOSITOR_1);
+    }
+
+    function test_deploy_emitsEvent() public {
+        address predicted = factory.getDepositAddress(USER_DESTINATION_1, DEPOSITOR_1);
+
+        vm.expectEmit(true, true, false, false);
+        emit BaseDepositFactory.DepositContractDeployed(
+            USER_DESTINATION_1,
+            predicted
+        );
+
+        factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+    }
+
+    function test_deploy_revertsIfZeroDestinationAddress() public {
+        vm.expectRevert(BaseDepositAddress.InvalidDestinationAddress.selector);
+        factory.deploy(address(0), DEPOSITOR_1);
+    }
+
+    function test_deploy_revertsIfAlreadyDeployed() public {
+        factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+
+        vm.expectRevert();
+        factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+    }
+
+    function test_deploy_allowsDifferentDepositorsToSameDestination() public {
+        address deployed1 = factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+        address deployed2 = factory.deploy(USER_DESTINATION_1, DEPOSITOR_2);
+
+        assertTrue(deployed1 != deployed2);
+        assertTrue(deployed1.code.length > 0);
+        assertTrue(deployed2.code.length > 0);
+
+        assertEq(DepositAddress_CCTPMint_GatewayERC20(deployed1).destinationAddress(), bytes32(uint256(uint160(USER_DESTINATION_1))));
+        assertEq(DepositAddress_CCTPMint_GatewayERC20(deployed1).depositor(), DEPOSITOR_1);
+        assertEq(DepositAddress_CCTPMint_GatewayERC20(deployed2).destinationAddress(), bytes32(uint256(uint160(USER_DESTINATION_1))));
+        assertEq(DepositAddress_CCTPMint_GatewayERC20(deployed2).depositor(), DEPOSITOR_2);
+    }
+
+    function test_deploy_allowsDifferentUsers() public {
+        address deployed1 = factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+        address deployed2 = factory.deploy(USER_DESTINATION_2, DEPOSITOR_2);
+
+        assertTrue(deployed1 != deployed2);
+        assertTrue(deployed1.code.length > 0);
+        assertTrue(deployed2.code.length > 0);
+    }
+
+    // ============ isDeployed Tests ============
+
+    function test_isDeployed_returnsFalseBeforeDeployment() public view {
+        assertFalse(factory.isDeployed(USER_DESTINATION_1, DEPOSITOR_1));
+    }
+
+    function test_isDeployed_returnsTrueAfterDeployment() public {
+        factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+        assertTrue(factory.isDeployed(USER_DESTINATION_1, DEPOSITOR_1));
+    }
+
+    function test_isDeployed_independentForDifferentUsers() public {
+        factory.deploy(USER_DESTINATION_1, DEPOSITOR_1);
+
+        assertTrue(factory.isDeployed(USER_DESTINATION_1, DEPOSITOR_1));
+        assertFalse(factory.isDeployed(USER_DESTINATION_2, DEPOSITOR_1));
+    }
+
+    // ============ Fuzz Tests ============
+
+    function testFuzz_getDepositAddress_deterministic(
+        address destination,
+        address depositor
+    ) public view {
+        vm.assume(destination != address(0));
+        vm.assume(depositor != address(0));
+
+        address predicted1 = factory.getDepositAddress(destination, depositor);
+        address predicted2 = factory.getDepositAddress(destination, depositor);
+
+        assertEq(predicted1, predicted2);
+    }
+
+    function testFuzz_deploy_succeeds(
+        address destination,
+        address depositor
+    ) public {
+        vm.assume(destination != address(0));
+        vm.assume(depositor != address(0));
+
+        address predicted = factory.getDepositAddress(destination, depositor);
+        address deployed = factory.deploy(destination, depositor);
+
+        assertEq(deployed, predicted);
+        assertTrue(deployed.code.length > 0);
+    }
+}

--- a/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
@@ -22,6 +22,7 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
     address constant DESTINATION_PROVER_ADDRESS = address(0xBBBB);
     address constant DESTINATION_USDC = address(0xCCCC);
     address constant GATEWAY_ADDRESS = address(0xDDDD);
+    uint256 constant FLAT_FEE = 500_000;
 
     // Test user addresses
     address constant USER_DESTINATION_1 = address(0x1111);
@@ -43,7 +44,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -61,7 +63,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             address destinationProverAddress,
             address destinationUsdc,
             address gatewayAddress,
-            uint256 maxFeeBps
+            uint256 maxFeeBps,
+            uint256 flatFee
         ) = factory.getConfiguration();
 
         assertEq(sourceToken, SOURCE_TOKEN);
@@ -75,6 +78,7 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
         assertEq(destinationUsdc, DESTINATION_USDC);
         assertEq(gatewayAddress, GATEWAY_ADDRESS);
         assertEq(maxFeeBps, 13);
+        assertEq(flatFee, FLAT_FEE);
     }
 
     function test_constructor_deploysImplementation() public view {
@@ -96,7 +100,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -113,7 +118,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -130,7 +136,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -147,7 +154,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -164,7 +172,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -181,7 +190,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -198,7 +208,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             address(0), // Invalid
             DESTINATION_USDC,
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -215,7 +226,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             address(0), // Invalid
             GATEWAY_ADDRESS,
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 
@@ -232,7 +244,8 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
             DESTINATION_PROVER_ADDRESS,
             DESTINATION_USDC,
             address(0), // Invalid
-            13 // 1.3 bps CCTP fast-deposit fee
+            13, // 1.3 bps CCTP fast-deposit fee
+            FLAT_FEE
         );
     }
 


### PR DESCRIPTION
## Summary

Extends the CCTP-based deposit address system along two complementary axes:

1. **ERC20 variant for non-Arc destinations.** A new deposit address / factory pair targeting chains where USDC arrives as a standard ERC20 (Base, Optimism, Arbitrum, Polygon, …) instead of as the native gas token (Arc).
2. **Approval-based intent creation.** A new entry point on `BaseDepositAddress` that lets users sign a standard ERC20 approval to the deterministic deposit address, removing the need for a trusted operator wallet to custody funds before the intent is triggered.

Both changes are inherited by every deposit variant, so the existing Arc flow also picks up the approval entry point.

## Why

### ERC20 gateway deposits
The existing `DepositFactory_CCTPMint_Gateway` was shaped around Arc, where USDC is the native gas token. On every other EVM chain, the destination-side intent has to move USDC as a regular ERC20 — a different token structure with no native-amount scaling. Rather than stretching the Arc contract with conditional paths, this branch introduces a dedicated variant with destination-agnostic naming so the same contract can be reused across EVM chains. It's been deployed at the same CREATE3 address on Base, Optimism, and Arbitrum.

### Approval-based flow
Deposit flows today lean on an operator wallet to receive funds and trigger the intent. That wallet is mutable, human-controlled, and has to be trusted by the user. With the new flow, the user signs a plain ERC20 approval to the **deposit address itself** — a deterministic, CREATE2-derived contract whose address can be computed off-chain before it's even deployed. The contract then pulls the lesser of allowance and balance when the intent is created. Net effect: no custodial operator in the path, and the UX reduces to a single approve that anyone can later crank.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Scope

- 1 new deposit variant (`DepositAddress_CCTPMint_GatewayERC20` + `DepositFactory_CCTPMint_GatewayERC20`)
- 1 cross-cutting addition to `BaseDepositAddress` that all variants inherit
- CREATE3 deployment script for same-address multi-chain deployment
- Forge test coverage for both additions (existing test style preserved)

## Test plan

- [ ] `forge test` — full suite green
- [x] Targeted runs: `DepositAddress_CCTPMint_GatewayERC20.t.sol`, `DepositFactory_CCTPMint_GatewayERC20.t.sol`, and the new `createIntentWithApproval` cases in `BaseDepositAddress`
- [x] Sanity check: deployed addresses on Base / Optimism / Arbitrum match the CREATE3 prediction for `0x5947DfA1Ef80Fc4c6c6aECE2dF350429162cbEFb`
- [x] Regression: existing Arc-variant behavior unchanged end-to-end