### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        update-types:
+          - "major"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        update-types:
+          - "major"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Add Dependabot to keep dependencies up to date automatically.

**Schedule:** Weekly
**Grouping strategy:**
- Minor and patch updates grouped into a single PR (reduces noise)
- Major updates grouped into a single PR (highlights breaking changes)

Closes ECO-1036