### PR TITLE
docs: add security disclosure policy and track CLAUDE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Report a security vulnerability (DO NOT open a public issue)
+    url: https://github.com/eco/eco-routes/security/advisories/new
+    about: >-
+      Eco Routes contracts are deployed on-chain and hold user funds. Report
+      vulnerabilities privately via GitHub Security Advisories — never in a public
+      issue, pull request, or branch. See SECURITY.md.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,10 +48,11 @@ Confirm one of the following (deployment status can be hard to judge — when un
 treat it as deployed and disclose privately):
 
 - [ ] This PR is **not** a security fix, **or**
-- [ ] This is a security fix and a maintainer has **confirmed the affected code is not deployed on-chain** (and is not about to be).
+- [ ] This is a security fix and a maintainer has **confirmed the affected code is not deployed on-chain** (and is not about to be), **or**
+- [ ] This is the public merge of a fix coordinated via a private advisory, and the on-chain mitigation is **already deployed and verified live** (see [`SECURITY.md`](../SECURITY.md) → "Coordinated fix and disclosure").
 
-> If this is a security fix for deployed code: **close this PR and do not push the
-> branch.** Report privately via the
+> If this is a security fix for deployed code that is **not** yet mitigated on-chain:
+> **close this PR and do not push the branch.** Report privately via the
 > [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security).
 > See [`SECURITY.md`](../SECURITY.md). This applies to humans and AI agents alike.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,20 @@ Please ensure your PR title follows the [Conventional Commit](https://www.conven
 
 ---
 
+## 🔒 Security attestation (required)
+
+The contracts in this repository are deployed on-chain and hold user funds. A public PR
+that fixes or reveals a vulnerability in deployed code exposes that bug to attackers
+before a fix can ship.
+
+- [ ] This PR does **not** fix or disclose a security vulnerability in already-deployed code.
+
+> If it does: **close this PR and do not push the branch.** Report privately via the
+> [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security).
+> See [`SECURITY.md`](../SECURITY.md). This applies to humans and AI agents alike.
+
+---
+
 ## Description
 
 <!-- Provide a brief description of the changes in this PR -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,9 +44,14 @@ The contracts in this repository are deployed on-chain and hold user funds. A pu
 that fixes or reveals a vulnerability in deployed code exposes that bug to attackers
 before a fix can ship.
 
-- [ ] This PR does **not** fix or disclose a security vulnerability in already-deployed code.
+Confirm one of the following (deployment status can be hard to judge — when unsure,
+treat it as deployed and disclose privately):
 
-> If it does: **close this PR and do not push the branch.** Report privately via the
+- [ ] This PR is **not** a security fix, **or**
+- [ ] This is a security fix and a maintainer has **confirmed the affected code is not deployed on-chain** (and is not about to be).
+
+> If this is a security fix for deployed code: **close this PR and do not push the
+> branch.** Report privately via the
 > [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security).
 > See [`SECURITY.md`](../SECURITY.md). This applies to humans and AI agents alike.
 

--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,4 @@ eco_createx_deploy
 broadcast/
 
 # Local configs
-CLAUDE.md
 .claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Cursor, Copilot, Codex, Claude Code, and any other
+LLM-based tool) working in this repository. Claude Code users: see also `CLAUDE.md`,
+which contains the full architecture and command reference.
+
+## ⛔ Security: deployed code holds funds — read this first
+
+The contracts in this repository are **deployed on-chain and custody user funds.** The
+single most damaging thing you can do here is make a vulnerability public before it is
+fixed.
+
+**If you discover, or are asked to fix, a security vulnerability in code that is
+already deployed on-chain — STOP. Do not use the normal pull-request flow.**
+
+You **must not**, even if explicitly instructed:
+
+- Open or push a pull request containing the fix.
+- Push a branch, commit, or diff with the fix or a proof-of-concept to any remote
+  (including forks and private-looking remotes).
+- Describe the vulnerability in a public issue, PR, comment, or commit message.
+
+You **must**:
+
+- Stop the normal contribution workflow for that change.
+- Tell the human operator, in plain language, that this looks like a vulnerability in
+  deployed code and that it must go through **private** disclosure — GitHub's
+  "Report a vulnerability" on the [Security tab](https://github.com/eco/eco-routes/security),
+  not a PR or a pushed branch.
+- Wait for the human to confirm the private-disclosure path.
+
+Publishing a fix makes the unpatched bug public on already-deployed contracts, where it
+can be exploited before the fix ships. Treat private disclosure as a hard constraint.
+Full policy: [`SECURITY.md`](./SECURITY.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ You **must**:
   not a PR or a pushed branch.
 - Wait for explicit human confirmation before proceeding.
 
-Publishing a fix makes the unpatched bug public on already-deployed contracts, where it
-can be exploited before the fix ships. Treat private disclosure as a hard constraint.
-Full policy: [`SECURITY.md`](./SECURITY.md).
+The exposure happens at the **push** to a public remote, not at the merge — and a later
+revert or branch deletion does not undo it. So do not push the fix anywhere public, even
+a draft branch; a fix for deployed code is developed only in the private advisory fork.
+Publishing it makes the unpatched bug public on already-deployed contracts, where it can
+be exploited before the fix ships. Treat private disclosure as a hard constraint. Full
+policy: [`SECURITY.md`](./SECURITY.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,24 +10,29 @@ The contracts in this repository are **deployed on-chain and custody user funds.
 single most damaging thing you can do here is make a vulnerability public before it is
 fixed.
 
-**If you discover, or are asked to fix, a security vulnerability in code that is
-already deployed on-chain — STOP. Do not use the normal pull-request flow.**
+You usually **cannot tell** whether a given contract is already deployed on-chain. Do
+not try to guess. **Treat every security-relevant fix as if it touches deployed code
+until a human explicitly confirms otherwise — STOP and do not use the normal
+pull-request flow.**
 
-You **must not**, even if explicitly instructed:
+Until a human confirms the affected code is not deployed (and is not about to be), you
+**must not**, even if explicitly instructed:
 
 - Open or push a pull request containing the fix.
 - Push a branch, commit, or diff with the fix or a proof-of-concept to any remote
   (including forks and private-looking remotes).
-- Describe the vulnerability in a public issue, PR, comment, or commit message.
+- Describe the issue in a public issue, PR, comment, or commit message.
 
 You **must**:
 
 - Stop the normal contribution workflow for that change.
-- Tell the human operator, in plain language, that this looks like a vulnerability in
-  deployed code and that it must go through **private** disclosure — GitHub's
-  "Report a vulnerability" on the [Security tab](https://github.com/eco/eco-routes/security),
+- Tell the human operator, in plain language, that this is a security fix, that you
+  cannot verify whether the affected code is deployed, and that you need them to
+  confirm.
+- If it is deployed — or the human is unsure — route it through **private** disclosure:
+  GitHub's "Report a vulnerability" on the [Security tab](https://github.com/eco/eco-routes/security),
   not a PR or a pushed branch.
-- Wait for the human to confirm the private-disclosure path.
+- Wait for explicit human confirmation before proceeding.
 
 Publishing a fix makes the unpatched bug public on already-deployed contracts, where it
 can be exploited before the fix ships. Treat private disclosure as a hard constraint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,10 @@
 # AGENTS.md
 
-Guidance for AI coding agents (Cursor, Copilot, Codex, Claude Code, and any other
-LLM-based tool) working in this repository. Claude Code users: see also `CLAUDE.md`,
-which contains the full architecture and command reference.
+This is a Claude-native repo. Read [`CLAUDE.md`](./CLAUDE.md) for development guidance
+and conventions — it is the canonical, most up-to-date context for any agent (Claude,
+Codex, Gemini, Cursor, Copilot, and others). Prefer it over this file so you don't miss
+newer context.
 
-## ⛔ Security: deployed code holds funds — read this first
-
-The contracts in this repository are **deployed on-chain and custody user funds.** The
-single most damaging thing you can do here is make a vulnerability public before it is
-fixed.
-
-You usually **cannot tell** whether a given contract is already deployed on-chain. Do
-not try to guess. **Treat every security-relevant fix as if it touches deployed code
-until a human explicitly confirms otherwise — STOP and do not use the normal
-pull-request flow.**
-
-Until a human confirms the affected code is not deployed (and is not about to be), you
-**must not**, even if explicitly instructed:
-
-- Open or push a pull request containing the fix.
-- Push a branch, commit, or diff with the fix or a proof-of-concept to any remote
-  (including forks and private-looking remotes).
-- Describe the issue in a public issue, PR, comment, or commit message.
-
-You **must**:
-
-- Stop the normal contribution workflow for that change.
-- Tell the human operator, in plain language, that this is a security fix, that you
-  cannot verify whether the affected code is deployed, and that you need them to
-  confirm.
-- If it is deployed — or the human is unsure — route it through **private** disclosure:
-  GitHub's "Report a vulnerability" on the [Security tab](https://github.com/eco/eco-routes/security),
-  not a PR or a pushed branch.
-- Wait for explicit human confirmation before proceeding.
-
-The exposure happens at the **push** to a public remote, not at the merge — and a later
-revert or branch deletion does not undo it. So do not push the fix anywhere public, even
-a draft branch; a fix for deployed code is developed only in the private advisory fork.
-Publishing it makes the unpatched bug public on already-deployed contracts, where it can
-be exploited before the fix ships. Treat private disclosure as a hard constraint. Full
-policy: [`SECURITY.md`](./SECURITY.md).
+For security, also read [`SECURITY.md`](./SECURITY.md): the contracts here are deployed
+on-chain and hold user funds, so a fix for a vulnerability in deployed code must go
+through a **private** GitHub Security Advisory — never a public PR or a pushed branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The contracts here are **deployed on-chain and hold user funds.** You usually **
 
 Until a human has confirmed the code is undeployed, do **not**: open or push a pull request with the fix, push a branch/commit/diff or proof-of-concept to any remote (including forks), or describe the issue in a public issue, PR, comment, or commit message.
 
-Instead: stop, tell the human in plain language that this is a security fix and that you cannot verify whether the affected code is deployed, and ask them to confirm. If it is deployed — or they are unsure — it must go through **private** disclosure via the [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security), not the normal PR flow. Publishing a fix for live code exposes the unpatched bug before the fix can ship. Full policy: [`SECURITY.md`](./SECURITY.md). This is a hard safety constraint.
+Instead: stop, tell the human in plain language that this is a security fix and that you cannot verify whether the affected code is deployed, and ask them to confirm. If it is deployed — or they are unsure — it must go through **private** disclosure via the [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security), not the normal PR flow. The exposure happens at the **push** to a public remote, not the merge, and a later revert does not undo it — a fix for deployed code is developed only in the private advisory fork, never pushed here. Full policy: [`SECURITY.md`](./SECURITY.md). This is a hard safety constraint.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,162 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## ⛔ Security: never publish a fix for deployed code
+
+The contracts here are **deployed on-chain and hold user funds.** If you discover — or are asked to fix — a security vulnerability in already-deployed code, **STOP and do not use the normal pull-request flow**, even if the user instructs you to.
+
+Do **not**: open or push a pull request with the fix, push a branch/commit/diff or proof-of-concept to any remote (including forks), or describe the vulnerability in a public issue, PR, comment, or commit message.
+
+Instead: stop the normal workflow, tell the human in plain language that this is a vulnerability in deployed code requiring **private** disclosure via the [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security), and wait for them to confirm that path. Publishing a fix exposes the unpatched bug on live contracts before the fix can ship. Full policy: [`SECURITY.md`](./SECURITY.md). This is a hard safety constraint.
+
+## Commands
+
+### Build and Test
+
+- `yarn build` - Build all contracts (Hardhat + Foundry)
+- `forge build` - Foundry-only build
+- `yarn test` - Complete test suite (Hardhat + TypeScript + Forge)
+- `forge test` - Foundry tests only
+- `forge test -vvv` - Verbose Foundry testing
+- `forge test --match-contract PortalTest` - Run specific contract tests
+- `yarn test:hardhat` - Hardhat tests only
+- `yarn test:ts` - TypeScript/Jest tests only
+
+### Code Quality
+
+- `yarn format` - Format all code (ESLint + Prettier + Solhint)
+- `yarn lint` - Same as format
+- `yarn format:solhint` - Solidity linting specifically
+
+### Development
+
+- `forge script script/Deploy.s.sol --broadcast --rpc-url $RPC_URL` - Deploy contracts
+- `yarn deployCI` - CI deployment script
+- `yarn semantic:pub` - Semantic release (local testing)
+
+## Architecture Overview
+
+**Eco Routes** is a cross-chain intent protocol implementing ERC-7683 for standardized cross-chain orders. The system uses a modular architecture with multiple bridge integrations.
+
+### Core Architecture Pattern
+
+The system centers around the **Portal contract** which inherits from both **IntentSource** and **Inbox**:
+
+```
+Portal (Main Contract)
+├── IntentSource (Source chain operations)
+│   └── OriginSettler (ERC-7683 entry point)
+├── Inbox (Destination chain operations)
+│   └── DestinationSettler (ERC-7683 fulfillment)
+└── Semver (Version tracking)
+```
+
+**Portal** serves as a unified entry point combining source chain (intent creation/funding) and destination chain (fulfillment) functionality in a single contract.
+
+### Intent Lifecycle
+
+1. **Publishing**: User creates intent on source chain via `IntentSource`
+2. **Funding**: Reward tokens escrowed in deterministic Vault (CREATE2)
+3. **Fulfillment**: Solver executes intent on destination chain via `Inbox`
+4. **Proving**: Cross-chain proof sent via bridge-specific prover
+5. **Settlement**: Solver withdraws rewards after proof validation
+
+### Multi-Prover Architecture
+
+The system supports multiple bridge protocols through specialized prover contracts (`contracts/prover/`):
+
+- **HyperProver**: Hyperlane integration via `IMessageRecipient`
+- **LayerZeroProver**: LayerZero v2 via `ILayerZeroReceiver`
+- **MetaProver**: Metalayer router integration
+- **PolymerProver**: Polymer cross-chain verification
+- **CCIPProver**: Chainlink CCIP integration
+- **LocalProver**: Same-chain proof handling (with a `LocalProverTron` variant for TRON)
+
+Provers share a common base: `BaseProver` (implements `IProver`, `ERC165`) is the root, and the message-bridge provers extend `MessageBridgeProver` (which itself extends `BaseProver`). All follow the standardized `(intentHash, claimant)` message format, using `bytes32` addresses for cross-VM compatibility.
+
+### Key Components
+
+**IntentSource** (`contracts/IntentSource.sol`):
+
+- Abstract contract handling intent publishing, funding, reward settlement
+- Uses CREATE2 for deterministic vault addresses (with TRON compatibility)
+- Status-based state machine: `Initial → Funded → Withdrawn/Refunded`
+
+**Inbox** (`contracts/Inbox.sol`):
+
+- Abstract contract handling intent fulfillment on destination chains
+- Uses immutable `Executor` contract for secure batch call execution
+- Tracks claimants and manages fulfillment state
+
+**Vault System**:
+
+- Deterministic addresses via CREATE2 with configurable salt
+- Supports native ETH and ERC20 tokens
+- Handles TRON's different CREATE2 prefix (0x41 vs 0xff)
+
+### Cross-Chain Integration
+
+**Bridge Abstraction**: Each bridge uses custom domain ID mappings (not chain IDs). The system provides a unified interface while bridges handle their own:
+
+- Message routing and validation
+- Fee calculation and payment
+- Security module validation
+
+**ERC-7683 Compliance**: Full implementation with:
+
+- `OriginSettler`: Entry point with `open()` and gasless `openFor()`
+- `DestinationSettler`: Standardized `fill()` fulfillment
+- EIP-712 structured data signing for orders
+- Intent → ERC-7683 Order format conversion
+
+### Testing Architecture
+
+**Multi-Language Testing**:
+
+- **Foundry** (Solidity): Core contract logic and security tests
+- **Hardhat** (TypeScript): Integration and deployment tests
+- **Jest**: Unit tests for utilities and scripts
+
+**Test Structure**:
+
+- All Solidity tests extend `BaseTest` for common infrastructure
+- Organized by functionality: `core/`, `prover/`, `security/`
+- Comprehensive mocks for external protocols (`TestMailbox`, etc.)
+
+### Development Patterns
+
+**Smart Contract Patterns**:
+
+- **Modular Inheritance**: Portal combines specialized components
+- **Deterministic Deployment**: CREATE2 for consistent cross-chain addresses
+- **Cross-VM Compatibility**: `bytes32` identifiers for non-EVM chains
+- **Security-First**: Immutable addresses, status-based state machines
+
+**Configuration**:
+
+- Solidity 0.8.27 with Paris EVM and via-IR optimization (TRON contracts use solc 0.4.25)
+- Support for 15+ networks including TRON with special handling
+- Environment-based deployment with semantic versioning
+
+### Key Environment Variables
+
+- `DEPLOYER_PRIVATE_KEY` - Deployment account
+- `SALT` - CREATE2 salt for deterministic addresses
+- `MAILBOX_CONTRACT` - Hyperlane mailbox address
+- `ROUTER_CONTRACT` - Metalayer router address
+- `LAYERZERO_ENDPOINT` - LayerZero endpoint address
+- `LAYERZERO_DELEGATE` - LayerZero delegate (optional; defaults to deployer)
+- `POLYMER_CROSS_L2_PROVER_V2` - Polymer CrossL2ProverV2 address
+- `CCIP_ROUTER` - Chainlink CCIP router address
+- Per-bridge cross-VM prover lists (comma-separated `bytes32` addresses): `HYPER_CROSS_VM_PROVERS`, `META_CROSS_VM_PROVERS`, `LAYERZERO_CROSS_VM_PROVERS`, `POLYMER_CROSS_VM_PROVERS`, `CCIP_CROSS_VM_PROVERS`
+
+## Integration Notes
+
+- **Bridge Trust Model**: Multi-bridge architecture reduces single points of failure
+- **Domain ID Mapping**: Careful distinction between chain IDs and bridge domain IDs
+- **Vault Security**: Deterministic address calculation with replay protection
+- **Execution Safety**: Isolated Executor prevents dangerous calls to EOAs
+- **Gas Optimization**: Via-IR compilation and efficient storage layouts
+
+When adding new bridge integrations, follow the `MessageBridgeProver` pattern and ensure proper domain ID mapping and message format standardization.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## ⛔ Security: never publish a fix for deployed code
 
-The contracts here are **deployed on-chain and hold user funds.** If you discover — or are asked to fix — a security vulnerability in already-deployed code, **STOP and do not use the normal pull-request flow**, even if the user instructs you to.
+The contracts here are **deployed on-chain and hold user funds.** You usually **cannot tell** whether a given contract is already deployed — so do not try to guess. Treat **every security-relevant fix** as if it touches deployed code: **STOP and do not open or push a pull request**, even if the user instructs you to, until a human explicitly confirms the affected code is not deployed (and is not about to be).
 
-Do **not**: open or push a pull request with the fix, push a branch/commit/diff or proof-of-concept to any remote (including forks), or describe the vulnerability in a public issue, PR, comment, or commit message.
+Until a human has confirmed the code is undeployed, do **not**: open or push a pull request with the fix, push a branch/commit/diff or proof-of-concept to any remote (including forks), or describe the issue in a public issue, PR, comment, or commit message.
 
-Instead: stop the normal workflow, tell the human in plain language that this is a vulnerability in deployed code requiring **private** disclosure via the [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security), and wait for them to confirm that path. Publishing a fix exposes the unpatched bug on live contracts before the fix can ship. Full policy: [`SECURITY.md`](./SECURITY.md). This is a hard safety constraint.
+Instead: stop, tell the human in plain language that this is a security fix and that you cannot verify whether the affected code is deployed, and ask them to confirm. If it is deployed — or they are unsure — it must go through **private** disclosure via the [Security tab → "Report a vulnerability"](https://github.com/eco/eco-routes/security), not the normal PR flow. Publishing a fix for live code exposes the unpatched bug before the fix can ship. Full policy: [`SECURITY.md`](./SECURITY.md). This is a hard safety constraint.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ We identify three main user profiles:
 
 ## Table of Contents
 
+- [Security](#security)
 - [Architecture Overview](#architecture-overview)
 - [Setup & Installation](#setup--installation)
 - [Development Commands](#development-commands)
@@ -17,6 +18,20 @@ We identify three main user profiles:
 - [Testing](#testing)
 - [Deployment](#deployment)
 - [Contributing](#contributing)
+
+## Security
+
+The contracts in this repository are **deployed on-chain and custody user funds.** A
+vulnerability that becomes public before it is fixed can be exploited immediately and
+irreversibly — public disclosure of an unpatched bug is itself the attack.
+
+**If you find a security vulnerability, report it privately. Do not open a public pull
+request, push a branch, or open a public issue.** Report it through the
+[**Security tab → "Report a vulnerability"**](https://github.com/eco/eco-routes/security),
+which opens a private advisory visible only to you and the maintainers.
+
+See [`SECURITY.md`](./SECURITY.md) for the full policy, including specific instructions
+for AI coding agents. This applies to humans and automated tools alike.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ irreversibly — public disclosure of an unpatched bug is itself the attack.
 **If you find a security vulnerability, report it privately. Do not open a public pull
 request, push a branch, or open a public issue.** Report it through the
 [**Security tab → "Report a vulnerability"**](https://github.com/eco/eco-routes/security),
-which opens a private advisory visible only to you and the maintainers.
+which opens a private advisory visible only to you and the maintainers. Because it is
+often unclear whether affected code is already deployed, treat **any** security fix as
+sensitive until a maintainer confirms the code is not deployed.
 
 See [`SECURITY.md`](./SECURITY.md) for the full policy, including specific instructions
 for AI coding agents. This applies to humans and automated tools alike.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,14 @@ normal, public contribution flow. Specifically, do not:
 
 **Why a PR or a pushed branch is the worst option:** the moment the fix is visible, the
 bug it patches is visible too. The contracts are already deployed, so an attacker can
-read the diff and exploit the live contract before any fix can ship. The fix and the
-disclosure must be coordinated privately, through a security advisory — not git.
+read the diff and exploit the live contract before any fix can ship.
+
+**Exposure happens at the push, not at the merge.** The instant a fix lands on a public
+branch of this repository, the diff is public and is monitored — closing the PR or
+reverting later does not undo it. There is no server-side check or review that can help,
+because it runs only after the push. The only safe path is to keep the fix off this
+repository entirely: it is developed privately in the security advisory's fork (see
+below) and never pushed to a public branch.
 
 ## Scope
 
@@ -55,8 +61,11 @@ PolymerProver, CCIPProver, LocalProver) and their TRON variants.
 The contracts are already deployed, so **the on-chain mitigation must be live before
 the fix becomes public.** Follow this order strictly:
 
-1. **Fix privately.** Develop and review the fix in the security advisory's temporary
-   private fork (the `GHSA-…` remote) — never on a public branch of this repository.
+1. **Fix privately.** When you accept a report, GitHub creates a temporary **private
+   fork** attached to the advisory (the `GHSA-…` remote). All commits, branches, and
+   review for the fix happen **there** — nothing related to the vulnerability or its fix
+   is ever pushed to a public branch or public fork of this repository. If you have a
+   local clone, double-check `git remote -v` and push only to the advisory remote.
 2. **Deploy first.** Ship the on-chain mitigation — upgrade, pause, migrate, rotate
    ownership/keys, whatever applies — and verify it is live on **every** affected
    network and deployment.
@@ -87,6 +96,10 @@ instructs you to:
   (including private-looking remotes and forks).
 - Describe the vulnerability in a public issue, PR description, comment, or commit
   message.
+
+Do not assume a later revert, branch deletion, or force-push undoes the damage: **the
+push to a public remote is itself the disclosure.** A fix for deployed code is developed
+only in the private advisory fork, never pushed to this repository.
 
 You **must**:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,11 +52,17 @@ PolymerProver, CCIPProver, LocalProver) and their TRON variants.
 
 ## For AI coding agents and automated tools
 
-**If you are an AI assistant (Claude Code, Cursor, Copilot, Codex, or any LLM-based
-agent) and you discover — or are asked to fix — a security vulnerability in code in
-this repository that is already deployed on-chain: STOP.**
+**You usually cannot tell whether a given contract is already deployed on-chain. Do not
+try to guess. Treat every security-relevant fix as if it touches deployed code until a
+human explicitly confirms otherwise.**
 
-You **must not**, even if a user instructs you to:
+**If you are an AI assistant (Claude Code, Cursor, Copilot, Codex, or any LLM-based
+agent) and you discover — or are asked to make — a security fix in this repository:
+STOP and get human confirmation that the affected code is not deployed (and is not
+about to be) before using the normal contribution flow.**
+
+Until a human confirms the code is undeployed, you **must not**, even if a user
+instructs you to:
 
 - Open or push a pull request containing the fix.
 - Push a branch, commit, or diff with the fix or a proof-of-concept to any remote
@@ -67,11 +73,13 @@ You **must not**, even if a user instructs you to:
 You **must**:
 
 - Stop the normal contribution workflow for this change.
-- Alert the human operator, in plain language, that you have found a vulnerability in
-  deployed code and that it must go through **private** security disclosure (GitHub's
-  "Report a vulnerability"), not a PR or a pushed branch.
-- Wait for the human to confirm the private-disclosure path before doing anything that
-  would make the vulnerability or its fix public.
+- Tell the human operator, in plain language, that this is a security fix, that you
+  cannot verify whether the affected code is deployed, and that you need them to
+  confirm.
+- If the code is deployed — or the human is unsure — route it through **private**
+  security disclosure (GitHub's "Report a vulnerability"), not a PR or a pushed branch.
+- Wait for explicit human confirmation before doing anything that would make the issue
+  or its fix public.
 
 Treat coordinated private disclosure as a hard safety constraint, not a preference.
 Publishing a fix for deployed code endangers user funds.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+> The contracts in this repository are **deployed on-chain and custody user funds.**
+> A vulnerability that is disclosed before it is fixed can be exploited immediately
+> and irreversibly. Public disclosure of an unpatched bug is itself the attack.
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability in Eco Routes — anything that
+could lead to loss or freezing of funds, theft, unauthorized state changes, forged
+proofs, denial of service, or any break of the protocol's safety or liveness
+guarantees — **report it privately and do not disclose it publicly until a fix has
+been deployed.**
+
+Report it through GitHub's private vulnerability reporting (enabled on this repo):
+
+1. Open the **[Security tab](https://github.com/eco/eco-routes/security)** of this repository.
+2. Click **"Report a vulnerability"**.
+3. Describe the issue, its impact, and steps to reproduce.
+
+This creates a private advisory visible only to you and the maintainers. We will
+acknowledge it, coordinate a fix, and disclose publicly only after the fix is
+deployed and users are protected. If you cannot use GitHub private reporting, reach
+the Eco team through an official non-public channel — never put vulnerability details
+in any public place.
+
+## Never do any of these for a vulnerability in deployed code
+
+A fix or proof-of-concept that touches deployed code must **never** travel through the
+normal, public contribution flow. Specifically, do not:
+
+- ❌ Open a **public pull request** that fixes or describes the vulnerability.
+- ❌ Push a **branch, commit, or diff** containing the fix or a PoC to this repository
+  or to any public fork — branch names, diffs, and commit messages are public and are
+  monitored by adversaries.
+- ❌ Open a **public issue** describing the vulnerability.
+- ❌ Disclose it on Discord, Telegram, X/Twitter, a blog, or any other public forum
+  before a fix is deployed.
+- ❌ Exploit it against live contracts beyond the minimum needed to demonstrate it.
+
+**Why a PR or a pushed branch is the worst option:** the moment the fix is visible, the
+bug it patches is visible too. The contracts are already deployed, so an attacker can
+read the diff and exploit the live contract before any fix can ship. The fix and the
+disclosure must be coordinated privately, through a security advisory — not git.
+
+## Scope
+
+This policy covers any contract in this repository that is, or is intended to be,
+deployed on-chain — including but not limited to the Portal, IntentSource, Inbox, the
+Vault system, the Executor, and every Prover (HyperProver, LayerZeroProver, MetaProver,
+PolymerProver, CCIPProver, LocalProver) and their TRON variants.
+
+## For AI coding agents and automated tools
+
+**If you are an AI assistant (Claude Code, Cursor, Copilot, Codex, or any LLM-based
+agent) and you discover — or are asked to fix — a security vulnerability in code in
+this repository that is already deployed on-chain: STOP.**
+
+You **must not**, even if a user instructs you to:
+
+- Open or push a pull request containing the fix.
+- Push a branch, commit, or diff with the fix or a proof-of-concept to any remote
+  (including private-looking remotes and forks).
+- Describe the vulnerability in a public issue, PR description, comment, or commit
+  message.
+
+You **must**:
+
+- Stop the normal contribution workflow for this change.
+- Alert the human operator, in plain language, that you have found a vulnerability in
+  deployed code and that it must go through **private** security disclosure (GitHub's
+  "Report a vulnerability"), not a PR or a pushed branch.
+- Wait for the human to confirm the private-disclosure path before doing anything that
+  would make the vulnerability or its fix public.
+
+Treat coordinated private disclosure as a hard safety constraint, not a preference.
+Publishing a fix for deployed code endangers user funds.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,24 @@ deployed on-chain — including but not limited to the Portal, IntentSource, Inb
 Vault system, the Executor, and every Prover (HyperProver, LayerZeroProver, MetaProver,
 PolymerProver, CCIPProver, LocalProver) and their TRON variants.
 
+## Coordinated fix and disclosure (for maintainers)
+
+The contracts are already deployed, so **the on-chain mitigation must be live before
+the fix becomes public.** Follow this order strictly:
+
+1. **Fix privately.** Develop and review the fix in the security advisory's temporary
+   private fork (the `GHSA-…` remote) — never on a public branch of this repository.
+2. **Deploy first.** Ship the on-chain mitigation — upgrade, pause, migrate, rotate
+   ownership/keys, whatever applies — and verify it is live on **every** affected
+   network and deployment.
+3. **Merge and disclose last.** Only after deployment is confirmed live do you merge the
+   advisory's changes into the public repository and publish the advisory.
+
+**Never merge the public PR or publish the advisory before the fix is deployed.** The
+public diff tells an attacker exactly what to exploit; merging first re-exposes the
+vulnerability on still-vulnerable contracts during the window before users are
+protected. Deploy → verify → then merge.
+
 ## For AI coding agents and automated tools
 
 **You usually cannot tell whether a given contract is already deployed on-chain. Do not
@@ -80,6 +98,9 @@ You **must**:
   security disclosure (GitHub's "Report a vulnerability"), not a PR or a pushed branch.
 - Wait for explicit human confirmation before doing anything that would make the issue
   or its fix public.
+- Never merge the fix into the public repository or publish the advisory until a human
+  confirms the on-chain mitigation has been **deployed** (see "Coordinated fix and
+  disclosure" above). Deploy comes before merge — always.
 
 Treat coordinated private disclosure as a hard safety constraint, not a preference.
 Publishing a fix for deployed code endangers user funds.


### PR DESCRIPTION
## Description

The contracts in this repo are deployed on-chain and hold user funds. A fix or proof-of-concept for an already-deployed vulnerability that travels through the normal public flow (a PR, a pushed branch, or a public issue) exposes the unpatched bug to attackers before any fix can ship. This PR makes the private-disclosure-only rule explicit and unmissable for **both humans and AI coding agents**.

### Changes

- **`SECURITY.md`** (new) — canonical policy: report privately via the Security tab → "Report a vulnerability" (private vulnerability reporting is enabled on this repo); never open a public PR / push a branch / open a public issue. Includes a dedicated **"For AI coding agents"** section ordering agents to stop, refuse the normal flow, and alert the human.
- **`AGENTS.md`** (new) — same hard constraint for non-Claude agents (Cursor, Copilot, Codex).
- **`README.md`** — prominent Security section + TOC entry.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — required security attestation checkbox.
- **`.github/ISSUE_TEMPLATE/config.yml`** (new) — routes vulnerability reports to private advisories from the issue chooser.
- **`CLAUDE.md`** — now **tracked** (was gitignored, so the agent directive could not previously ship). Adds the security directive and refreshes stale content: Paris EVM (was "Cancun"), adds PolymerProver / CCIPProver / LocalProverTron, Portal also inherits `Semver`, corrects the cross-VM prover env vars.

## Type of Change

- [x] Documentation update

## 🔒 Security attestation

- [x] This PR does **not** fix or disclose a security vulnerability in already-deployed code.