### PR TITLE
fix(vault): revert on failed native transfer in withdraw

### DIFF
--- a/contracts/vault/Vault.sol
+++ b/contracts/vault/Vault.sol
@@ -95,9 +95,13 @@ contract Vault is IVault {
         }
 
         uint256 nativeAmount = address(this).balance.min(reward.nativeAmount);
-        if (nativeAmount > 0) {
-            // Try to send to claimant - if it fails, ETH remains in vault for refund
-            claimant.call{value: nativeAmount}("");
+        if (nativeAmount == 0) {
+            return;
+        }
+
+        (bool success, ) = claimant.call{value: nativeAmount}("");
+        if (!success) {
+            revert NativeTransferFailed(claimant, nativeAmount);
         }
     }
 

--- a/test/core/Vault.t.sol
+++ b/test/core/Vault.t.sol
@@ -836,8 +836,7 @@ contract VaultTest is Test {
         vault.recover(creator, address(recoverToken));
     }
 
-    function test_withdraw_success_withRevertingClaimant() public {
-        // Deploy a contract that always reverts on receive
+    function test_withdraw_reverts_withRevertingClaimant() public {
         RevertingClaimant revertingClaimant = new RevertingClaimant();
 
         TokenAmount[] memory tokens = new TokenAmount[](1);
@@ -854,28 +853,25 @@ contract VaultTest is Test {
         token.mint(address(vault), 1000);
         vm.deal(address(vault), 1 ether);
 
-        // Withdrawal should succeed - tokens transfer, ETH remains if claimant rejects
         vm.prank(portal);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IVault.NativeTransferFailed.selector,
+                address(revertingClaimant),
+                1 ether
+            )
+        );
         vault.withdraw(reward, address(revertingClaimant));
-
-        // Verify ETH remains in vault (claimant rejected it)
-        assertEq(address(vault).balance, 1 ether);
-        assertEq(token.balanceOf(address(vault)), 0);
-
-        // Verify claimant received tokens but NOT native ETH (reverted)
-        assertEq(address(revertingClaimant).balance, 0);
-        assertEq(token.balanceOf(address(revertingClaimant)), 1000);
     }
 
     function test_refund_success_withRevertingRefundee() public {
-        // Deploy a contract that always reverts on receive
         RevertingClaimant revertingRefundee = new RevertingClaimant();
 
         TokenAmount[] memory tokens = new TokenAmount[](1);
         tokens[0] = TokenAmount({token: address(token), amount: 1000});
 
         Reward memory reward = Reward({
-            creator: creator, // Normal creator address
+            creator: creator,
             prover: address(0),
             deadline: uint64(block.timestamp + 1000),
             nativeAmount: 1 ether,
@@ -887,15 +883,11 @@ contract VaultTest is Test {
 
         vm.warp(block.timestamp + 2000);
 
-        // Refund should succeed - tokens transfer, ETH remains if refundee rejects
         vm.prank(portal);
         vault.refund(reward, address(revertingRefundee));
 
-        // Verify ETH remains in vault (refundee rejected it)
         assertEq(address(vault).balance, 1 ether);
         assertEq(token.balanceOf(address(vault)), 0);
-
-        // Verify refundee received tokens but NOT native ETH (reverted)
         assertEq(address(revertingRefundee).balance, 0);
         assertEq(token.balanceOf(address(revertingRefundee)), 1000);
     }


### PR DESCRIPTION
## Summary

- `Vault.withdraw()` silently discarded the return value of the native `call`, introduced in #387
- A failed ETH transfer left the intent permanently marked `Withdrawn` (blocking any refund path) with the ETH locked in the vault and the claimant never receiving their reward
- Restores the pre-#387 revert-on-failure behaviour in `withdraw()` only
- `refund()` intentionally keeps fire-and-forget: the refundee is the creator address which may be a contract that cannot receive ETH — reverting there would permanently block refunds
- Updates the withdraw test added in #387 that was asserting the wrong outcome

## Test plan

- [ ] `forge test --match-contract VaultTest` — all 35 pass
- [ ] Verify `test_withdraw_reverts_withRevertingClaimant` expects `NativeTransferFailed` revert
- [ ] Verify `test_refund_success_withRevertingRefundee` still passes (fire-and-forget preserved)