### PR TITLE
v3 PR4: reward-conservation + chain gates + fulfillAndSettle

### DIFF
--- a/contracts/ERC7683/DestinationSettler.sol
+++ b/contracts/ERC7683/DestinationSettler.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.26;
 
 import {IDestinationSettler} from "../interfaces/ERC7683/IDestinationSettler.sol";
-import {Route} from "../types/Intent.sol";
+import {Route, Reward} from "../types/Intent.sol";
 
 /**
  * @title DestinationSettler
@@ -27,9 +27,11 @@ abstract contract DestinationSettler is IDestinationSettler {
         bytes calldata fillerData
     ) external payable {
         // originData carries the origin-emitted intent data: the committed `source` chain id (Model C —
-        // hashed into the intent), the encoded route, and the reward hash.
-        (uint64 source, bytes memory encodedRoute, bytes32 rewardHash) = abi
-            .decode(originData, (uint64, bytes, bytes32));
+        // hashed into the intent), the encoded route, and the full reward (needed for the reward-leg
+        // authentication + conservation snapshot at fulfill). The `destination` is this chain
+        // (block.chainid) — the fill happens on the destination chain.
+        (uint64 source, bytes memory encodedRoute, Reward memory reward) = abi
+            .decode(originData, (uint64, bytes, Reward));
 
         emit OrderFilled(orderId, msg.sender);
 
@@ -48,9 +50,9 @@ abstract contract DestinationSettler is IDestinationSettler {
 
         fulfillAndProve(
             source,
-            orderId,
+            uint64(block.chainid),
             abi.decode(encodedRoute, (Route)),
-            rewardHash,
+            reward,
             claimant,
             providedAmounts,
             prover,
@@ -63,9 +65,9 @@ abstract contract DestinationSettler is IDestinationSettler {
      * @notice Fulfills an intent and initiates proving in one transaction
      * @dev Abstract function to be implemented by concrete settlement contracts
      * @param source The origin chain ID committed in the intent hash (Model C)
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination The destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route The route information for the intent
-     * @param rewardHash The hash of the reward details
+     * @param reward The reward details (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens`
      * @param prover Address of prover on the destination chain
@@ -75,9 +77,9 @@ abstract contract DestinationSettler is IDestinationSettler {
      */
     function fulfillAndProve(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover,

--- a/contracts/ERC7683/OriginSettler.sol
+++ b/contracts/ERC7683/OriginSettler.sol
@@ -182,7 +182,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
      *      with token == address(0). The rate-scaled component depends on the measured fulfillment and
      *      is not known at open time. Uses orderData.maxSpent directly for maxSpent. The route is kept
      *      opaque (cross-VM), so it is not decoded here.
-     * @dev FillInstruction.originData contains (route, rewardHash)
+     * @dev FillInstruction.originData contains (source, route, reward)
      * @param openDeadline The deadline for opening the order
      * @param orderData The updated OrderData with maxSpent, routePortal, and routeDeadline
      * @return ResolvedCrossChainOrder ERC-7683 compliant format with proper field mappings
@@ -218,10 +218,13 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
         );
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);
+        // originData carries the full reward (not just its hash): the destination fill needs the reward
+        // legs to authenticate them against the derived intent hash and to snapshot the reward escrow for
+        // the conservation postcondition.
         bytes memory originData = abi.encode(
             source,
             orderData.route,
-            rewardHash
+            orderData.reward
         );
         fillInstructions[0] = FillInstruction(
             orderData.destination,

--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -8,7 +8,7 @@ import {IPolicy} from "./interfaces/IPolicy.sol";
 import {IInbox} from "./interfaces/IInbox.sol";
 import {IAccount} from "./interfaces/IAccount.sol";
 
-import {Route} from "./types/Intent.sol";
+import {Route, Reward} from "./types/Intent.sol";
 import {IntentLib} from "./types/Intent.sol";
 import {Refund} from "./libs/Refund.sol";
 
@@ -18,23 +18,20 @@ import {AccountDeployer} from "./account/AccountDeployer.sol";
 /**
  * @title Inbox
  * @notice Main entry point for fulfilling intents on the destination chain
- * @dev Validates intent hash authenticity (with `source` in the preimage, Model C), enforces a
- *      solver-INPUT floor, and executes the route INSIDE the per-intent DESTINATION Account. There is no
- *      separate `Executor`: the solver's route inputs are staged onto the destination Account and
- *      `route.runtime(payload)` runs in that Account's `delegatecall` context (the Account merged in the
- *      Executor's execution sandbox). The destination Account is chain-parameterized by
- *      `intent.destination` (== this chain), so its address is DISTINCT from the source escrow Account
- *      (`intent.source`) for a cross-chain intent (Model C address separation) and identical for a
- *      same-chain intent.
+ * @dev Derives the intent hash on-chain from `(source, destination, route, reward)`, requires
+ *      `destination == block.chainid` ({WrongDestinationChain}), enforces a solver-INPUT floor, executes
+ *      the route INSIDE the per-intent DESTINATION Account, and enforces a REWARD-CONSERVATION
+ *      postcondition (the reward escrow must survive execution). There is no separate `Executor`: the
+ *      solver's input is staged onto the destination Account and `route.runtime(payload)` runs in that
+ *      Account's `delegatecall` context. The destination Account is chain-parameterized by
+ *      `intent.destination` (== this chain), so for a cross-chain intent it is a DIFFERENT address than
+ *      the source escrow Account (`intent.source`) — Model C address separation — and identical for a
+ *      same-chain intent (the reward-conservation snapshot then protects the shared escrow).
  *
- *      The solver must provide AT LEAST `route.minTokens[j].amount` of each min-in token (it may provide
- *      more, via `providedAmounts`); the provided input is staged onto the Account and becomes
- *      `fulfilled[j]`. The core is UNOPINIONATED about fund destinations: there is no `recipient` and no
- *      protocol-level auto-sweep — DELIVERY IS THE PAYLOAD'S JOB. Any input the runtime does not consume
- *      simply STAYS in the destination Account (leftover stays WITH THE INTENT for `route.keeper` to
- *      retrieve via {executeAsOwner}) — no sweep call at all. The Inbox commits
- *      `(intentHash, claimant, fulfilled[])` into a HASH-ONLY fact and records it into the named prover
- *      (policy), which owns the fulfillment store and cross-chain proof.
+ *      The core is UNOPINIONATED about fund destinations: no `recipient`, no output floor, no auto-sweep.
+ *      DELIVERY IS THE PAYLOAD'S JOB. Any input the runtime does not consume simply STAYS in the
+ *      destination Account (leftover stays WITH THE INTENT for `route.keeper`). The Inbox commits
+ *      `(intentHash, claimant, fulfilled[])` into a HASH-ONLY fact and records it into the named prover.
  */
 abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
     using SafeERC20 for IERC20;
@@ -60,14 +57,15 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
 
     /**
      * @notice Fulfills an intent, recording the fulfillment into the named prover
-     * @dev Validates intent hash (with `source` in the preimage), stages the solver's provided input onto
-     *      the DESTINATION Account, executes `route.runtime(payload)` in it, and records the hash-only
-     *      fulfillment fact into `prover`. Naming a prover other than the reward's committed
-     *      `reward.prover` is solver self-harm only.
+     * @dev Derives the intent hash from `(source, destination, route, reward)`, requires
+     *      `destination == block.chainid`, stages the solver's provided input onto the destination Account,
+     *      executes `route.runtime(payload)` in it, enforces reward-conservation, and records the hash-only
+     *      fulfillment fact into `prover`. Naming a prover other than the reward's committed `reward.prover`
+     *      is solver self-harm only.
      * @param source Origin chain ID committed in the intent hash
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route The route of the intent
-     * @param rewardHash The hash of the reward details
+     * @param reward The reward details of the intent (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens` (each
      *        `>= route.minTokens[j].amount`)
@@ -76,18 +74,18 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      */
     function fulfill(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover
     ) external payable returns (bytes memory) {
-        (bytes memory result, ) = _fulfill(
+        (bytes memory result, , ) = _fulfill(
             source,
-            intentHash,
+            destination,
             route,
-            rewardHash,
+            reward,
             claimant,
             providedAmounts,
             prover
@@ -103,36 +101,32 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      * @notice Fulfills an intent and initiates proving in one transaction
      * @dev Executes intent actions and sends proof message to source chain
      * @param source Origin chain ID committed in the intent hash
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route The route of the intent
-     * @param rewardHash The hash of the reward details
+     * @param reward The reward details of the intent (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens`
      * @param prover Address of prover on the destination chain
      * @param sourceChainDomainID Bridge transport domain ID of the source chain
      * @param data Additional data for message formatting
      * @return The runtime's raw return data
-     *
-     * @dev WARNING: sourceChainDomainID is NOT necessarily the same as chain ID (nor the same as
-     *      `source`): `source` is the origin CHAIN ID committed in the hash, while sourceChainDomainID
-     *      is the bridge transport's domain id used to route the proof back.
      */
     function fulfillAndProve(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover,
         uint64 sourceChainDomainID,
         bytes memory data
     ) public payable override(DestinationSettler, IInbox) returns (bytes memory) {
-        (bytes memory result, ) = _fulfill(
+        (bytes memory result, , bytes32 intentHash) = _fulfill(
             source,
-            intentHash,
+            destination,
             route,
-            rewardHash,
+            reward,
             claimant,
             providedAmounts,
             prover
@@ -177,16 +171,14 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
     /**
      * @notice Owner-cook on the DESTINATION side: `route.keeper` runs an arbitrary runtime against the
      *         intent's DESTINATION (execution) Account via delegatecall.
-     * @dev The destination-side counterpart to {IntentSource-executeAsOwner}. Only `route.keeper` may
-     *      call. The Account is derived from THIS chain id (`CHAIN_ID`) as the role chain id, so it
-     *      operates the destination execution Account — the one that holds any unconsumed solver input —
-     *      and never the source escrow Account (which lives at `keccak(intentHash, source)`, a different
-     *      address for a cross-chain intent). Because the Account salt is keyed by `CHAIN_ID`, this is
-     *      structurally the `block.chainid == intent.destination` gate: the Inbox only ever reaches the
-     *      local (this-chain) execution Account. This is the destination stray-fund / leftover retrieval
-     *      path (there is no `recipient` / auto-sweep). The delegatecall bubbles the runtime's raw
-     *      return/revert verbatim.
-     * @param source Origin chain ID committed in the intent hash
+     * @dev CROSS-CHAIN ONLY. Reverts {SourceChainOwnerOnly} when `source == block.chainid` — on this chain
+     *      the `CHAIN_ID`-keyed Account is (or collapses with) the SOURCE escrow Account, which must be
+     *      governed by the reward-aware {IntentSource-executeAsOwner} (reward.keeper + escrow/proof lock),
+     *      NOT this reward-blind arbitrary-runtime path. When `source != block.chainid` this chain is
+     *      purely the destination, so the `CHAIN_ID`-keyed Account provably holds only unconsumed solver
+     *      input (never escrow) and `route.keeper` may retrieve it freely. This is the destination
+     *      leftover-retrieval / stray-fund rescue (the core is unopinionated — no `recipient`/auto-sweep).
+     * @param source Origin chain ID committed in the intent hash (must NOT equal block.chainid)
      * @param route The route of the intent (supplies `route.keeper` + `route.portal`)
      * @param rewardHash The hash of the reward details (opaque on the destination)
      * @param runtime The delegatecall target to run against the Account
@@ -200,6 +192,9 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         address runtime,
         bytes calldata payload
     ) external payable returns (bytes memory) {
+        if (source == CHAIN_ID) {
+            revert SourceChainOwnerOnly(source);
+        }
         if (route.portal != address(this)) {
             revert InvalidPortal(route.portal);
         }
@@ -222,56 +217,68 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
 
     /**
      * @notice Internal function to fulfill intents
-     * @dev Validates intent, enforces the solver-INPUT floor, stages the provided input onto the
-     *      DESTINATION Account, runs `route.runtime(payload)` in the Account's delegatecall context,
-     *      and records the hash-only fulfillment fact into the named prover. `fulfilled[j] =
-     *      providedAmounts[j]` (the actual input provided; the reward scales on it). The prover's
-     *      {IPolicy-recordFulfillment} enforces the one-shot gate. Recording happens AFTER execution; a
-     *      re-entrant second fulfillment of the same intent reverts the whole tx (the one-shot gate), so
-     *      recording after effects cannot double-deliver.
+     * @dev Derives the intent hash from `(source, destination, route, reward)` and requires
+     *      `destination == block.chainid` ({WrongDestinationChain}). Snapshots the Account's reward-escrow
+     *      balances, enforces the solver-INPUT floor and stages the provided input onto the Account, runs
+     *      `route.runtime(payload)` in the Account's delegatecall context, enforces the REWARD-CONSERVATION
+     *      postcondition (the reward escrow must survive execution), and records the hash-only fulfillment
+     *      fact into the named prover. `fulfilled[j] = providedAmounts[j]`. The prover's
+     *      {IPolicy-recordFulfillment} enforces the one-shot gate; recording happens AFTER execution, and a
+     *      re-entrant second fulfillment reverts the whole tx, so recording after effects cannot
+     *      double-deliver.
      * @param source Origin chain ID committed in the intent hash
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route The route of the intent
-     * @param rewardHash The hash of the reward
+     * @param reward The reward of the intent (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens`
      * @param prover Prover (policy) to record the fulfillment into
      * @return result The runtime's raw return data
      * @return fulfilled Per-leg provided-input amounts, index-aligned with `route.minTokens`
+     * @return intentHash The derived intent hash
      */
     function _fulfill(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover
-    ) internal returns (bytes memory result, uint256[] memory fulfilled) {
+    )
+        internal
+        returns (
+            bytes memory result,
+            uint256[] memory fulfilled,
+            bytes32 intentHash
+        )
+    {
+        // Destination gate (belt-and-braces on the Model C address separation): a fulfill can only be
+        // recorded on the chain the intent commits to as its destination.
+        if (destination != CHAIN_ID) {
+            revert WrongDestinationChain(CHAIN_ID, destination);
+        }
         // Check if the route has expired
         if (block.timestamp > route.deadline) {
             revert IntentExpired();
         }
-
-        bytes32 routeHash = keccak256(abi.encode(route));
-        // Re-derive the hash from `source` + this chain (the destination). A wrong-destination intent
-        // will not match `intentHash` and reverts below.
-        bytes32 computedIntentHash = IntentLib.hashIntent(
-            source,
-            CHAIN_ID,
-            routeHash,
-            rewardHash
-        );
-
         if (route.portal != address(this)) {
             revert InvalidPortal(route.portal);
-        }
-        if (computedIntentHash != intentHash) {
-            revert InvalidHash(intentHash);
         }
         if (claimant == bytes32(0)) {
             revert ZeroClaimant();
         }
+
+        // Derive the intent hash from the supplied components. The full `reward` is supplied (not just its
+        // hash) so `reward.tokens` are authenticated by this derivation and can be snapshotted below.
+        bytes32 routeHash = keccak256(abi.encode(route));
+        bytes32 rewardHash = keccak256(abi.encode(reward));
+        intentHash = IntentLib.hashIntent(
+            source,
+            destination,
+            routeHash,
+            rewardHash
+        );
 
         // min-in legs must be canonical (strictly ascending by token -> deduped) so the provided inputs
         // pair unambiguously with the reward legs at settlement.
@@ -286,13 +293,26 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
 
         // The DESTINATION (execution) Account is keyed by this chain id (== intent.destination). For a
         // cross-chain intent this is a DIFFERENT address than the source escrow Account; for a same-chain
-        // intent it is the SAME Account that holds the escrow.
-        address account = _getOrDeployAccount(intentHash, CHAIN_ID);
+        // intent it is the SAME Account that holds the reward escrow.
+        address account = _getOrDeployAccount(intentHash, destination);
 
-        // Enforce the solver INPUT floor per leg and stage the provided input onto the DESTINATION
-        // Account. The solver must provide at least `minTokens[j].amount` and MAY provide more;
-        // `fulfilled[j]` records the actual amount provided (what the reward scales on). Native folds in
-        // as the `address(0)` leg — its provided amount is forwarded into execution as the Account's value.
+        // --- REWARD-CONSERVATION snapshot (before any solver input is staged) ---------------------------
+        // Snapshot the Account's balance of every reward-leg token (and native) — the reserved reward
+        // escrow `E`. For a same-chain intent the escrow lives in THIS Account; for a cross-chain intent the
+        // execution Account holds no source escrow so every snapshot is ~0 and the postcondition below is a
+        // cheap no-op. Snapshotting BEFORE staging the route inputs means a reward token that ALSO happens
+        // to be a route input is measured as escrow-only, so the runtime legitimately consuming the staged
+        // input does not trip conservation.
+        uint256 rewardLen = reward.tokens.length;
+        uint256[] memory escrowBefore = new uint256[](rewardLen);
+        for (uint256 i = 0; i < rewardLen; ++i) {
+            escrowBefore[i] = _balanceOf(reward.tokens[i].token, account);
+        }
+
+        // Enforce the solver INPUT floor per leg and stage the provided input onto the DESTINATION Account.
+        // The solver must provide at least `minTokens[j].amount` and MAY provide more; `fulfilled[j]`
+        // records the actual amount provided. Native folds in as the `address(0)` leg — its provided amount
+        // is forwarded into execution as the Account's value.
         fulfilled = providedAmounts;
         uint256 nativeProvided = 0;
         for (uint256 j = 0; j < inLen; ++j) {
@@ -319,12 +339,28 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         }
 
         // Execute the keeper-committed runtime in the Account (delegatecall), forwarding the provided
-        // native input to the Account to be spent by the runtime. Any input the runtime does not consume
-        // stays in the Account — leftover stays WITH THE INTENT (no sweep).
+        // native input. Any input the runtime does not consume stays in the Account (no sweep).
         result = IAccount(account).execute{value: nativeProvided}(
             route.runtime,
             route.payload
         );
+
+        // --- REWARD-CONSERVATION postcondition ----------------------------------------------------------
+        // The runtime may consume only balance ABOVE the reserved reward escrow `E`, never `E` itself.
+        // For a same-chain intent this protects the escrow that shares this Account against a malicious
+        // keeper-authored runtime; for a cross-chain intent every snapshot was ~0 so this is vacuous. A
+        // violation reverts the WHOLE fulfill — worst case a griefing DoS for the solver (who simulates
+        // first), never reward theft.
+        for (uint256 i = 0; i < rewardLen; ++i) {
+            uint256 live = _balanceOf(reward.tokens[i].token, account);
+            if (live < escrowBefore[i]) {
+                revert RewardEscrowTouched(
+                    reward.tokens[i].token,
+                    live,
+                    escrowBefore[i]
+                );
+            }
+        }
 
         // Commit the (intentHash, claimant, fulfilled[]) preimage as a hash-only fact and record it into
         // the named prover (policy). The prover enforces the one-shot gate.
@@ -338,5 +374,21 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
             CHAIN_ID,
             fulfillmentHash
         );
+    }
+
+    /**
+     * @notice Reads the balance of `token` held by `account`; `address(0)` denotes native.
+     * @param token The token address, or `address(0)` for native
+     * @param account The account whose balance to read
+     * @return The balance
+     */
+    function _balanceOf(
+        address token,
+        address account
+    ) internal view returns (uint256) {
+        if (token == address(0)) {
+            return account.balance;
+        }
+        return IERC20(token).balanceOf(account);
     }
 }

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -56,6 +56,22 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     }
 
     /**
+     * @notice Restricts a source-side operation to the intent's committed source chain
+     * @dev Every source-side op resolves the SOURCE (escrow) account keyed by `intent.source`, so it is
+     *      only valid when `block.chainid == source`. Belt-and-braces on top of the Model C address
+     *      separation: even though a cross-chain intent's source account is a different address than its
+     *      destination account, this gate makes a source-side op on the wrong chain fail loudly
+     *      ({WrongSourceChain}) instead of silently operating on an empty source-account address.
+     * @param source The intent's committed source chain id
+     */
+    modifier onlySourceChain(uint64 source) {
+        if (block.chainid != source) {
+            revert WrongSourceChain(uint64(block.chainid), source);
+        }
+        _;
+    }
+
+    /**
      * @notice Retrieves reward status for a given intent hash
      * @param intentHash Hash of the intent to query
      * @return status Current status of the intent
@@ -320,7 +336,12 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes memory route,
         Reward calldata reward,
         bool allowPartial
-    ) public payable returns (bytes32 intentHash, address account) {
+    )
+        public
+        payable
+        onlySourceChain(source)
+        returns (bytes32 intentHash, address account)
+    {
         return
             _publishAndFund(
                 source,
@@ -347,7 +368,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes32 routeHash,
         Reward calldata reward,
         bool allowPartial
-    ) external payable returns (bytes32 intentHash) {
+    ) external payable onlySourceChain(source) returns (bytes32 intentHash) {
         (intentHash, , ) = getIntentHash(
             source,
             destination,
@@ -385,7 +406,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bool allowPartial,
         address funder,
         address permitContract
-    ) external payable returns (bytes32 intentHash) {
+    ) external payable onlySourceChain(source) returns (bytes32 intentHash) {
         (intentHash, , ) = getIntentHash(
             source,
             destination,
@@ -451,7 +472,12 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bool allowPartial,
         address funder,
         address permitContract
-    ) public payable returns (bytes32 intentHash, address account) {
+    )
+        public
+        payable
+        onlySourceChain(source)
+        returns (bytes32 intentHash, address account)
+    {
         (intentHash, ) = publish(source, destination, route, reward);
 
         account = _fundIntentFor(
@@ -485,7 +511,30 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         Reward calldata reward,
         bytes32 claimant,
         uint256[] calldata fulfilled
-    ) public {
+    ) public onlySourceChain(source) {
+        _settle(source, destination, routeHash, reward, claimant, fulfilled);
+    }
+
+    /**
+     * @notice Internal settle: verifies the proven `(claimant, fulfilled[])` preimage and pays the reward
+     * @dev Shared by the two-step {settle} (source chain) and the same-chain one-tx
+     *      {IPortal-fulfillAndSettle}. The source-chain gate lives on the public entry points; this
+     *      internal assumes the caller has established that the SOURCE (escrow) account is on this chain.
+     * @param source Origin chain ID for the intent (selects the source/escrow account)
+     * @param destination Destination chain ID for the intent
+     * @param routeHash Hash of the intent's route
+     * @param reward Reward structure of the intent
+     * @param claimant Cross-VM claimant identifier committed in the fulfillment
+     * @param fulfilled Per-leg delivered amounts committed in the fulfillment (paired prefix)
+     */
+    function _settle(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward,
+        bytes32 claimant,
+        uint256[] memory fulfilled
+    ) internal {
         (bytes32 intentHash, , bytes32 rewardHash) = getIntentHash(
             source,
             destination,
@@ -550,7 +599,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         uint64 destination,
         bytes32 routeHash,
         Reward calldata reward
-    ) external {
+    ) external onlySourceChain(source) {
         (bytes32 intentHash, , ) = getIntentHash(
             source,
             destination,
@@ -575,7 +624,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes32 routeHash,
         Reward calldata reward,
         address refundee
-    ) external {
+    ) external onlySourceChain(source) {
         if (msg.sender != reward.keeper) {
             revert NotKeeperCaller(msg.sender);
         }
@@ -605,7 +654,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes32 routeHash,
         Reward calldata reward,
         address token
-    ) external {
+    ) external onlySourceChain(source) {
         (bytes32 intentHash, , ) = getIntentHash(
             source,
             destination,
@@ -651,10 +700,12 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         Intent calldata intent,
         address runtime,
         bytes calldata payload
-    ) external payable returns (bytes memory) {
-        if (block.chainid != intent.source) {
-            revert WrongSourceChain(intent.source);
-        }
+    )
+        external
+        payable
+        onlySourceChain(intent.source)
+        returns (bytes memory)
+    {
         if (msg.sender != intent.reward.keeper) {
             revert NotAccountOwner(msg.sender);
         }

--- a/contracts/Portal.sol
+++ b/contracts/Portal.sol
@@ -2,21 +2,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Semver} from "./libs/Semver.sol";
-
-import {IntentSource} from "./IntentSource.sol";
-import {Inbox} from "./Inbox.sol";
+import {PortalCore} from "./PortalCore.sol";
 import {AccountDeployer} from "./account/AccountDeployer.sol";
 import {Account} from "./account/Account.sol";
 
 /**
  * @title Portal
  * @notice Portal contract combining IntentSource and Inbox functionality
- * @dev Main entry point for intent publishing, fulfillment, and proving. Both halves inherit the shared
- *      {AccountDeployer}, whose constructor args (the Account clone template + CREATE2 prefix) are
- *      supplied here once via C3 linearization.
+ * @dev Main entry point for intent publishing, fulfillment, and proving. The combined-half logic
+ *      (same-chain {PortalCore-fulfillAndSettle}) lives in {PortalCore}; this contract only supplies the
+ *      shared {AccountDeployer} constructor args (the Account clone template + CREATE2 prefix) via C3
+ *      linearization.
  */
-contract Portal is IntentSource, Inbox, Semver {
+contract Portal is PortalCore {
     /**
      * @notice Initializes the Portal contract
      * @dev Creates a unified entry point combining source and destination chain functionality

--- a/contracts/PortalCore.sol
+++ b/contracts/PortalCore.sol
@@ -1,0 +1,83 @@
+/* -*- c-basic-offset: 4 -*- */
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Semver} from "./libs/Semver.sol";
+
+import {IntentSource} from "./IntentSource.sol";
+import {Inbox} from "./Inbox.sol";
+import {IPortal} from "./interfaces/IPortal.sol";
+import {Intent} from "./types/Intent.sol";
+import {Refund} from "./libs/Refund.sol";
+
+/**
+ * @title PortalCore
+ * @notice Combined-half base for the Portal: everything that needs BOTH the source-side {IntentSource}
+ *         and the destination-side {Inbox} in one contract.
+ * @dev {Portal} and {PortalTron} inherit this and supply only the {AccountDeployer} constructor args (the
+ *      Account clone template + CREATE2 prefix). The one cross-cutting primitive here is the same-chain
+ *      {fulfillAndSettle}: fulfilling names its policy (destination half) AND settling reads the reward
+ *      status (source half), which only the combined contract can do. Keeping it in a shared base means
+ *      {Portal} and {PortalTron} do not duplicate the logic.
+ */
+abstract contract PortalCore is IntentSource, Inbox, Semver {
+    /**
+     * @notice Atomically fulfills and settles a SAME-CHAIN intent in one transaction
+     * @dev See {IPortal-fulfillAndSettle}. Requires `intent.source == intent.destination ==
+     *      block.chainid`. Because source == destination the escrow Account and the execution Account are
+     *      ONE (Model C same-chain collapse), so the reward-conservation postcondition inside {_fulfill}
+     *      protects the escrow from the keeper-committed runtime, and the settle then pays the reward out
+     *      of that same Account. The solver supplies the route input capital (this is NOT the v2
+     *      zero-capital flash: reward-conservation forbids the runtime from consuming the escrow to fund
+     *      the route), and receives the reward atomically after delivery.
+     * @param intent The complete same-chain intent
+     * @param providedAmounts Per-leg input the solver provides, index-aligned with `intent.route.minTokens`
+     * @param claimant Address that receives the reward (as a cross-VM identifier)
+     * @return The runtime's raw return data
+     */
+    function fulfillAndSettle(
+        Intent calldata intent,
+        uint256[] calldata providedAmounts,
+        bytes32 claimant
+    ) external payable returns (bytes memory) {
+        uint64 chainId = uint64(block.chainid);
+        if (intent.source != chainId || intent.destination != chainId) {
+            revert IPortal.NotSameChain(
+                intent.source,
+                intent.destination,
+                chainId
+            );
+        }
+
+        // Fulfill: execute the runtime in the shared Account, enforce reward-conservation, and record the
+        // fulfillment into the keeper-committed prover. For a same-chain intent this recorded fact IS the
+        // proof the settle reads below (no relay, no cross-chain round-trip).
+        (bytes memory result, uint256[] memory fulfilled, ) = _fulfill(
+            intent.source,
+            intent.destination,
+            intent.route,
+            intent.reward,
+            claimant,
+            providedAmounts,
+            intent.reward.prover
+        );
+
+        // Settle atomically from the SAME Account, using the just-recorded local fulfillment fact. The
+        // `(claimant, fulfilled)` preimage is known in-tx, so it re-derives the fulfillmentHash the fulfill
+        // recorded and pays out without a cross-chain hash round-trip.
+        bytes32 routeHash = keccak256(abi.encode(intent.route));
+        _settle(
+            intent.source,
+            intent.destination,
+            routeHash,
+            intent.reward,
+            claimant,
+            fulfilled
+        );
+
+        // Refund any excess native.
+        Refund.excessNative();
+
+        return result;
+    }
+}

--- a/contracts/interfaces/IInbox.sol
+++ b/contracts/interfaces/IInbox.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Route} from "../types/Intent.sol";
+import {Route, Reward} from "../types/Intent.sol";
 
 /**
  * @title IInbox
@@ -44,15 +44,35 @@ interface IInbox {
     error IntentExpired();
 
     /**
-     * @notice Generated hash doesn't match expected hash
-     * @param expectedHash Hash that was expected
-     */
-    error InvalidHash(bytes32 expectedHash);
-
-    /**
      * @notice Zero claimant identifier provided
      */
     error ZeroClaimant();
+
+    /**
+     * @notice A fulfill was attempted on a chain whose id is not the intent's committed `destination`
+     * @param current The current chain id (block.chainid)
+     * @param expected The intent's committed destination chain id
+     */
+    error WrongDestinationChain(uint64 current, uint64 expected);
+
+    /**
+     * @notice The runtime consumed reward escrow reserved in a (same-chain collapsed) execution Account
+     * @dev Reward-conservation postcondition: a reward-leg token's Account balance dropped below its
+     *      pre-execution snapshot. Reverts the whole fulfill (griefing DoS at worst, never reward theft).
+     * @param token The reward-leg token whose escrow was touched
+     * @param live The reward-leg token balance after execution
+     * @param reserved The reserved escrow snapshot taken before staging solver input
+     */
+    error RewardEscrowTouched(address token, uint256 live, uint256 reserved);
+
+    /**
+     * @notice The destination-side {executeAsOwner} was called for a source-chain (or same-chain) intent
+     * @dev CROSS-CHAIN ONLY: when `source == block.chainid` the `block.chainid`-keyed Account is (or
+     *      collapses with) the SOURCE escrow Account, which must be governed by the reward-aware
+     *      {IIntentSource-executeAsOwner}, not this reward-blind path.
+     * @param source The intent's committed source chain id (equal to block.chainid)
+     */
+    error SourceChainOwnerOnly(uint64 source);
 
     /**
      * @notice Attempted to batch an unfulfilled intent
@@ -101,13 +121,14 @@ interface IInbox {
 
     /**
      * @notice Fulfills an intent, recording the fulfillment into the named prover
-     * @dev Validates intent hash (with `source` in the preimage), stages the solver's provided input onto
-     *      the DESTINATION Account, executes `route.runtime(payload)` in it, and records the fulfillment
-     *      into `prover`. The solver names the prover (policy) that will settle the reward.
+     * @dev Derives the intent hash from `(source, destination, route, reward)`, requires
+     *      `destination == block.chainid`, stages the solver's provided input onto the DESTINATION
+     *      Account, executes `route.runtime(payload)` in it, enforces reward-conservation, and records the
+     *      fulfillment into `prover`. The solver names the prover (policy) that will settle the reward.
      * @param source Origin chain ID committed in the intent hash
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route Route information for the intent
-     * @param rewardHash Hash of the reward details
+     * @param reward Reward details of the intent (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens` (each
      *        `>= route.minTokens[j].amount`)
@@ -116,9 +137,9 @@ interface IInbox {
      */
     function fulfill(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover
@@ -128,9 +149,9 @@ interface IInbox {
      * @notice Fulfills an intent and initiates proving in one transaction
      * @dev Validates intent hash, executes the route, and records the fulfillment
      * @param source Origin chain ID committed in the intent hash
-     * @param intentHash The hash of the intent to fulfill
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route Route information for the intent
-     * @param rewardHash Hash of the reward details
+     * @param reward Reward details of the intent (legs authenticated by the derived intent hash)
      * @param claimant Cross-VM compatible claimant identifier
      * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens` (each
      *        `>= route.minTokens[j].amount`)
@@ -153,9 +174,9 @@ interface IInbox {
      */
     function fulfillAndProve(
         uint64 source,
-        bytes32 intentHash,
+        uint64 destination,
         Route memory route,
-        bytes32 rewardHash,
+        Reward memory reward,
         bytes32 claimant,
         uint256[] memory providedAmounts,
         address prover,

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -66,6 +66,18 @@ interface IIntentSource {
     error NotKeeperCaller(address caller);
 
     /**
+     * @notice A source-side operation was attempted on a chain whose id is not the intent's committed
+     *         `source`
+     * @dev Belt-and-braces on top of the Model C address separation: fund / settle / refund / recover /
+     *      executeAsOwner all resolve the SOURCE (escrow) vault keyed by `intent.source`, so they are only
+     *      valid on the source chain (`intent.source == block.chainid`). This keeps a source-side op on the
+     *      destination chain from ever reaching a cross-chain intent's destination vault.
+     * @param current The current chain id (block.chainid)
+     * @param expected The intent's committed source chain id
+     */
+    error WrongSourceChain(uint64 current, uint64 expected);
+
+    /**
      * @notice The supplied (claimant, fulfilled[]) preimage does not match the proven fulfillment hash
      * @param intentHash The hash of the intent being settled
      */
@@ -74,10 +86,6 @@ interface IIntentSource {
     /// @notice Thrown when {executeAsOwner} is called by someone other than the reward keeper
     /// @param caller The unauthorized caller
     error NotAccountOwner(address caller);
-
-    /// @notice Thrown when a source-side op is called on a chain other than the intent's `source`
-    /// @param expected The chain id the op must run on (`intent.source`)
-    error WrongSourceChain(uint64 expected);
 
     /**
      * @notice Thrown when {executeAsOwner} is attempted while the Account holds a LIVE escrow

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -69,9 +69,9 @@ interface IIntentSource {
      * @notice A source-side operation was attempted on a chain whose id is not the intent's committed
      *         `source`
      * @dev Belt-and-braces on top of the Model C address separation: fund / settle / refund / recover /
-     *      executeAsOwner all resolve the SOURCE (escrow) vault keyed by `intent.source`, so they are only
-     *      valid on the source chain (`intent.source == block.chainid`). This keeps a source-side op on the
-     *      destination chain from ever reaching a cross-chain intent's destination vault.
+     *      executeAsOwner all resolve the SOURCE (escrow) account keyed by `intent.source`, so they are
+     *      only valid on the source chain (`intent.source == block.chainid`). This keeps a source-side op
+     *      on the destination chain from ever reaching a cross-chain intent's destination account.
      * @param current The current chain id (block.chainid)
      * @param expected The intent's committed source chain id
      */

--- a/contracts/interfaces/IPortal.sol
+++ b/contracts/interfaces/IPortal.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {IIntentSource} from "./IIntentSource.sol";
 import {IInbox} from "./IInbox.sol";
+import {Intent} from "../types/Intent.sol";
 
 /**
  * @title IPortal
@@ -10,5 +11,33 @@ import {IInbox} from "./IInbox.sol";
  * @dev Combines source chain operations (publish, fund, refund, withdraw) and
  *      destination chain operations (fulfill, prove) in a single interface
  */
-// solhint-disable-next-line no-empty-blocks
-interface IPortal is IIntentSource, IInbox {}
+interface IPortal is IIntentSource, IInbox {
+    /**
+     * @notice A `fulfillAndSettle` was attempted on an intent that is not same-chain (source ==
+     *         destination == block.chainid)
+     * @param source The intent's committed source chain id
+     * @param destination The intent's committed destination chain id
+     * @param current The current chain id (block.chainid)
+     */
+    error NotSameChain(uint64 source, uint64 destination, uint64 current);
+
+    /**
+     * @notice Atomically fulfills and settles a SAME-CHAIN intent in one transaction
+     * @dev Requires `intent.source == intent.destination == block.chainid`. Runs the fulfill (stage the
+     *      solver's provided input onto the shared Account, execute the runtime, enforce reward-conservation,
+     *      record the fulfillment into `intent.reward.prover`) and then settles the reward to `claimant`
+     *      from the SAME Account, reading the just-recorded local fulfillment fact — no relay, no
+     *      cross-chain hash round-trip. The solver supplies the route input capital (NOT zero-capital: the
+     *      reward escrow is protected by reward-conservation and can never fund the route) and receives the
+     *      reward atomically after delivery.
+     * @param intent The complete same-chain intent
+     * @param providedAmounts Per-leg input the solver provides, index-aligned with `intent.route.minTokens`
+     * @param claimant Address that receives the reward (as a cross-VM identifier)
+     * @return The runtime's raw return data
+     */
+    function fulfillAndSettle(
+        Intent calldata intent,
+        uint256[] calldata providedAmounts,
+        bytes32 claimant
+    ) external payable returns (bytes memory);
+}

--- a/contracts/prover/LocalPolicy.sol
+++ b/contracts/prover/LocalPolicy.sol
@@ -211,9 +211,9 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
 
         results = _PORTAL.fulfill{value: msg.value}(
             _CHAIN_ID,
-            intentHash,
+            _CHAIN_ID,
             route,
-            rewardHash,
+            reward,
             claimant,
             providedAmounts,
             address(this)

--- a/contracts/test/TestDestinationSettler.sol
+++ b/contracts/test/TestDestinationSettler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {DestinationSettler, Route} from "../ERC7683/DestinationSettler.sol";
+import {DestinationSettler, Route, Reward} from "../ERC7683/DestinationSettler.sol";
 import {Portal} from "../Portal.sol";
 
 contract TestDestinationSettler is DestinationSettler {
@@ -13,9 +13,9 @@ contract TestDestinationSettler is DestinationSettler {
 
     function fulfillAndProve(
         uint64 _source,
-        bytes32 _intentHash,
+        uint64 _destination,
         Route memory _route,
-        bytes32 _rewardHash,
+        Reward memory _reward,
         bytes32 _claimant,
         uint256[] memory _providedAmounts,
         address _prover,
@@ -26,9 +26,9 @@ contract TestDestinationSettler is DestinationSettler {
         return
             PORTAL.fulfillAndProve{value: msg.value}(
                 _source,
-                _intentHash,
+                _destination,
                 _route,
-                _rewardHash,
+                _reward,
                 _claimant,
                 _providedAmounts,
                 _prover,

--- a/contracts/test/TestDestinationSettlerComplete.sol
+++ b/contracts/test/TestDestinationSettlerComplete.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {DestinationSettler, Route} from "../ERC7683/DestinationSettler.sol";
+import {DestinationSettler, Route, Reward} from "../ERC7683/DestinationSettler.sol";
 import {Portal} from "../Portal.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {AddressConverter} from "../libs/AddressConverter.sol";
@@ -18,9 +18,9 @@ contract TestDestinationSettlerComplete is DestinationSettler {
 
     function fulfillAndProve(
         uint64 _source,
-        bytes32 _intentHash,
+        uint64 _destination,
         Route memory _route,
-        bytes32 _rewardHash,
+        Reward memory _reward,
         bytes32 _claimant,
         uint256[] memory _providedAmounts,
         address _prover,
@@ -45,9 +45,9 @@ contract TestDestinationSettlerComplete is DestinationSettler {
         return
             PORTAL.fulfillAndProve{value: msg.value}(
                 _source,
-                _intentHash,
+                _destination,
                 _route,
-                _rewardHash,
+                _reward,
                 _claimant,
                 _providedAmounts,
                 _prover,

--- a/contracts/tron/PortalTron.sol
+++ b/contracts/tron/PortalTron.sol
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
-import {Semver} from "../libs/Semver.sol";
-import {IntentSource} from "../IntentSource.sol";
-import {Inbox} from "../Inbox.sol";
+import {PortalCore} from "../PortalCore.sol";
 import {AccountDeployer} from "../account/AccountDeployer.sol";
 import {AccountTron} from "./AccountTron.sol";
 
@@ -15,6 +13,6 @@ import {AccountTron} from "./AccountTron.sol";
  *      tokens such as Tron USDT. Identical to {Portal} apart from the Account clone template and the
  *      CREATE2 prefix supplied to the shared {AccountDeployer}.
  */
-contract PortalTron is IntentSource, Inbox, Semver {
+contract PortalTron is PortalCore {
     constructor() AccountDeployer(address(new AccountTron()), bytes1(0x41)) {}
 }

--- a/docs/v3/04-same-chain-and-gates.md
+++ b/docs/v3/04-same-chain-and-gates.md
@@ -1,0 +1,79 @@
+# PR4 — reward-conservation + chain gates + same-chain fulfillAndSettle
+
+> Hardens the Model C dual-account/runtime from PR3 and makes same-chain a first-class primitive.
+> Re-authored onto the reconciled PR3 (minTokens input-floor, no sweep, dual `executeAsOwner`).
+
+## 1. fulfill derives the hash on-chain and takes the full reward
+
+`fulfill` / `fulfillAndProve` now take `(source, destination, route, Reward reward, claimant,
+providedAmounts, prover [, sourceChainDomainID, data])` and DERIVE the intent hash on-chain
+(`IntentLib.hashIntent(source, destination, keccak(route), keccak(reward))`). The caller-supplied
+`intentHash` and the `InvalidHash` mismatch check are gone: a tampered route is simply recorded under its
+own derived hash (solver self-harm, not a double-spend). Passing the full `reward` (not just its hash)
+authenticates `reward.tokens` so the conservation snapshot below can identify the escrow legs. The
+ERC-7683 `originData` becomes `(uint64 source, bytes route, Reward reward)`.
+
+## 2. Reward-conservation postcondition (same-chain escrow protection)
+
+In `Inbox._fulfill`, BEFORE staging any solver input, snapshot the execution Account's balance of every
+`reward.tokens` leg (and native) — the reserved escrow `E`. AFTER `account.execute`, require each leg's
+balance `>= E`, else revert `RewardEscrowTouched`.
+
+- **Same-chain** (`source == destination` → escrow and execution Account collapse to ONE): this stops a
+  malicious keeper-authored runtime from consuming the reward escrow to fund the route. A violation
+  reverts the whole fulfill (griefing DoS for the solver, who simulates first — never reward theft).
+- **Cross-chain**: the execution Account holds no source escrow, so every snapshot is ~0 and the check is
+  a cheap no-op.
+
+Snapshotting BEFORE staging means a reward token that is ALSO a solver-input token is measured
+escrow-only, so the runtime legitimately consuming the staged input does not trip conservation.
+
+## 3. block.chainid role gates
+
+- Source-side ops (`onlySourceChain(source)`): `fund` / `fundFor` / `publishAndFund(For)` / `settle` /
+  `refund` / `refundTo` / `recoverToken` / `executeAsOwner` revert `WrongSourceChain(current, expected)`
+  unless `block.chainid == source`. Each resolves the SOURCE escrow account keyed by `intent.source`, so
+  it is only meaningful on the source chain — belt-and-braces on top of the Model C address separation.
+- Destination op: `fulfill` reverts `WrongDestinationChain(current, expected)` unless
+  `destination == block.chainid`.
+
+## 4. PortalCore.fulfillAndSettle (same-chain, one tx)
+
+New abstract `PortalCore` (shared by `Portal` + `PortalTron`) adds
+`fulfillAndSettle(intent, providedAmounts, claimant)` for `source == destination == block.chainid`: it
+runs `_fulfill` (execute in the shared Account, enforce reward-conservation, record the local fact) then
+`_settle` from that same Account, reading the just-recorded fact — no relay, no cross-chain round-trip.
+`settle` is split into an `onlySourceChain` public wrapper + an internal `_settle` reused here. This is
+capital-EFFICIENT but NOT the v2 zero-capital flash: reward-conservation forbids the runtime from
+consuming the escrow, so the solver supplies the route input capital.
+
+## 5. Destination executeAsOwner is CROSS-CHAIN ONLY
+
+PR3 added `Inbox.executeAsOwner(source, route, rewardHash, runtime, payload)` gated by `route.keeper` for
+destination leftover retrieval. PR4 restricts it to cross-chain: it reverts `SourceChainOwnerOnly` when
+`source == block.chainid`. Rationale: on this chain the `block.chainid`-keyed Account is (or, same-chain,
+collapses with) the SOURCE escrow Account, and this path is reward-blind (only `rewardHash`), so it cannot
+run the conservation snapshot or the `AccountLocked` escrow/proof lock. Same-chain leftover retrieval
+therefore flows solely through the reward-aware `IntentSource.executeAsOwner` (reward.keeper +
+`AccountLocked`). Cross-chain, the destination Account provably holds only unconsumed solver input (a
+distinct address from the source escrow), so `route.keeper` may cook it freely.
+
+> This supersedes PR4's original recipient-authorized `rescueDestination` (a token-scoped, reward-excluding
+> rescue): under the unopinionated core there is no `recipient`, and the destination cannot see the reward
+> to exclude its tokens — which is exactly the isolation property that motivated `route.keeper`. Restricting
+> the arbitrary-runtime path to where the account is provably escrow-free is the equivalent safety.
+
+## 6. Size budget
+
+Portal / PortalTron = 22,880 B (< 24,576, headroom 1,696) at `optimizer_runs = 20,000`. PR4's additions
+(conservation loop, chain-gate modifiers, PortalCore) pushed the size past the ceiling at 1,000,000, so
+the optimizer was lowered to the highest value that keeps comfortable headroom (foundry.toml +
+hardhat.config.ts in lockstep).
+
+## 7. Tests
+
+`test/core/SameChainAndGates.t.sol` (19 tests): reward-conservation (malicious drain reverts, honest
+passes); source/destination chain gates on every gated op; `fulfillAndSettle` (happy path,
+solver-supplies-capital, `NotSameChain`); destination `executeAsOwner` (cross-chain keeper recovers
+leftover, same-chain reverts `SourceChainOwnerOnly`, non-keeper reverts `NotAccountKeeper`); and the
+role-collision matrix. Full suite green: forge 608, hardhat 112, jest 42.

--- a/docs/v3/migration-loss-inventory.md
+++ b/docs/v3/migration-loss-inventory.md
@@ -1,0 +1,39 @@
+# v3 migration-loss inventory
+
+Deliberate narrowings vs v2 / the earlier v3 draft, recorded here as they are accepted (not bugs). Each
+is a consequence of a locked v3 decision.
+
+## No zero-capital same-chain flash
+v2's `flashFulfill` could borrow the reward escrow to fund the route (withdraw-before-fulfill). Under v3
+the reward scales on the solver-provided `fulfilled[]` and settlement is gated on the fulfillment
+preimage, and — decisively — the PR4 reward-conservation postcondition forbids the runtime from consuming
+the escrow. So same-chain solving (`fulfillAndSettle`) is capital-EFFICIENT (one tx) but the solver must
+supply the route input capital. Accepted: the zero-capital flow is out of scope for this stack.
+
+## Destination leftover retrieval on same-chain is escrow-locked
+Under the unopinionated core there is no `recipient` and no auto-sweep; unconsumed solver input stays in
+the intent's Account. Cross-chain, `route.keeper` retrieves it via the destination
+`Inbox.executeAsOwner`. Same-chain, that path is disabled (`SourceChainOwnerOnly`) because the account is
+(or collapses with) the escrow account; retrieval then flows through the source
+`IntentSource.executeAsOwner`, which is subject to the `AccountLocked` escrow/proof lock. Net: same-chain
+leftover is retrievable only after the escrow is free (settled / past deadline) and only by
+`reward.keeper`. Accepted (safety over a minor liveness convenience); in practice a same-chain intent's
+keeper sets `route.keeper == reward.keeper`.
+
+## fulfill signature carries the full reward
+`fulfill` now takes the full `Reward` (not just `rewardHash`) so the destination can authenticate the
+escrow legs for reward-conservation. This re-exposes the reward struct on the destination side; it is
+public data (committed on the source) and is used only for the local snapshot, so no confidentiality or
+cross-VM property is lost. The intent hash still commits `rewardHash`.
+
+## Hash-only proof: a proven intent can be refunded after the deadline
+In v2 a proven intent could never be refunded. In the v3 hash-only model the source cannot introspect the
+committed claimant, so the anti-griefing guarantee (a bad-claimant fulfillment cannot permanently lock the
+keeper's funds) is preserved by the deadline instead: after `reward.deadline` an unsettled intent is
+always refundable. Accepted (documented in `IntentSource._validateRefund`).
+
+## Deferred (tracked, not lost)
+- Deposit-address migration onto standing streaming intents — deferred to a PR6b follow-up; the H2
+  anti-poison guard and all deposit families stay functional in the meantime.
+- Generated `contracts/README.md` and the root docs still carry v2/pre-rename wording — regenerated in the
+  deploy/docs stage (PR8).

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = "out"
 fs_permissions = [{ access = "read-write", path = "./out"}]
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 1000000
+optimizer_runs = 20000
 via_ir = true
 retries = 2
 evm_version = "paris"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,7 @@ const config: HardhatUserConfig = {
           viaIR: true,
           optimizer: {
             enabled: true,
-            runs: 1000000,
+            runs: 20000,
           },
         },
       },

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -54,6 +54,12 @@ contract BaseTest is Test {
     Intent internal intent;
 
     function setUp() public virtual {
+        // Pin the test chain id to CHAIN_ID BEFORE deploying so `block.chainid` equals the default
+        // same-chain intent's source == destination, satisfying the source/destination chain gates
+        // (onlySourceChain / WrongDestinationChain). Cross-chain tests override the intent's chain fields
+        // explicitly (with a foreign chain distinct from CHAIN_ID).
+        vm.chainId(CHAIN_ID);
+
         // Setup test addresses
         keeper = makeAddr("keeper");
         claimant = makeAddr("claimant");

--- a/test/DestinationSettler.spec.ts
+++ b/test/DestinationSettler.spec.ts
@@ -173,9 +173,9 @@ describe('Destination Settler Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          hashIntent(intent).rewardHash,
+          intent.reward,
           ethers.zeroPadValue(solver.address, 32),
           [nativeAmount, mintAmount],
           await prover.getAddress(),
@@ -204,9 +204,9 @@ describe('Destination Settler Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          hashIntent(intent).rewardHash,
+          intent.reward,
           ethers.zeroPadValue(solver.address, 32),
           [nativeAmount, mintAmount],
           await prover.getAddress(),

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -363,9 +363,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),
@@ -505,9 +505,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),
@@ -630,9 +630,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),
@@ -982,9 +982,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfillAndProve(
           intent.source,
-          intentHash,
+          intent.destination,
           route,
-          rewardHash,
+          reward,
           nonAddressClaimant,
           [amount],
           await hyperProver.getAddress(),
@@ -1132,9 +1132,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfillAndProve(
           intent.source,
-          intentHash,
+          intent.destination,
           route,
-          rewardHash,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),
@@ -1282,9 +1282,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent0.source,
-          intentHash0,
+          intent0.destination,
           route,
-          rewardHash0,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),
@@ -1343,9 +1343,9 @@ describe('HyperPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent1.source,
-          intentHash1,
+          intent1.destination,
           route1,
-          rewardHash1,
+          reward1,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await hyperProver.getAddress(),

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -157,53 +157,74 @@ describe('Inbox Test', (): void => {
 
   describe('fulfill when the intent is invalid', () => {
     it('should revert if fulfillment is attempted on an incorrect destination chain', async () => {
-      // Create an intent hash for a different destination chain
+      // `fulfill` requires `destination == block.chainid`; a foreign destination reverts
+      // `WrongDestinationChain` before it ever reaches hash derivation.
       const wrongDestination = 123
-      const wrongIntent: Intent = {
-        source: wrongDestination,
-        destination: wrongDestination,
-        route: route,
-        reward: reward,
-      }
-      const { intentHash: wrongIntentHash } = hashIntent(wrongIntent)
-
       await expect(
         inbox
           .connect(owner)
           .fulfill(
-            wrongIntent.source,
-            wrongIntentHash,
+            chainId,
+            wrongDestination,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
           ),
-      ).to.be.revertedWithCustomError(inbox, 'InvalidHash')
+      )
+        .to.be.revertedWithCustomError(inbox, 'WrongDestinationChain')
+        .withArgs(chainId, wrongDestination)
     })
 
-    it('should revert if the generated hash does not match the expected hash', async () => {
-      const goofyHash = keccak256(
-        ethers.AbiCoder.defaultAbiCoder().encode(
-          ['string'],
-          ["you wouldn't block a chain"],
+    it('records the fulfillment under the route-derived hash (no separate hash input to tamper with)', async () => {
+      // The new `fulfill` no longer takes a separate intent-hash input to malform — the hash is
+      // derived on-chain from (source, destination, route, reward). Tampering with the route no
+      // longer reverts; it just fulfills under a DIFFERENT derived hash than the original
+      // (untampered) intent's.
+      const _route: Route = {
+        ...route,
+        salt: keccak256(
+          ethers.AbiCoder.defaultAbiCoder().encode(
+            ['string'],
+            ["you wouldn't block a chain"],
+          ),
         ),
-      )
+      }
+      const { intentHash: tamperedHash } = hashIntent({
+        source: chainId,
+        destination: chainId,
+        route: _route,
+        reward,
+      })
+      expect(tamperedHash).to.not.equal(intentHash)
+
+      await erc20.connect(solver).approve(await inbox.getAddress(), mintAmount)
+
       await expect(
         inbox
           .connect(solver)
           .fulfill(
             chainId,
-            goofyHash,
-            route,
-            rewardHash,
+            chainId,
+            _route,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
           ),
-      ).to.be.revertedWithCustomError(inbox, 'InvalidHash')
+      ).to.not.be.reverted
+
+      expect(await mockProver.destFulfillment(tamperedHash)).to.equal(
+        hashFulfillment(tamperedHash, addressToBytes32(dstAddr.address), [
+          mintAmount,
+        ]),
+      )
+      expect(await mockProver.destFulfillment(intentHash)).to.equal(
+        ethers.ZeroHash,
+      )
     })
-    it('should revert via InvalidHash if all intent data was input correctly, but the intent used a different inbox on creation', async () => {
+    it('should revert via InvalidPortal if all intent data was input correctly, but the intent used a different portal on creation', async () => {
       const anotherPortal = await (
         await ethers.getContractFactory('Portal')
       ).deploy()
@@ -229,9 +250,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            _intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -247,9 +268,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             ethers.ZeroHash,
             [mintAmount],
             await mockProver.getAddress(),
@@ -263,9 +284,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -298,9 +319,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            _intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -332,9 +353,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -360,9 +381,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -397,9 +418,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -411,9 +432,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -453,9 +474,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [ethAmount],
             await mockProver.getAddress(),
@@ -471,9 +492,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [ethAmount],
             await mockProver.getAddress(),
@@ -517,9 +538,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [ethAmount],
             await mockProver.getAddress(),
@@ -579,9 +600,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            _intentHash,
+            chainId,
             _route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -615,9 +636,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfill(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -678,9 +699,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfillAndProve(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(dstAddr.address),
             [mintAmount],
             await mockProver.getAddress(),
@@ -717,9 +738,9 @@ describe('Inbox Test', (): void => {
           .connect(solver)
           .fulfillAndProve(
             chainId,
-            intentHash,
+            chainId,
             route,
-            rewardHash,
+            reward,
             addressToBytes32(validClaimant),
             [mintAmount],
             await mockProver.getAddress(),

--- a/test/LayerZeroProver.spec.ts
+++ b/test/LayerZeroProver.spec.ts
@@ -414,9 +414,9 @@ describe('LayerZeroPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await layerZeroProver.getAddress(),
@@ -537,9 +537,9 @@ describe('LayerZeroPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await layerZeroProver.getAddress(),
@@ -798,9 +798,9 @@ describe('LayerZeroPolicy Test', (): void => {
         .connect(solver)
         .fulfillAndProve(
           intent.source,
-          intentHash,
+          intent.destination,
           route,
-          rewardHash,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await layerZeroProver.getAddress(),
@@ -922,9 +922,9 @@ describe('LayerZeroPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent0.source,
-          intentHash0,
+          intent0.destination,
           route,
-          rewardHash0,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await layerZeroProver.getAddress(),
@@ -981,9 +981,9 @@ describe('LayerZeroPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent1.source,
-          intentHash1,
+          intent1.destination,
           route1,
-          rewardHash1,
+          reward1,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await layerZeroProver.getAddress(),

--- a/test/MetaProver.spec.ts
+++ b/test/MetaProver.spec.ts
@@ -425,9 +425,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),
@@ -546,9 +546,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),
@@ -654,9 +654,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent.source,
-          intentHash,
+          intent.destination,
           intent.route,
-          rewardHash,
+          intent.reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),
@@ -949,9 +949,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfillAndProve(
           intent.source,
-          intentHash,
+          intent.destination,
           route,
-          rewardHash,
+          reward,
           nonAddressClaimant,
           [amount],
           await metaProver.getAddress(),
@@ -1084,9 +1084,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfillAndProve(
           intent.source,
-          intentHash,
+          intent.destination,
           route,
-          rewardHash,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),
@@ -1231,9 +1231,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent0.source,
-          intentHash0,
+          intent0.destination,
           route,
-          rewardHash0,
+          reward,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),
@@ -1289,9 +1289,9 @@ describe('MetaPolicy Test', (): void => {
         .connect(solver)
         .fulfill(
           intent1.source,
-          intentHash1,
+          intent1.destination,
           route1,
-          rewardHash1,
+          reward1,
           ethers.zeroPadValue(await claimant.getAddress(), 32),
           [amount],
           await metaProver.getAddress(),

--- a/test/OriginSettler.spec.ts
+++ b/test/OriginSettler.spec.ts
@@ -13,6 +13,7 @@ import { keccak256, BytesLike, Provider, AbiCoder } from 'ethers'
 import { encodeTransfer } from '../utils/encode'
 import {
   encodeRoute,
+  encodeOriginData,
   encodeCalls,
   Call,
   TokenAmount,
@@ -579,28 +580,13 @@ describe('Origin Settler Test', (): void => {
         expect(fillInstruction.destinationSettler).to.eq(
           onchainCrosschainOrderData.routePortal,
         )
-        // originData is (source, route, rewardHash) -- Model C carries the committed `source` chain
-        // id so the destination fill can re-derive the same hash.
-        const rewardForEncoding = [
-          reward.deadline,
-          reward.keeper,
-          reward.prover,
-          reward.tokens.map((token) => [token.token, token.rate, token.flat]),
-        ]
-        const expectedOriginData = AbiCoder.defaultAbiCoder().encode(
-          ['uint64', 'bytes', 'bytes32'],
-          [
-            sourceChainId,
-            encodeRoute(route),
-            keccak256(
-              AbiCoder.defaultAbiCoder().encode(
-                [
-                  'tuple(uint64,address,address,tuple(address,uint256,uint256)[])',
-                ],
-                [rewardForEncoding],
-              ),
-            ),
-          ],
+        // originData is (source, route, reward) -- Model C carries the committed `source` chain id
+        // and the FULL reward struct (not just its hash) so the destination fill can derive the
+        // intent hash and settle against the reward on-chain.
+        const expectedOriginData = encodeOriginData(
+          sourceChainId,
+          encodeRoute(route),
+          reward,
         )
         expect(fillInstruction.originData).to.eq(expectedOriginData)
       })
@@ -734,28 +720,13 @@ describe('Origin Settler Test', (): void => {
         expect(fillInstruction.destinationSettler).to.eq(
           gaslessCrosschainOrderData.routePortal,
         )
-        // originData is (source, route, rewardHash) -- Model C carries the committed `source` chain
-        // id so the destination fill can re-derive the same hash.
-        const rewardForEncoding = [
-          reward.deadline,
-          reward.keeper,
-          reward.prover,
-          reward.tokens.map((token) => [token.token, token.rate, token.flat]),
-        ]
-        const expectedOriginData = AbiCoder.defaultAbiCoder().encode(
-          ['uint64', 'bytes', 'bytes32'],
-          [
-            sourceChainId,
-            encodeRoute(route),
-            keccak256(
-              AbiCoder.defaultAbiCoder().encode(
-                [
-                  'tuple(uint64,address,address,tuple(address,uint256,uint256)[])',
-                ],
-                [rewardForEncoding],
-              ),
-            ),
-          ],
+        // originData is (source, route, reward) -- Model C carries the committed `source` chain id
+        // and the FULL reward struct (not just its hash) so the destination fill can derive the
+        // intent hash and settle against the reward on-chain.
+        const expectedOriginData = encodeOriginData(
+          sourceChainId,
+          encodeRoute(route),
+          reward,
         )
         expect(fillInstruction.originData).to.eq(expectedOriginData)
       })

--- a/test/TokenSecurityTests.spec.ts
+++ b/test/TokenSecurityTests.spec.ts
@@ -119,7 +119,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
-      source: chainId + 1,
+      source: chainId,
       destination: chainId + 1,
       route,
       reward,
@@ -188,7 +188,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
-      source: chainId + 1,
+      source: chainId,
       destination: chainId + 1,
       route,
       reward,
@@ -252,7 +252,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
-      source: chainId + 1,
+      source: chainId,
       destination: chainId + 1,
       route,
       reward,
@@ -330,7 +330,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
-      source: chainId + 1,
+      source: chainId,
       destination: chainId + 1,
       route,
       reward,

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -63,9 +63,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -86,9 +86,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -114,9 +114,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -137,9 +137,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -164,9 +164,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -225,9 +225,9 @@ contract InboxTest is BaseTest {
         vm.deal(solver, ethAmount);
         portal.fulfill{value: ethAmount}(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -288,9 +288,9 @@ contract InboxTest is BaseTest {
         );
         portal.fulfill{value: ethAmount / 2}(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -307,9 +307,9 @@ contract InboxTest is BaseTest {
         );
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -365,9 +365,9 @@ contract InboxTest is BaseTest {
 
         portal.fulfill{value: ethAmount + extraFee}(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -399,9 +399,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             nonAddressClaimant,
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -426,9 +426,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfillAndProve(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             claimantBytes,
             _providedFromMinTokens(intent.route),
             address(prover),
@@ -482,9 +482,9 @@ contract InboxTest is BaseTest {
             vm.prank(solver);
             portal.fulfill(
                 intent.source,
-                intentHash,
+                intent.destination,
                 intent.route,
-                rewardHash,
+                intent.reward,
                 bytes32(uint256(uint160(recipient))),
                 _providedFromMinTokens(intent.route),
                 address(prover)
@@ -517,9 +517,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             claimantBytes,
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -530,9 +530,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             claimantBytes,
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -556,9 +556,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -583,9 +583,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             claimantBytes,
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -607,9 +607,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(0),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -749,9 +749,9 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)

--- a/test/core/InboxAdvanced.t.sol
+++ b/test/core/InboxAdvanced.t.sol
@@ -120,9 +120,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -179,9 +179,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -246,9 +246,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.deal(solver, ethAmount);
         portal.fulfill{value: ethAmount}(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -263,19 +263,26 @@ contract InboxAdvancedTest is BaseTest {
 
     function testValidationWithMalformedIntentHash() public {
         Intent memory intent = _createBasicIntent();
-        // bytes32 routeHash = keccak256(abi.encode(intent.route)); // unused
-        bytes32 rewardHash = keccak256(abi.encode(intent.reward));
 
-        // Create malformed intent hash
-        bytes32 malformedHash = keccak256(abi.encodePacked("malformed"));
+        // The new `fulfill` no longer takes a separate `intentHash` input to malform — the hash
+        // is derived on-chain from (source, destination, route, reward). The closest surviving
+        // "bad identifier" gate is an out-of-range `destination`: fulfill requires
+        // `destination == block.chainid`.
+        uint64 wrongDestination = uint64(block.chainid) + 1;
 
-        vm.expectRevert();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.WrongDestinationChain.selector,
+                uint64(block.chainid),
+                wrongDestination
+            )
+        );
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            malformedHash,
+            wrongDestination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -292,21 +299,40 @@ contract InboxAdvancedTest is BaseTest {
             rewardHash
         );
 
-        // Create mismatched route
+        // Tamper with the route (still targets this portal + block.chainid). Under the new
+        // signature the hash is derived on-chain from whatever route/reward is passed in, so a
+        // tampered route no longer reverts — it just records the fulfillment under a DIFFERENT
+        // derived hash than the original (untampered) intent's.
         Route memory mismatchedRoute = intent.route;
         mismatchedRoute.salt = keccak256("different");
+        bytes32 mismatchedHash = IntentLib.hashIntent(
+            intent.source,
+            intent.destination,
+            keccak256(abi.encode(mismatchedRoute)),
+            rewardHash
+        );
+        assertTrue(mismatchedHash != intentHash);
 
-        vm.expectRevert();
+        bytes32 claimantBytes = bytes32(uint256(uint160(recipient)));
+        uint256[] memory provided = _providedFromMinTokens(intent.route);
+
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             mismatchedRoute,
-            rewardHash,
-            bytes32(uint256(uint160(recipient))),
-            _providedFromMinTokens(intent.route),
+            intent.reward,
+            claimantBytes,
+            provided,
             address(prover)
         );
+
+        // Fulfilled under the TAMPERED route's own derived hash, not the original intent's hash.
+        assertEq(
+            prover.destFulfillment(mismatchedHash),
+            IntentLib.fulfillmentHash(mismatchedHash, claimantBytes, provided)
+        );
+        assertEq(prover.destFulfillment(intentHash), bytes32(0));
     }
 
     function testValidationWithExpiredDeadline() public {
@@ -326,9 +352,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -350,9 +376,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(0), // Zero claimant
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -376,9 +402,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -465,9 +491,9 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             intent.source,
-            intentHash,
+            intent.destination,
             intent.route,
-            rewardHash,
+            intent.reward,
             bytes32(uint256(uint160(recipient))),
             _providedFromMinTokens(intent.route),
             address(prover)
@@ -507,9 +533,9 @@ contract InboxAdvancedTest is BaseTest {
             vm.prank(solver);
             portal.fulfill(
                 intent.source,
-                intentHash,
+                intent.destination,
                 intent.route,
-                rewardHash,
+                intent.reward,
                 bytes32(uint256(uint160(recipient))),
                 _providedFromMinTokens(intent.route),
                 address(prover)

--- a/test/core/RewardLegs.t.sol
+++ b/test/core/RewardLegs.t.sol
@@ -92,9 +92,9 @@ contract RewardLegsTest is BaseTest {
         tokenA.approve(address(portal), provided);
         portal.fulfill(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             bytes32(uint256(uint160(claimant))),
             providedAmounts,
             address(prover)
@@ -261,7 +261,6 @@ contract RewardLegsTest is BaseTest {
     function test_fulfill_revertsOnInsufficientTokens() public {
         // Provide only 400 but the min-tokens floor is 500.
         Intent memory _intent = _rateIntent(500, 500, WAD, 0);
-        bytes32 intentHash = _hashIntent(_intent);
         tokenA.mint(solver, 400);
         uint256[] memory providedAmounts = new uint256[](1);
         providedAmounts[0] = 400;
@@ -277,9 +276,9 @@ contract RewardLegsTest is BaseTest {
         );
         portal.fulfill(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             bytes32(uint256(uint160(claimant))),
             providedAmounts,
             address(prover)
@@ -290,7 +289,6 @@ contract RewardLegsTest is BaseTest {
     function test_fulfill_revertsOnProvidedAmountsLengthMismatch() public {
         // One min-tokens leg, but an empty providedAmounts array.
         Intent memory _intent = _rateIntent(500, 500, WAD, 0);
-        bytes32 intentHash = _hashIntent(_intent);
         vm.expectRevert(
             abi.encodeWithSelector(
                 IInbox.ProvidedAmountsLengthMismatch.selector,
@@ -301,9 +299,9 @@ contract RewardLegsTest is BaseTest {
         vm.prank(solver);
         portal.fulfill(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             bytes32(uint256(uint160(claimant))),
             new uint256[](0),
             address(prover)
@@ -442,16 +440,15 @@ contract RewardLegsTest is BaseTest {
             route: r,
             reward: rw
         });
-        bytes32 intentHash = _hashIntent(_intent);
 
         vm.expectRevert(
             abi.encodeWithSelector(IntentLib.MinTokensNotSorted.selector, hi, lo)
         );
         portal.fulfill(
             _intent.source,
-            intentHash,
+            _intent.destination,
             r,
-            keccak256(abi.encode(rw)),
+            rw,
             bytes32(uint256(uint160(claimant))),
             new uint256[](2),
             address(prover)
@@ -485,7 +482,6 @@ contract RewardLegsTest is BaseTest {
             route: r,
             reward: rw
         });
-        bytes32 intentHash = _hashIntent(_intent);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -496,9 +492,9 @@ contract RewardLegsTest is BaseTest {
         );
         portal.fulfill(
             _intent.source,
-            intentHash,
+            _intent.destination,
             r,
-            keccak256(abi.encode(rw)),
+            rw,
             bytes32(uint256(uint160(claimant))),
             new uint256[](n),
             address(prover)

--- a/test/core/SameChainAndGates.t.sol
+++ b/test/core/SameChainAndGates.t.sol
@@ -1,0 +1,648 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {BaseTest} from "../BaseTest.sol";
+import {IInbox} from "../../contracts/interfaces/IInbox.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {IPortal} from "../../contracts/interfaces/IPortal.sol";
+import {LocalPolicy} from "../../contracts/prover/LocalPolicy.sol";
+import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../../contracts/types/Intent.sol";
+import {Call} from "../../contracts/interfaces/IRuntime.sol";
+
+/**
+ * @title SameChainAndGatesTest
+ * @notice PR4 tests: reward-conservation postcondition, the source/destination chain gates, the
+ *         same-chain first-class {IPortal-fulfillAndSettle}, the destination-side owner-cook
+ *         ({Inbox-executeAsOwner}, cross-chain only), and the role-collision attack matrix.
+ */
+contract SameChainAndGatesTest is BaseTest {
+    address internal solver;
+    address internal attacker;
+
+    // A same-chain-settling policy (its destination store IS the proof) so fulfillAndSettle can read the
+    // just-recorded local fact in-tx.
+    LocalPolicy internal localPolicy;
+
+    uint64 internal constant FOREIGN_CHAIN = 2; // a source chain that is NOT this chain
+
+    function setUp() public override {
+        super.setUp();
+        solver = makeAddr("solver");
+        attacker = makeAddr("attacker");
+
+        vm.prank(deployer);
+        localPolicy = new LocalPolicy(address(portal));
+
+        // Fund keeper + solver with both tokens and native.
+        _mintAndApprove(keeper, MINT_AMOUNT * 10);
+        _mintAndApprove(solver, MINT_AMOUNT * 10);
+        _fundUserNative(keeper, 100 ether);
+        _fundUserNative(solver, 100 ether);
+
+        vm.startPrank(solver);
+        tokenA.approve(address(portal), type(uint256).max);
+        tokenB.approve(address(portal), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    // ─────────────────────────────── helpers ───────────────────────────────
+
+    function _noopPayload() internal pure returns (bytes memory) {
+        return abi.encode(new Call[](0));
+    }
+
+    function _transferPayload(
+        address token,
+        address to,
+        uint256 amount
+    ) internal pure returns (bytes memory) {
+        Call[] memory c = new Call[](1);
+        c[0] = Call({
+            target: token,
+            data: abi.encodeWithSignature(
+                "transfer(address,uint256)",
+                to,
+                amount
+            ),
+            value: 0
+        });
+        return abi.encode(c);
+    }
+
+    /// @notice A same-chain intent whose reward is a single flat tokenA leg, no solver input, and whose
+    ///         route runs `payload`.
+    function _sameChainFlatIntent(
+        address prover,
+        uint256 flatReward,
+        bytes memory payload
+    ) internal view returns (Intent memory) {
+        RewardToken[] memory legs = new RewardToken[](1);
+        legs[0] = RewardToken({token: address(tokenA), rate: 0, flat: flatReward});
+
+        return
+            Intent({
+                source: uint64(block.chainid),
+                destination: uint64(block.chainid),
+                route: Route({
+                    salt: salt,
+                    deadline: uint64(expiry),
+                    portal: address(portal),
+                    keeper: keeper,
+                    runtime: address(multicallRuntime),
+                    payload: payload,
+                    minTokens: new TokenAmount[](0)
+                }),
+                reward: Reward({
+                    deadline: uint64(expiry),
+                    keeper: keeper,
+                    prover: prover,
+                    tokens: legs
+                })
+            });
+    }
+
+    function _fund(Intent memory _intent) internal {
+        vm.prank(keeper);
+        intentSource.publishAndFund(_intent, false);
+    }
+
+    // ───────────────────────── reward-conservation ─────────────────────────
+
+    function test_conservation_maliciousRuntimeDrainingEscrowReverts() public {
+        // Same-chain intent: ONE Account holds both the reward escrow and runs the runtime. A malicious
+        // keeper-authored runtime that transfers the escrow token out during execution must make the whole
+        // fulfill revert (solver self-DoS), never steal the escrow.
+        uint256 rewardFlat = MINT_AMOUNT;
+        Intent memory _intent = _sameChainFlatIntent(
+            address(localPolicy),
+            rewardFlat,
+            _transferPayload(address(tokenA), attacker, rewardFlat) // drains the escrow
+        );
+        _fund(_intent);
+
+        address account = intentSource.intentAccountAddress(_intent);
+        assertEq(tokenA.balanceOf(account), rewardFlat); // escrow present
+
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.RewardEscrowTouched.selector,
+                address(tokenA),
+                0,
+                rewardFlat
+            )
+        );
+        portal.fulfill(
+            _intent.source,
+            _intent.destination,
+            _intent.route,
+            _intent.reward,
+            bytes32(uint256(uint160(solver))),
+            _noFulfilled(),
+            address(localPolicy)
+        );
+
+        // Escrow untouched, attacker got nothing (whole tx reverted).
+        assertEq(tokenA.balanceOf(account), rewardFlat);
+        assertEq(tokenA.balanceOf(attacker), 0);
+    }
+
+    function test_conservation_honestRuntimeWithEscrowPresentPasses() public {
+        // An honest no-op runtime leaves the escrow intact -> fulfill succeeds even though the shared
+        // Account holds the reward escrow.
+        uint256 rewardFlat = MINT_AMOUNT;
+        Intent memory _intent = _sameChainFlatIntent(
+            address(localPolicy),
+            rewardFlat,
+            _noopPayload()
+        );
+        _fund(_intent);
+        address account = intentSource.intentAccountAddress(_intent);
+
+        vm.prank(solver);
+        portal.fulfill(
+            _intent.source,
+            _intent.destination,
+            _intent.route,
+            _intent.reward,
+            bytes32(uint256(uint160(solver))),
+            _noFulfilled(),
+            address(localPolicy)
+        );
+
+        // Escrow still intact after fulfill (settle pays it out later).
+        assertEq(tokenA.balanceOf(account), rewardFlat);
+    }
+
+    // ─────────────────────────── fulfillAndSettle ──────────────────────────
+
+    function test_fulfillAndSettle_sameChain_paysRewardToClaimant() public {
+        uint256 rewardFlat = MINT_AMOUNT;
+        Intent memory _intent = _sameChainFlatIntent(
+            address(localPolicy),
+            rewardFlat,
+            _noopPayload()
+        );
+        _fund(_intent);
+
+        uint256 claimantBefore = tokenA.balanceOf(solver);
+
+        vm.prank(solver);
+        portal.fulfillAndSettle(
+            _intent,
+            _noFulfilled(),
+            bytes32(uint256(uint160(solver)))
+        );
+
+        // Solver (claimant) received the flat reward atomically, no relay.
+        assertEq(tokenA.balanceOf(solver), claimantBefore + rewardFlat);
+        // Account drained (reward paid, no residual).
+        address account = intentSource.intentAccountAddress(_intent);
+        assertEq(tokenA.balanceOf(account), 0);
+        // Terminal status.
+        (bytes32 intentHash, , ) = intentSource.getIntentHash(_intent);
+        assertEq(
+            uint256(intentSource.getRewardStatus(intentHash)),
+            uint256(IIntentSource.Status.Withdrawn)
+        );
+    }
+
+    function test_fulfillAndSettle_solverSuppliesRouteCapital() public {
+        // Realistic same-chain solve: the solver provides the route INPUT capital (tokenB via minTokens),
+        // the runtime delivers it to a beneficiary, and the solver is paid the tokenA reward atomically.
+        // Capital-EFFICIENT (one tx) but NOT zero-capital (the escrow is conserved, never used to fund the
+        // route).
+        address beneficiary = makeAddr("beneficiary");
+        uint256 deliver = MINT_AMOUNT;
+        uint256 rewardFlat = MINT_AMOUNT * 2;
+
+        TokenAmount[] memory minTokensIn = new TokenAmount[](1);
+        minTokensIn[0] = TokenAmount({token: address(tokenB), amount: deliver});
+        RewardToken[] memory legs = new RewardToken[](1);
+        legs[0] = RewardToken({token: address(tokenA), rate: 0, flat: rewardFlat});
+
+        Intent memory _intent = Intent({
+            source: uint64(block.chainid),
+            destination: uint64(block.chainid),
+            route: Route({
+                salt: salt,
+                deadline: uint64(expiry),
+                portal: address(portal),
+                keeper: keeper,
+                runtime: address(multicallRuntime),
+                payload: _transferPayload(address(tokenB), beneficiary, deliver),
+                minTokens: minTokensIn
+            }),
+            reward: Reward({
+                deadline: uint64(expiry),
+                keeper: keeper,
+                prover: address(localPolicy),
+                tokens: legs
+            })
+        });
+        _fund(_intent);
+
+        uint256 beneficiaryBBefore = tokenB.balanceOf(beneficiary);
+        uint256 solverABefore = tokenA.balanceOf(solver);
+        uint256 solverBBefore = tokenB.balanceOf(solver);
+
+        uint256[] memory provided = new uint256[](1);
+        provided[0] = deliver;
+
+        vm.prank(solver);
+        portal.fulfillAndSettle(
+            _intent,
+            provided,
+            bytes32(uint256(uint160(solver)))
+        );
+
+        // Beneficiary got the delivered tokenB; solver spent tokenB capital and received the tokenA reward.
+        assertEq(tokenB.balanceOf(beneficiary), beneficiaryBBefore + deliver);
+        assertEq(tokenB.balanceOf(solver), solverBBefore - deliver);
+        assertEq(tokenA.balanceOf(solver), solverABefore + rewardFlat);
+    }
+
+    function test_fulfillAndSettle_revertsForCrossChainIntent() public {
+        Intent memory _intent = _sameChainFlatIntent(
+            address(localPolicy),
+            MINT_AMOUNT,
+            _noopPayload()
+        );
+        _intent.source = FOREIGN_CHAIN; // source != destination => not same-chain
+
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPortal.NotSameChain.selector,
+                FOREIGN_CHAIN,
+                uint64(block.chainid),
+                uint64(block.chainid)
+            )
+        );
+        portal.fulfillAndSettle(
+            _intent,
+            _noFulfilled(),
+            bytes32(uint256(uint160(solver)))
+        );
+    }
+
+    // ─────────────────────────── source-chain gate ─────────────────────────
+
+    function _crossChainIntent() internal view returns (Intent memory) {
+        // A cross-chain intent whose SOURCE is foreign and whose DESTINATION is this chain.
+        Intent memory _intent = _sameChainFlatIntent(
+            address(prover),
+            MINT_AMOUNT,
+            _noopPayload()
+        );
+        _intent.source = FOREIGN_CHAIN;
+        return _intent;
+    }
+
+    function test_gate_fund_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+        (, bytes32 routeHash, ) = intentSource.getIntentHash(_intent);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.fund(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            false
+        );
+    }
+
+    function test_gate_publishAndFund_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.publishAndFund(_intent, false);
+    }
+
+    function test_gate_settle_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+        (, bytes32 routeHash, ) = intentSource.getIntentHash(_intent);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.settle(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            bytes32(uint256(uint160(claimant))),
+            _noFulfilled()
+        );
+    }
+
+    function test_gate_refund_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+        (, bytes32 routeHash, ) = intentSource.getIntentHash(_intent);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.refund(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward
+        );
+    }
+
+    function test_gate_recoverToken_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+        (, bytes32 routeHash, ) = intentSource.getIntentHash(_intent);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.recoverToken(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            address(tokenB)
+        );
+    }
+
+    function test_gate_executeAsOwner_revertsOnWrongSourceChain() public {
+        Intent memory _intent = _crossChainIntent();
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.WrongSourceChain.selector,
+                uint64(block.chainid),
+                FOREIGN_CHAIN
+            )
+        );
+        intentSource.executeAsOwner(
+            _intent,
+            address(multicallRuntime),
+            _noopPayload()
+        );
+    }
+
+    // ──────────────────────── destination-chain gate ───────────────────────
+
+    function test_gate_fulfill_revertsOnWrongDestinationChain() public {
+        Intent memory _intent = _sameChainFlatIntent(
+            address(prover),
+            0,
+            _noopPayload()
+        );
+        uint64 wrongDestination = uint64(block.chainid) + 1;
+
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.WrongDestinationChain.selector,
+                uint64(block.chainid),
+                wrongDestination
+            )
+        );
+        portal.fulfill(
+            _intent.source,
+            wrongDestination,
+            _intent.route,
+            _intent.reward,
+            bytes32(uint256(uint160(solver))),
+            _noFulfilled(),
+            address(prover)
+        );
+    }
+
+    // ─────────────────── destination executeAsOwner (cross-chain) ───────────
+
+    function test_executeAsOwner_dest_keeperRecoversStrayToken() public {
+        // A cross-chain intent's DESTINATION account holds a stray (non-escrow) token. The destination
+        // owner (route.keeper) cooks it out via the runtime. Cross-chain => the dest account is a distinct
+        // address that never holds escrow, so an arbitrary runtime is safe here.
+        Intent memory _intent = _crossChainIntent(); // source foreign, dest = this chain
+        (bytes32 intentHash, , bytes32 rewardHash) = intentSource.getIntentHash(
+            _intent
+        );
+        address destAccount = portal.accountAddress(
+            intentHash,
+            _intent.destination
+        );
+
+        // Force a stray token (tokenB) into the destination account.
+        tokenB.mint(destAccount, MINT_AMOUNT);
+
+        uint256 keeperBefore = tokenB.balanceOf(keeper);
+
+        vm.prank(keeper);
+        portal.executeAsOwner(
+            _intent.source,
+            _intent.route,
+            rewardHash,
+            address(multicallRuntime),
+            _transferPayload(address(tokenB), keeper, MINT_AMOUNT)
+        );
+
+        assertEq(tokenB.balanceOf(keeper), keeperBefore + MINT_AMOUNT);
+        assertEq(tokenB.balanceOf(destAccount), 0);
+    }
+
+    function test_executeAsOwner_dest_revertsForSameChain() public {
+        // Same-chain intent: the block.chainid-keyed account is (or collapses with) the SOURCE escrow
+        // account, so the reward-blind destination path is rejected — use the source executeAsOwner.
+        Intent memory _intent = _sameChainFlatIntent(
+            address(prover),
+            MINT_AMOUNT,
+            _noopPayload()
+        );
+        (, , bytes32 rewardHash) = intentSource.getIntentHash(_intent);
+
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.SourceChainOwnerOnly.selector,
+                uint64(block.chainid)
+            )
+        );
+        portal.executeAsOwner(
+            _intent.source, // == block.chainid (same-chain)
+            _intent.route,
+            rewardHash,
+            address(multicallRuntime),
+            _noopPayload()
+        );
+    }
+
+    function test_executeAsOwner_dest_revertsForNonKeeper() public {
+        Intent memory _intent = _crossChainIntent();
+        (, , bytes32 rewardHash) = intentSource.getIntentHash(_intent);
+
+        vm.prank(attacker);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.NotAccountKeeper.selector,
+                attacker
+            )
+        );
+        portal.executeAsOwner(
+            _intent.source,
+            _intent.route,
+            rewardHash,
+            address(multicallRuntime),
+            _noopPayload()
+        );
+    }
+
+    // ───────────────────── role-collision attack matrix ─────────────────────
+
+    // (a) An A->B intent fulfilled on B: an attacker running a source-side op on B for that intent cannot
+    //     reach the destination account's leftovers — the source op reverts on the WrongSourceChain gate
+    //     (and would otherwise resolve the empty source-account address, never the destination account).
+    function test_Qa_sourceOpOnDestChainCannotReachDestVault() public {
+        Intent memory _intent = _crossChainIntent(); // source = A (foreign), destination = B (this chain)
+        (bytes32 intentHash, bytes32 routeHash, ) = intentSource.getIntentHash(
+            _intent
+        );
+
+        // The DESTINATION account (keyed by destination) is distinct from the source escrow account
+        // (keyed by source).
+        address destAccount = portal.accountAddress(
+            intentHash,
+            _intent.destination
+        );
+        address srcAccount = portal.accountAddress(intentHash, _intent.source);
+        assertTrue(destAccount != srcAccount);
+
+        // The attacker tries every source-side op on B for this intent -> all revert WrongSourceChain,
+        // so none can operate on the destination account.
+        bytes memory wrongSource = abi.encodeWithSelector(
+            IIntentSource.WrongSourceChain.selector,
+            uint64(block.chainid),
+            FOREIGN_CHAIN
+        );
+        vm.startPrank(attacker);
+        vm.expectRevert(wrongSource);
+        intentSource.settle(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            bytes32(uint256(uint160(attacker))),
+            _noFulfilled()
+        );
+        vm.expectRevert(wrongSource);
+        intentSource.refund(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward
+        );
+        vm.expectRevert(wrongSource);
+        intentSource.recoverToken(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            address(tokenB)
+        );
+        vm.stopPrank();
+    }
+
+    // (b) A fund-before-fulfill race on B does not let a later refund/settle drain destination funds: on B
+    //     (the destination chain) you cannot even FUND a cross-chain intent (fund is source-gated), and a
+    //     later refund is source-gated too.
+    function test_Qb_fundThenRefundOnDestChainReverts() public {
+        Intent memory _intent = _crossChainIntent();
+        (, bytes32 routeHash, ) = intentSource.getIntentHash(_intent);
+
+        bytes memory wrongSource = abi.encodeWithSelector(
+            IIntentSource.WrongSourceChain.selector,
+            uint64(block.chainid),
+            FOREIGN_CHAIN
+        );
+        vm.startPrank(attacker);
+        vm.expectRevert(wrongSource);
+        intentSource.fund(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward,
+            false
+        );
+        vm.expectRevert(wrongSource);
+        intentSource.refund(
+            _intent.source,
+            _intent.destination,
+            routeHash,
+            _intent.reward
+        );
+        vm.stopPrank();
+    }
+
+    // (c) The honest same-chain B->B lifecycle (fund, then fulfillAndSettle) works end-to-end, including
+    //     the reward-conservation postcondition on the shared account.
+    function test_Qc_honestSameChainLifecycle() public {
+        uint256 rewardFlat = MINT_AMOUNT;
+        Intent memory _intent = _sameChainFlatIntent(
+            address(localPolicy),
+            rewardFlat,
+            _noopPayload()
+        );
+        _fund(_intent);
+        assertTrue(intentSource.isIntentFunded(_intent));
+
+        uint256 before = tokenA.balanceOf(solver);
+        vm.prank(solver);
+        portal.fulfillAndSettle(
+            _intent,
+            _noFulfilled(),
+            bytes32(uint256(uint160(solver)))
+        );
+        assertEq(tokenA.balanceOf(solver), before + rewardFlat);
+    }
+
+    // (d) The same route+reward opened from two different source chains has DIFFERENT intent hashes
+    //     (source is in the hash) and DIFFERENT escrow account addresses, so a fulfillment for one can
+    //     never double-claim the other.
+    function test_Qd_sourceInHashSeparatesTwoOrigins() public view {
+        Intent memory a = _crossChainIntent();
+        a.source = 2;
+        Intent memory b = _crossChainIntent();
+        b.source = 3;
+
+        (bytes32 hashA, , ) = intentSource.getIntentHash(a);
+        (bytes32 hashB, , ) = intentSource.getIntentHash(b);
+        assertTrue(hashA != hashB);
+
+        // Escrow accounts (keyed by source) also differ.
+        address accountA = portal.accountAddress(hashA, a.source);
+        address accountB = portal.accountAddress(hashB, b.source);
+        assertTrue(accountA != accountB);
+    }
+}

--- a/test/prover/CCIPProver.t.sol
+++ b/test/prover/CCIPProver.t.sol
@@ -467,10 +467,19 @@ contract CCIPProverTest is BaseTest {
     // ============ Challenge Tests ============
 
     function testChallengeIntentProofWithWrongChain() public {
+        // BaseTest's default `intent` is now same-chain (source == destination == block.chainid),
+        // so it can no longer exercise the "proven on the wrong chain" mismatch on its own. Build an
+        // intent whose OWN committed destination is a FOREIGN chain (distinct from block.chainid) to
+        // reproduce the scenario: the intent claims destination X, but the fulfillment was actually
+        // proven on block.chainid != X.
+        uint64 foreignDestination = uint64(block.chainid) + 1;
+        Intent memory foreignIntent = intent;
+        foreignIntent.destination = foreignDestination;
+
         // First, prove the intent
         bytes32[] memory intentHashes = new bytes32[](1);
         bytes32[] memory claimants = new bytes32[](1);
-        bytes32 intentHash = _hashIntent(intent);
+        bytes32 intentHash = _hashIntent(foreignIntent);
         intentHashes[0] = intentHash;
         claimants[0] = bytes32(uint256(uint160(claimant)));
 
@@ -478,18 +487,22 @@ contract CCIPProverTest is BaseTest {
         vm.prank(address(portal));
         bytes memory proverData =
             _encodeProverData(bytes32(uint256(uint160(whitelistedProver))), DEFAULT_GAS_LIMIT);
+        // prove() reports the ACTUAL chain the fulfillment happened on: block.chainid.
         ccipProver.prove{value: 1 ether}(keeper, uint64(block.chainid), intentHashes, proverData);
 
-        // Verify intent is proven (with chain ID = 31337 from the prove call)
+        // Verify intent is proven, recorded against the actual fulfillment chain (block.chainid).
         IPolicy.ProofData memory proof = ccipProver.provenIntents(intentHash);
         assertTrue(proof.fulfillmentHash != bytes32(0));
-        assertEq(proof.destination, uint96(block.chainid)); // 31337
+        assertEq(proof.destination, uint96(block.chainid));
 
-        // The original intent has destination = 1 (CHAIN_ID from BaseTest)
-        // So challenging with the original intent should clear the proof
+        // The intent's OWN committed destination (foreignDestination) does not match where it was
+        // actually proven (block.chainid), so challenging with the intent's true fields should clear it.
         vm.prank(keeper);
         ccipProver.challengeIntentProof(
-            intent.source, intent.destination, keccak256(abi.encode(intent.route)), keccak256(abi.encode(intent.reward))
+            foreignIntent.source,
+            foreignIntent.destination,
+            keccak256(abi.encode(foreignIntent.route)),
+            keccak256(abi.encode(foreignIntent.reward))
         );
 
         // Verify proof was cleared

--- a/test/prover/HyperProver.t.sol
+++ b/test/prover/HyperProver.t.sol
@@ -390,10 +390,19 @@ contract HyperProverTest is BaseTest {
     }
 
     function testChallengeIntentProofWithWrongChain() public {
+        // BaseTest's default `intent` is now same-chain (source == destination == block.chainid), so
+        // it can no longer exercise the "proven on the wrong chain" mismatch on its own. Build an
+        // intent whose OWN committed destination is a FOREIGN chain (distinct from block.chainid) to
+        // reproduce the scenario: the intent claims destination X, but the fulfillment was actually
+        // proven on block.chainid != X.
+        uint64 foreignDestination = uint64(block.chainid) + 1;
+        Intent memory foreignIntent = intent;
+        foreignIntent.destination = foreignDestination;
+
         // First, prove the intent
         bytes32[] memory intentHashes = new bytes32[](1);
         bytes32[] memory claimants = new bytes32[](1);
-        bytes32 intentHash = _hashIntent(intent);
+        bytes32 intentHash = _hashIntent(foreignIntent);
         intentHashes[0] = intentHash;
         claimants[0] = bytes32(uint256(uint160(claimant)));
 
@@ -404,6 +413,7 @@ contract HyperProverTest is BaseTest {
             "",
             address(0)
         );
+        // prove() reports the ACTUAL chain the fulfillment happened on: block.chainid.
         hyperProver.prove{value: 1 ether}(
             keeper,
             uint64(block.chainid),
@@ -411,20 +421,19 @@ contract HyperProverTest is BaseTest {
             proverData
         );
 
-        // Verify intent is proven (with chain ID = 31337 from the prove call)
+        // Verify intent is proven, recorded against the actual fulfillment chain (block.chainid).
         IPolicy.ProofData memory proof = hyperProver.provenIntents(intentHash);
         assertTrue(proof.fulfillmentHash != bytes32(0));
-        assertEq(proof.destination, uint96(block.chainid)); // 31337
+        assertEq(proof.destination, uint96(block.chainid));
 
-        // The original intent has destination = 1 (CHAIN_ID from BaseTest)
-        // So challenging with the original intent should clear the proof
-        // because intent.destination (1) != proof.destination (31337)
+        // The intent's OWN committed destination (foreignDestination) does not match where it was
+        // actually proven (block.chainid), so challenging with the intent's true fields should clear it.
         vm.prank(keeper);
         hyperProver.challengeIntentProof(
-            intent.source,
-            intent.destination,
-            keccak256(abi.encode(intent.route)),
-            keccak256(abi.encode(intent.reward))
+            foreignIntent.source,
+            foreignIntent.destination,
+            keccak256(abi.encode(foreignIntent.route)),
+            keccak256(abi.encode(foreignIntent.reward))
         );
 
         // Verify proof was cleared

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -157,9 +157,9 @@ contract LocalProverTest is Test {
         vm.deal(solver, REWARD_AMOUNT);
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             bytes32(uint256(uint160(solver))),
             new uint256[](0),
             address(localProver)
@@ -245,9 +245,9 @@ contract LocalProverTest is Test {
         vm.deal(solver, REWARD_AMOUNT);
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             bytes32(uint256(uint160(solver))),
             new uint256[](0),
             address(localProver)
@@ -553,9 +553,9 @@ contract LocalProverTest is Test {
         );
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             localProverAsBytes32,
             new uint256[](0),
             address(localProver)
@@ -616,9 +616,9 @@ contract LocalProverTest is Test {
         bytes32 nonEVMBytes32 = bytes32(uint256(type(uint256).max)); // All 1s
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             nonEVMBytes32,
             new uint256[](0),
             address(localProver)
@@ -680,9 +680,9 @@ contract LocalProverTest is Test {
         );
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             localProverAsBytes32,
             new uint256[](0),
             address(localProver)
@@ -719,9 +719,9 @@ contract LocalProverTest is Test {
         );
         portal.fulfill{value: REWARD_AMOUNT}(
             _intent.source,
-            intentHash,
+            _intent.destination,
             _intent.route,
-            keccak256(abi.encode(_intent.reward)),
+            _intent.reward,
             localProverAsBytes32,
             new uint256[](0),
             address(localProver)

--- a/test/security/TokenSecurity.t.sol
+++ b/test/security/TokenSecurity.t.sol
@@ -136,21 +136,18 @@ contract TokenSecurityTest is BaseTest {
         vm.prank(attacker);
         maliciousToken.approve(address(portal), MINT_AMOUNT);
 
-        bytes32 intentHash = _hashIntent(destIntent);
-
         // Solver provides exactly the single min-tokens leg (the malicious token) as input.
         uint256[] memory providedAmounts = new uint256[](1);
         providedAmounts[0] = MINT_AMOUNT;
 
         // Should revert when the malicious token's transfer (executed by the executor) fails
         vm.prank(attacker);
-        bytes32 rewardHash = keccak256(abi.encode(destIntent.reward));
         vm.expectRevert();
         portal.fulfill(
             destIntent.source,
-            intentHash,
+            destIntent.destination,
             destIntent.route,
-            rewardHash,
+            destIntent.reward,
             bytes32(uint256(uint160(attacker))),
             providedAmounts,
             address(prover)

--- a/utils/intent.ts
+++ b/utils/intent.ts
@@ -138,6 +138,27 @@ export function encodeReward(reward: Reward) {
   )
 }
 
+/**
+ * ABI-encodes the ERC-7683 `FillInstruction.originData` payload the same way
+ * {OriginSettler-resolve} does: `abi.encode(source, routeBytes, reward)`, where `routeBytes` is the
+ * ALREADY-ENCODED route (see {encodeRoute}) and `reward` is the full (unhashed) `Reward` struct.
+ */
+export function encodeOriginData(
+  source: number | bigint,
+  routeBytes: string,
+  reward: Reward,
+) {
+  const abiCoder = AbiCoder.defaultAbiCoder()
+  return abiCoder.encode(
+    [
+      { name: 'source', type: 'uint64' },
+      { name: 'route', type: 'bytes' },
+      { name: 'reward', type: 'tuple', components: RewardStruct },
+    ],
+    [source, routeBytes, reward],
+  )
+}
+
 export function encodeIntent(intent: Intent) {
   const abiCoder = AbiCoder.defaultAbiCoder()
   return abiCoder.encode(


### PR DESCRIPTION
## Summary
Stacked on PR3 (#398). Adds the safety refinements Model C's mechanism needs:

- **Reward-conservation postcondition**: `Inbox._fulfill` snapshots each reward-leg token's escrow-account balance before staging the solver's input and requires it hasn't decreased after the runtime executes — protects a same-chain collapsed account's escrow from a malicious/buggy committed runtime.
- **`block.chainid` gates**: `WrongSourceChain` on every source-side op (fund/fundFor/settle/refund/refundTo/recoverToken/executeAsOwner); `WrongDestinationChain` on fulfill/fulfillAndProve.
- **`fulfillAndSettle`** (new `PortalCore`): a one-transaction same-chain solve when `source == destination == block.chainid`.
- **`Inbox.executeAsOwner` restricted to cross-chain only**: reverts `SourceChainOwnerOnly` when `source == block.chainid`. On a same-chain collapsed account, the destination-side owner path cannot see reward legs/deadline/proof state, so it can't safely run arbitrary code near live escrow — that capability belongs solely to the source-side `executeAsOwner` (gated by `reward.keeper`, protected by the escrow/proof lock fixed in PR3). Cross-chain, the destination account only ever holds leftover input (never escrow, by address separation), so it's safe there.
- v2's zero-capital same-chain flash-fulfill doesn't survive the conservation postcondition (a solver can no longer fund the route by borrowing escrow) — same-chain solving is now capital-efficient (one tx) rather than zero-capital. Documented in `migration-loss-inventory.md`.

## Test plan
- [x] `forge build` clean
- [x] `forge test`: 609 passed / 0 failed
- [x] `npx hardhat test`: 112 passing
- [x] `jest`: 42 passed
- [x] Portal size within EIP-170 budget throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N25m45iFpZQEycqw7YFNsK