### PR TITLE
v3 PR5: reward.hooks keeper-committed delegate hooks

### DIFF
--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -37,6 +37,14 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     /// @dev Tracks the lifecycle status of each intent's rewards
     mapping(bytes32 => Status) private rewardStatuses;
 
+    /// @dev Index of the REWARD hook in the default `Reward.hooks` (`abi.encode(Hook[2])`): run after a
+    ///      successful settle.
+    uint256 private constant HOOK_REWARD = 0;
+
+    /// @dev Index of the REFUND hook in the default `Reward.hooks` (`abi.encode(Hook[2])`): run after a
+    ///      refund.
+    uint256 private constant HOOK_REFUND = 1;
+
     /**
      * @notice Ensures intent can be funded based on its current status
      * @param intentHash Hash of the intent to validate for funding eligibility
@@ -585,6 +593,13 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         account.withdraw(reward, claimantAddr, fulfilled);
 
         emit IntentWithdrawn(intentHash, claimantAddr);
+
+        // CEI: run the keeper-committed REWARD hook LAST — after the claimant is paid, the residual is
+        // swept to the keeper, and the status is terminal (Withdrawn). Best-effort (try/catch): a
+        // reverting or malformed hook is caught so it can never strand the already-paid solver. The hook
+        // is committed in the reward hash and inspectable before fulfillment, so a hostile hook is
+        // self-harm for the keeper.
+        _runHook(intentHash, address(account), reward.hooks, HOOK_REWARD);
     }
 
     /**
@@ -1051,6 +1066,39 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     }
 
     /**
+ * @notice Runs a keeper-committed delegate hook against an intent's Account, best-effort
+     * @dev Invoked AFTER the core settle/refund effects (CEI). Short-circuits the common no-hooks case
+     *      (`hooks.length == 0`) without an external call. Otherwise it delegates to
+     *      {IAccount-runHook}, which decodes the default `abi.encode(Hook[2])`, skips a `target ==
+     *      address(0)` slot, and runs the hook in the Account's gated delegatecall sandbox. The call is
+     *      wrapped in try/catch: a reverting hook OR a malformed `hooks` (a decode revert in the Account) is
+     *      caught and surfaced via {HookReverted}, so it can never revert the settle/refund that already
+     *      committed its money effects. No reentrancy guard is needed: the terminal status is set and the
+     *      account drained before the hook runs, so a hook that reenters settle/refund of THIS intent
+     *      reverts on status (and cannot double-spend), and per-intent Account isolation means it cannot
+     *      touch another intent's escrow.
+     * @param intentHash The intent hash (for the {HookReverted} event)
+     * @param account The intent's SOURCE (escrow) Account, which runs the hook via delegatecall
+     * @param hooks The opaque `Reward.hooks` bytes (default: `abi.encode(Hook[2])`)
+     * @param index Which hook slot to run (0 = reward, 1 = refund)
+     */
+    function _runHook(
+        bytes32 intentHash,
+        address account,
+        bytes calldata hooks,
+        uint256 index
+    ) private {
+        if (hooks.length == 0) {
+            return;
+        }
+        try IAccount(account).runHook(hooks, index) {
+            // Hook ran (or the slot was a no-op target(0)); nothing more to do.
+        } catch {
+            emit HookReverted(intentHash, index);
+        }
+    }
+
+    /**
      * @notice Validates that token can be recovered (not zero address and not a reward token)
      * @param reward Reward structure containing token list
      * @param token Address of the token to recover
@@ -1094,6 +1142,12 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         account.refund(reward, refundee);
 
         emit IntentRefunded(intentHash, refundee);
+
+        // CEI: run the keeper-committed REFUND hook LAST — after the escrow is returned to the refundee and
+        // the status is terminal (Refunded). Best-effort (try/catch): a reverting or malformed refund hook
+        // is caught so it can NEVER permanently lock the keeper's refund (the core refund is already
+        // committed and irreversible before the hook runs).
+        _runHook(intentHash, address(account), reward.hooks, HOOK_REFUND);
     }
 
     /**

--- a/contracts/account/Account.sol
+++ b/contracts/account/Account.sol
@@ -9,7 +9,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import {IAccount} from "../interfaces/IAccount.sol";
 import {IPermit} from "../interfaces/IPermit.sol";
 import {IPolicy} from "../interfaces/IPolicy.sol";
-import {Reward, RewardToken} from "../types/Intent.sol";
+import {Reward, RewardToken, Hook} from "../types/Intent.sol";
 
 /**
  * @title Account
@@ -251,6 +251,59 @@ contract Account is IAccount {
                 returndatacopy(add(out, 0x40), 0, len)
                 return(out, add(0x40, len))
             }
+        }
+    }
+
+    /**
+     * @notice Runs a keeper-committed delegate hook against this Account via `delegatecall`.
+     * @dev `onlyPortal`. Reuses the {execute} sandbox exactly: the default `hooks` encoding is
+     *      `abi.encode(Hook[2])`, and `index` selects the slot (0 = reward hook, run after a successful
+     *      settle; 1 = refund hook, run after a refund). An empty `hooks` (length 0) or a slot with
+     *      `target == address(0)` returns without doing anything. Otherwise it stores the hook target in
+     *      {_IN_EXECUTE_SLOT} (so the gated {fallback} forwards any in-flight callback to it),
+     *      `delegatecall`s `Hook.target` with `Hook.data`, and clears the slot on success; on failure the
+     *      raw revert is bubbled verbatim and the slot write rolls back with the frame.
+     *
+     *      The heavy work (decoding `Hook[2]`, the delegatecall) lives HERE, in the Account, not the Portal:
+     *      the Portal only wraps `runHook` in a try/catch, so a malformed `hooks` (a decode revert) or a
+     *      reverting hook is caught there and can never break settle/refund. Decoding into a fixed-size
+     *      `Hook[2]` means a `hooks` that is non-empty but not a valid `Hook[2]` reverts here (and is
+     *      caught by the Portal), never silently mis-parsed.
+     * @param hooks The opaque `Reward.hooks` bytes (default: `abi.encode(Hook[2])`)
+     * @param index Which hook slot to run (0 = reward, 1 = refund)
+     */
+    function runHook(
+        bytes calldata hooks,
+        uint256 index
+    ) external onlyPortal {
+        if (hooks.length == 0) {
+            return;
+        }
+        Hook[2] memory parsed = abi.decode(hooks, (Hook[2]));
+        address target = parsed[index].target;
+        if (target == address(0)) {
+            return;
+        }
+        bytes memory data = parsed[index].data;
+        assembly ("memory-safe") {
+            // Mark in-execute with the hook target so {fallback} forwards in-flight callbacks to it.
+            sstore(_IN_EXECUTE_SLOT, target)
+            let ok := delegatecall(
+                gas(),
+                target,
+                add(data, 0x20),
+                mload(data),
+                0,
+                0
+            )
+            if iszero(ok) {
+                // Bubble the raw revert verbatim, rolling back the slot write above.
+                let p := mload(0x40)
+                returndatacopy(p, 0, returndatasize())
+                revert(p, returndatasize())
+            }
+            // Success: clear the in-execute slot. The hook's return data is not needed by the Portal.
+            sstore(_IN_EXECUTE_SLOT, 0)
         }
     }
 

--- a/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
@@ -219,7 +219,8 @@ contract DepositAddress_CCTPMint_Arc is BaseDepositAddress {
             deadline: deadline,
             keeper: depositor,
             prover: arcProverAddress,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         // Combine into Intent. Published on this (source) chain; fulfilled on Arc.
@@ -313,7 +314,8 @@ contract DepositAddress_CCTPMint_Arc is BaseDepositAddress {
             deadline: deadline,
             keeper: depositor,
             prover: proverAddress,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         // Combine into Intent. CCTP burn is fulfilled locally on the source chain (source == dest).

--- a/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
@@ -281,7 +281,8 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             deadline: deadline,
             keeper: depositor,
             prover: destinationProverAddress,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         // Combine into Intent. Published on this (source) chain; fulfilled on the destination.
@@ -384,7 +385,8 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
             deadline: deadline,
             keeper: depositor,
             prover: proverAddress,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         // Combine into Intent. CCTP burn is fulfilled locally on the source chain (source == dest).

--- a/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
+++ b/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
@@ -110,7 +110,8 @@ contract DepositAddress_USDCTransfer_Solana is BaseDepositAddress {
             deadline: uint64(block.timestamp + deadlineDuration),
             keeper: depositor, // Depositor receives refunds through normal intent flow
             prover: prover,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         // Approve Portal to spend tokens

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -38,6 +38,19 @@ interface IAccount {
     ) external payable returns (bytes memory);
 
     /**
+     * @notice Runs a keeper-committed delegate hook against this Account via `delegatecall`
+     * @dev Decodes `hooks` as the default `abi.encode(Hook[2])` and runs slot `index` (0 = reward hook,
+     *      1 = refund hook) in the SAME gated-execute sandbox as {execute}: it sets the in-execute slot,
+     *      `delegatecall`s `Hook.target` with `Hook.data`, and clears the slot, so an in-flight callback is
+     *      forwarded to the hook via the gated fallback. An empty `hooks` (length 0) or a slot with
+     *      `target == address(0)` is a no-op. On hook revert the raw revert data is bubbled verbatim (the
+     *      Portal wraps the call in try/catch so a reverting hook cannot break settle/refund).
+     * @param hooks The opaque `Reward.hooks` bytes (default: `abi.encode(Hook[2])`)
+     * @param index Which hook slot to run (0 = reward, 1 = refund)
+     */
+    function runHook(bytes calldata hooks, uint256 index) external;
+
+    /**
      * @notice Funds the account with reward legs
      * @param reward The reward structure containing the legs
      * @param targets Per-leg escrow targets, index-aligned with `reward.tokens`

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -139,6 +139,19 @@ interface IIntentSource {
     event IntentRefunded(bytes32 intentHash, address indexed refundee);
 
     /**
+     * @notice A keeper-committed reward/refund hook reverted (or its `hooks` data was malformed) and was
+     *         caught, so the core settle/refund still completed
+     * @dev Hook invocation is best-effort by design (CEI: the core reward payout / refund and the terminal
+     *      status are committed BEFORE the hook runs). A reverting hook therefore cannot strand an
+     *      already-paid solver or permanently lock a keeper's refund — it only forgoes the hook's own
+     *      side effects. This event surfaces that a hook did not run to completion. The hook is
+     *      keeper-committed (inside the reward hash) and so is self-harm for a hostile keeper.
+     * @param intentHash The hash of the intent whose hook reverted
+     * @param index Which hook slot reverted (0 = reward hook on settle, 1 = refund hook on refund)
+     */
+    event HookReverted(bytes32 indexed intentHash, uint256 index);
+
+    /**
      * @notice Signals successful token recovery from an intent account
      * @dev Emitted when tokens that were accidentally sent to a account are recovered
      *      Only tokens not part of the intent's reward structure can be recovered

--- a/contracts/types/ERC7683.sol
+++ b/contracts/types/ERC7683.sol
@@ -127,5 +127,5 @@ struct OrderData {
 
 // EIP712 type hash (referenced struct types sorted alphabetically per EIP-712)
 bytes32 constant ORDER_DATA_TYPEHASH = keccak256(
-    "OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens)RewardToken(address token,uint256 rate,uint256 flat)"
+    "OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)"
 );

--- a/contracts/types/Intent.sol
+++ b/contracts/types/Intent.sol
@@ -98,6 +98,20 @@ struct Route {
 }
 
 /**
+ * @notice A single delegate hook: `target` is delegatecalled by the intent's Account with `data`.
+ * @dev Encoded inside `Reward.hooks` (see below). Because the Account reaches `target` by
+ *      `delegatecall`, the hook runs AS the intent's own Account (`address(this)`, balances and approvals
+ *      are the Account's) and the gated Account fallback forwards any in-flight callbacks to it — the same
+ *      execution sandbox as the route `runtime`. A `target == address(0)` slot is a no-op (skipped).
+ * @param target The delegatecall target the Account runs (keeper-committed via the reward hash).
+ * @param data The opaque calldata forwarded to `target` verbatim.
+ */
+struct Hook {
+    address target;
+    bytes data;
+}
+
+/**
  * @notice Defines the reward and validation parameters for cross-chain execution
  * @dev `tokens` is POSITIONALLY PAIRED with `Route.minTokens` for its first `minTokens.length` entries and
  *      `tokens.length >= minTokens.length`. Legs split into PAIRED (rate+flat on `fulfilled[j]`) and EXTRA
@@ -106,12 +120,21 @@ struct Route {
  * @param keeper Address that created the intent and receives remainders / refunds
  * @param prover Address of the prover (settlement policy) that must approve execution
  * @param tokens Reward legs escrowed in the Account: paired with `Route.minTokens` then optional flat-only extras
+ * @param hooks Opaque, keeper-committed delegate-hook data run by the Account after the reward/refund core
+ *        effects. Empty (`length == 0`) means NO hooks (the common case). The DEFAULT encoding is
+ *        `abi.encode(Hook[2])`: index 0 is invoked after a successful settle (the REWARD hook) and index
+ *        1 after a refund (the REFUND hook). A `Hook.target == address(0)` slot is skipped. `hooks` is
+ *        HASH-AFFECTING (part of `rewardHash` -> `intentHash`), so it is committed by the keeper and
+ *        inspectable by solvers before anyone fulfills; a hostile hook only makes the intent unattractive
+ *        (self-harm), exactly like the committed `route.runtime`. Hook invocation is best-effort: a
+ *        reverting hook is caught so it can never strand an already-paid solver or lock a keeper's refund.
  */
 struct Reward {
     uint64 deadline;
     address keeper;
     address prover;
     RewardToken[] tokens;
+    bytes hooks;
 }
 
 /**

--- a/docs/v3/05-policy-hooks.md
+++ b/docs/v3/05-policy-hooks.md
@@ -1,0 +1,56 @@
+# PR5 — reward.hooks: keeper-committed delegate hooks on settle/refund
+
+> Adds an opaque, hash-affecting `bytes hooks` to `Reward`. Re-authored onto PR4; mechanically it is
+> additive (rename-clean) — the hook machinery reuses PR3's Account delegatecall sandbox.
+
+## 1. `Reward.hooks` (default `Hook[2]`)
+
+`Reward` gains a trailing `bytes hooks`. Decoded on demand as the DEFAULT `abi.encode(Hook[2])` where
+`Hook { address target; bytes data; }`:
+
+- index 0 = the **reward hook** — run after a successful `settle`.
+- index 1 = the **refund hook** — run after a `refund`.
+
+Empty `hooks` (`length == 0`) means NO hooks — the common case, short-circuited without an external call.
+A slot with `target == address(0)` is skipped. `hooks` is HASH-AFFECTING (`rewardHash` → `intentHash`),
+so it is keeper-committed and solver-inspectable before anyone fulfills; a hostile hook only makes the
+intent unattractive (self-harm), exactly like the committed `route.runtime`. It flows everywhere as opaque
+bytes via `abi.encode(reward)`; only the ERC-7683 `ORDER_DATA_TYPEHASH` needed a manual `,bytes hooks`.
+
+## 2. `Account.runHook` (reuses the execute sandbox)
+
+`Account.runHook(bytes hooks, uint256 index)` (`onlyPortal`) mirrors `execute`: it decodes `Hook[2]`,
+sets `_IN_EXECUTE_SLOT` to the hook target (so the gated `fallback` forwards in-flight callbacks to it),
+`delegatecall`s `Hook.target` with `Hook.data` — so the hook runs AS the intent's own Account
+(`address(this)` == the account, same sandbox as the route runtime) — and clears the slot. The heavy
+decode/delegatecall lives in the Account (~18 KB headroom), keeping the tight Portal small.
+
+## 3. CEI-LAST, best-effort invocation
+
+`IntentSource._settle` runs the reward hook LAST — after the claimant is paid, the residual swept to the
+keeper, and the status set to `Withdrawn`. `_refund` runs the refund hook after the escrow is returned and
+the status set to `Refunded`. Both wrap `runHook` in `try/catch` and emit `HookReverted(intentHash,
+index)` on failure. Because the `abi.decode` lives INSIDE `runHook` (behind the catch), a malformed
+`hooks` is caught too. So a reverting OR malformed hook can NEVER strand an already-paid solver or lock a
+keeper's refund — the money effects are committed and irreversible before the hook runs.
+
+## 4. No reentrancy guard (deliberate)
+
+CEI + terminal status + drained account + `onlyPortal` + per-intent Account isolation close the
+double-spend surface:
+- A hook that reenters `settle`/`refund` of THIS intent reverts on the terminal status (no double-pay).
+- A hook cannot re-drive the account's own `runHook`/`execute`: it runs AS the account, so `msg.sender`
+  to `runHook` is the account, not the Portal → `onlyPortal` blocks it (caught).
+- A hook cannot touch another intent's escrow: it runs AS its own account, which has no allowance over
+  any other per-intent account (transferFrom reverts, caught).
+
+## 5. Size
+
+Portal / PortalTron = 23,536 B (headroom 1,040) at `optimizer_runs = 20,000` (unchanged from PR4).
+
+## 6. Tests
+
+`test/core/PolicyHooks.t.sol` (12) + shared `test/core/HookHelpers.sol`: reward/refund hook runs as the
+account, zero-target skip, empty-hooks default, best-effort failure (reverting + malformed →
+`HookReverted`, money still moves), reentrancy containment, per-intent isolation, `runHook` `onlyPortal`.
+Full suite green: forge 620, hardhat 112, jest 42.

--- a/scripts/tron/run-evm-tron-intent.ts
+++ b/scripts/tron/run-evm-tron-intent.ts
@@ -253,6 +253,7 @@ async function createIntent(
       keeper: wallet.address,
       prover: evmProver,
       tokens: [{ token: evmUsdcAddr, rate: 0n, flat: REWARD_AMOUNT }],
+      hooks: '0x',
     },
   }
 
@@ -328,6 +329,7 @@ async function fulfillAndProveOnTron(
     keeper: keeperHex,
     prover: evmProver,
     tokens: [{ token: evmUsdcAddr, rate: 0n, flat: REWARD_AMOUNT }] as any[],
+    hooks: '0x',
   }
 
   const rewardHash = ethers.keccak256(

--- a/scripts/tron/run-tron-evm-intent.ts
+++ b/scripts/tron/run-tron-evm-intent.ts
@@ -336,6 +336,7 @@ async function fulfillAndProveOnEvm(
     keeper: keeperHex,
     prover: tronProver,
     tokens: [{ token: tronUsdtHex, rate: 0n, flat: REWARD_AMOUNT }],
+    hooks: '0x',
   }
 
   const rewardHash = ethers.keccak256(

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -157,7 +157,8 @@ contract BaseTest is Test {
             deadline: uint64(expiry),
             keeper: keeper,
             prover: address(prover),
-            tokens: rewardTokensMemory
+            tokens: rewardTokensMemory,
+            hooks: ""
         });
 
         // Setup intent (default is same-chain: source == destination == CHAIN_ID)

--- a/test/DestinationSettler.spec.ts
+++ b/test/DestinationSettler.spec.ts
@@ -130,6 +130,7 @@ describe('Destination Settler Test', (): void => {
           flat: amount,
         },
       ],
+      hooks: '0x',
     }
     const _chainId = Number((await owner.provider.getNetwork()).chainId)
     const _intent: Intent = {

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -336,6 +336,7 @@ describe('HyperPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -478,6 +479,7 @@ describe('HyperPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -603,6 +605,7 @@ describe('HyperPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -924,6 +927,7 @@ describe('HyperPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -1069,6 +1073,7 @@ describe('HyperPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -1248,6 +1253,7 @@ describe('HyperPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
 
       const destination = Number(
@@ -1318,6 +1324,7 @@ describe('HyperPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
       const intent1: Intent = {
         source: destination, // Current chain (same-chain default)
@@ -1467,6 +1474,7 @@ describe('HyperPolicy Test', (): void => {
           prover: await solver.getAddress(),
           deadline: (await time.latest()) + 3600,
           tokens: [{ token: await token.getAddress(), rate: 0n, flat: amount }],
+          hooks: '0x',
         },
       }
 

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -127,6 +127,7 @@ describe('Inbox Test', (): void => {
             flat: amount,
           },
         ],
+        hooks: '0x',
       },
     }
 

--- a/test/LayerZeroProver.spec.ts
+++ b/test/LayerZeroProver.spec.ts
@@ -392,6 +392,7 @@ describe('LayerZeroPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -515,6 +516,7 @@ describe('LayerZeroPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -750,6 +752,7 @@ describe('LayerZeroPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -890,6 +893,7 @@ describe('LayerZeroPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
 
       const destination = Number(
@@ -958,6 +962,7 @@ describe('LayerZeroPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
       const intent1: Intent = {
         source,
@@ -1082,6 +1087,7 @@ describe('LayerZeroPolicy Test', (): void => {
           prover: await solver.getAddress(),
           deadline: (await time.latest()) + 3600,
           tokens: [{ token: await token.getAddress(), rate: 0n, flat: amount }],
+          hooks: '0x',
         },
       }
 
@@ -1205,6 +1211,7 @@ describe('LayerZeroPolicy Test', (): void => {
         reward: {
           ...intent.reward,
           prover: await layerZeroProver.getAddress(),
+          hooks: '0x',
         },
       }
 

--- a/test/MetaProver.spec.ts
+++ b/test/MetaProver.spec.ts
@@ -403,6 +403,7 @@ describe('MetaPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -524,6 +525,7 @@ describe('MetaPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -632,6 +634,7 @@ describe('MetaPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -907,6 +910,7 @@ describe('MetaPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -1036,6 +1040,7 @@ describe('MetaPolicy Test', (): void => {
               flat: ethers.parseEther('0.01'),
             },
           ],
+          hooks: '0x',
         },
       }
 
@@ -1200,6 +1205,7 @@ describe('MetaPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
 
       const destination = Number(
@@ -1266,6 +1272,7 @@ describe('MetaPolicy Test', (): void => {
             flat: ethers.parseEther('0.01'),
           },
         ],
+        hooks: '0x',
       }
       const intent1: Intent = {
         source: destination,

--- a/test/OriginSettler.spec.ts
+++ b/test/OriginSettler.spec.ts
@@ -68,7 +68,7 @@ describe('Origin Settler Test', (): void => {
   // Use the correct ORDER_DATA_TYPEHASH from the contract (v3 rate+flat Reward shape)
   const ORDER_DATA_TYPEHASH = ethers.keccak256(
     ethers.toUtf8Bytes(
-      'OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens)RewardToken(address token,uint256 rate,uint256 flat)',
+      'OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)',
     ),
   )
 
@@ -186,6 +186,7 @@ describe('Origin Settler Test', (): void => {
         prover: await prover.getAddress(),
         deadline: expiry_fill,
         tokens: rewardTokens,
+        hooks: '0x',
       }
       intent = {
         source: sourceChainId,
@@ -214,7 +215,7 @@ describe('Origin Settler Test', (): void => {
         orderDataType: ORDER_DATA_TYPEHASH,
         orderData: AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[]),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
           ],
           [
             [
@@ -229,6 +230,7 @@ describe('Origin Settler Test', (): void => {
                   token.rate,
                   token.flat,
                 ]), // TokenAmount[] with proper structure
+                reward.hooks, // reward.hooks
               ],
               ethers.zeroPadValue(await inbox.getAddress(), 32), // routePortal
               expiry_fill, // routeDeadline
@@ -267,7 +269,7 @@ describe('Origin Settler Test', (): void => {
         orderDataType: ORDER_DATA_TYPEHASH,
         orderData: AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[]),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
           ],
           [
             [
@@ -282,6 +284,7 @@ describe('Origin Settler Test', (): void => {
                   token.rate,
                   token.flat,
                 ]), // TokenAmount[] with proper structure
+                reward.hooks, // reward.hooks
               ],
               ethers.zeroPadValue(await inbox.getAddress(), 32), // routePortal
               expiry_fill, // routeDeadline
@@ -330,7 +333,7 @@ describe('Origin Settler Test', (): void => {
         orderDataHash: keccak256(
           AbiCoder.defaultAbiCoder().encode(
             [
-              'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[]),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+              'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
             ],
             [
               [
@@ -345,6 +348,7 @@ describe('Origin Settler Test', (): void => {
                     token.rate,
                     token.flat,
                   ]), // TokenAmount[] with proper structure
+                  reward.hooks, // reward.hooks
                 ],
                 ethers.zeroPadValue(await inbox.getAddress(), 32), // routePortal
                 expiry_fill, // routeDeadline

--- a/test/TokenSecurityTests.spec.ts
+++ b/test/TokenSecurityTests.spec.ts
@@ -116,6 +116,7 @@ describe('Token Security Tests', () => {
       prover: await prover.getAddress(),
       deadline: expiry,
       tokens: rewardTokens,
+      hooks: '0x',
     }
 
     const intent = {
@@ -185,6 +186,7 @@ describe('Token Security Tests', () => {
       prover: await prover.getAddress(),
       deadline: expiry,
       tokens: rewardTokens,
+      hooks: '0x',
     }
 
     const intent = {
@@ -249,6 +251,7 @@ describe('Token Security Tests', () => {
       prover: await prover.getAddress(),
       deadline: expiry,
       tokens: rewardTokens,
+      hooks: '0x',
     }
 
     const intent = {
@@ -327,6 +330,7 @@ describe('Token Security Tests', () => {
       prover: await prover.getAddress(),
       deadline: expiry,
       tokens: rewardTokens,
+      hooks: '0x',
     }
 
     const intent = {

--- a/test/core/Account.t.sol
+++ b/test/core/Account.t.sol
@@ -123,7 +123,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.prank(portal);
@@ -147,7 +148,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.prank(portal);
@@ -170,7 +172,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -198,7 +201,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.deal(portal, 1 ether);
@@ -222,7 +226,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -252,7 +257,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -282,7 +288,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.prank(unauthorized);
@@ -304,7 +311,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -332,7 +340,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 500);
@@ -364,7 +373,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -394,7 +404,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -428,7 +439,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -458,7 +470,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -486,7 +499,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.prank(portal);
@@ -502,7 +516,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -530,7 +545,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -553,7 +569,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 500);
@@ -572,7 +589,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.deal(address(account), 1 ether);
@@ -595,7 +613,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -628,7 +647,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.prank(unauthorized);
@@ -647,7 +667,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.warp(block.timestamp + 2000);
@@ -665,7 +686,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -695,7 +717,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -720,7 +743,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.warp(block.timestamp + 2000);
@@ -741,7 +765,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(keeper, 1000);
@@ -779,7 +804,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -807,7 +833,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.warp(block.timestamp + 2000);
@@ -828,7 +855,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         vm.warp(block.timestamp + 2000);
@@ -894,7 +922,8 @@ contract AccountTest is Test {
             keeper: keeper, // Normal address that accepts ETH
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -931,7 +960,8 @@ contract AccountTest is Test {
             keeper: keeper, // Normal keeper address
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         token.mint(address(account), 1000);
@@ -1000,7 +1030,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         // Base Account uses SafeERC20 and will revert when TronUSDTMock.transfer()
@@ -1039,7 +1070,8 @@ contract AccountTest is Test {
             keeper: keeper,
             prover: address(prover),
             deadline: uint64(block.timestamp + 1000),
-            tokens: tokens
+            tokens: tokens,
+            hooks: ""
         });
 
         // AccountTron uses a raw call so it succeeds even though

--- a/test/core/HookHelpers.sol
+++ b/test/core/HookHelpers.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IAccount} from "../../contracts/interfaces/IAccount.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/**
+ * @notice External recorder a delegate hook can call so a test can observe that the hook ran, and that
+ *         it ran AS the intent's own Account (`lastCaller` == the account, because the hook is
+ *         delegatecalled).
+ */
+contract HookBeacon {
+    uint256 public rewardPings;
+    uint256 public refundPings;
+    address public lastCaller;
+
+    function pingReward() external {
+        rewardPings++;
+        lastCaller = msg.sender;
+    }
+
+    function pingRefund() external {
+        refundPings++;
+        lastCaller = msg.sender;
+    }
+}
+
+/**
+ * @notice Logic contracts delegatecalled by the Account as the reward/refund hook. Under delegatecall
+ *         these run in the Account's context (`address(this)` == the account), exactly like the route
+ *         runtime.
+ */
+contract HookLogic {
+    /// @dev Pings the beacon (observably runs as the account).
+    function reward(address beacon) external {
+        HookBeacon(beacon).pingReward();
+    }
+
+    function refund(address beacon) external {
+        HookBeacon(beacon).pingRefund();
+    }
+
+    /// @dev A hook that always reverts.
+    function boom() external pure {
+        revert("hook boom");
+    }
+
+    /// @dev Attempts to reenter the Portal (e.g. settle/refund); reverts if that call reverts.
+    function reenter(address portal, bytes calldata cd) external {
+        (bool ok, ) = portal.call(cd);
+        require(ok, "reenter reverted");
+    }
+
+    /// @dev Attempts to re-invoke the Account's own execute machinery (blocked by onlyPortal).
+    function reinvokeExecute(bytes calldata hooks) external {
+        IAccount(address(this)).runHook(hooks, 0);
+    }
+
+    /// @dev Attempts to move another intent's escrow (blocked: no allowance from the other account).
+    function steal(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) external {
+        IERC20(token).transferFrom(from, to, amount);
+    }
+}

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -203,7 +203,8 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -263,7 +264,8 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -343,7 +345,8 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -661,7 +664,8 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0)
+                    tokens: new RewardToken[](0),
+                    hooks: ""
                 })
             });
     }
@@ -730,7 +734,8 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0)
+                    tokens: new RewardToken[](0),
+                    hooks: ""
                 })
             });
     }
@@ -814,7 +819,8 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0)
+                    tokens: new RewardToken[](0),
+                    hooks: ""
                 })
             });
     }

--- a/test/core/InboxAdvanced.t.sol
+++ b/test/core/InboxAdvanced.t.sol
@@ -104,7 +104,8 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -163,7 +164,8 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -227,7 +229,8 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -475,7 +478,8 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0)
+                tokens: new RewardToken[](0),
+                hooks: ""
             })
         });
 
@@ -606,7 +610,8 @@ contract InboxAdvancedTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0)
+                    tokens: new RewardToken[](0),
+                    hooks: ""
                 })
             });
     }

--- a/test/core/PolicyHooks.t.sol
+++ b/test/core/PolicyHooks.t.sol
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../BaseTest.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {IAccount} from "../../contracts/interfaces/IAccount.sol";
+import {Hook} from "../../contracts/types/Intent.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {HookBeacon, HookLogic} from "./HookHelpers.sol";
+
+/**
+ * @title PolicyHooksTest
+ * @notice Tests for keeper-committed `reward.hooks` delegate hooks (PR5): the default `Hook[2]`
+ *         encoding, invocation on settle (reward hook) / refund (refund hook), the empty-hooks default,
+ *         and the money-safety failure semantics (best-effort, CEI, reentrancy containment, isolation).
+ */
+contract PolicyHooksTest is BaseTest {
+    HookBeacon internal beacon;
+    HookLogic internal hookLogic;
+
+    function setUp() public override {
+        super.setUp();
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        _fundUserNative(keeper, 10 ether);
+        beacon = new HookBeacon();
+        hookLogic = new HookLogic();
+    }
+
+    // --- helpers -------------------------------------------------------------------------------------
+
+    /// @notice Encode the default `Reward.hooks` = `abi.encode(Hook[2])` (index 0 reward, index 1 refund).
+    function _hooks(
+        address rTarget,
+        bytes memory rData,
+        address fTarget,
+        bytes memory fData
+    ) internal pure returns (bytes memory) {
+        Hook[2] memory h;
+        h[0] = Hook({target: rTarget, data: rData});
+        h[1] = Hook({target: fTarget, data: fData});
+        return abi.encode(h);
+    }
+
+    function _rewardHookOnly(
+        address target,
+        bytes memory data
+    ) internal pure returns (bytes memory) {
+        return _hooks(target, data, address(0), "");
+    }
+
+    function _refundHookOnly(
+        address target,
+        bytes memory data
+    ) internal pure returns (bytes memory) {
+        return _hooks(address(0), "", target, data);
+    }
+
+    function _fundProveIntent() internal returns (bytes32 intentHash) {
+        _publishAndFund(intent, false);
+        intentHash = _hashIntent(intent);
+        _addProof(intentHash, CHAIN_ID, claimant);
+    }
+
+    function _settleDefault() internal {
+        vm.prank(otherPerson);
+        intentSource.settle(
+            intent.source,
+            intent.destination,
+            keccak256(abi.encode(intent.route)),
+            intent.reward,
+            bytes32(uint256(uint160(claimant))),
+            _defaultFulfilled()
+        );
+    }
+
+    function _refundDefault() internal {
+        intentSource.refund(
+            intent.source,
+            intent.destination,
+            keccak256(abi.encode(intent.route)),
+            intent.reward
+        );
+    }
+
+    // --- reward hook on settle ----------------------------------------------------------------------
+
+    function test_hooks_rewardHookRunsOnSettle_asTheAccount() public {
+        intent.reward.hooks = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.reward, (address(beacon)))
+        );
+        address sourceAccount = intentSource.intentAccountAddress(intent);
+
+        _fundProveIntent();
+
+        uint256 balA = tokenA.balanceOf(claimant);
+        uint256 balB = tokenB.balanceOf(claimant);
+        _settleDefault();
+
+        // Reward hook ran exactly once, as the intent's own (source/escrow) account.
+        assertEq(beacon.rewardPings(), 1, "reward hook should run once");
+        assertEq(beacon.refundPings(), 0, "refund hook must not run on settle");
+        assertEq(beacon.lastCaller(), sourceAccount, "hook must run AS the account");
+
+        // Core settle effects are intact (solver paid the full reward).
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+        assertEq(tokenB.balanceOf(claimant), balB + MINT_AMOUNT * 2);
+        assertEq(
+            uint256(intentSource.getRewardStatus(_hashIntent(intent))),
+            uint256(IIntentSource.Status.Withdrawn)
+        );
+    }
+
+    function test_hooks_rewardHookTargetZeroIsSkipped() public {
+        // Reward slot present but target == address(0) => skipped no-op.
+        intent.reward.hooks = _hooks(
+            address(0),
+            "",
+            address(hookLogic),
+            abi.encodeCall(HookLogic.refund, (address(beacon)))
+        );
+        _fundProveIntent();
+        _settleDefault();
+        assertEq(beacon.rewardPings(), 0, "zero-target reward hook is a no-op");
+    }
+
+    // --- refund hook on refund ----------------------------------------------------------------------
+
+    function test_hooks_refundHookRunsOnRefund_asTheAccount() public {
+        intent.reward.hooks = _refundHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.refund, (address(beacon)))
+        );
+        address sourceAccount = intentSource.intentAccountAddress(intent);
+
+        _publishAndFund(intent, false);
+        // Move past the reward deadline so refund is allowed.
+        _timeTravel(intent.reward.deadline + 1);
+
+        uint256 balA = tokenA.balanceOf(keeper);
+        _refundDefault();
+
+        assertEq(beacon.refundPings(), 1, "refund hook should run once");
+        assertEq(beacon.rewardPings(), 0, "reward hook must not run on refund");
+        assertEq(beacon.lastCaller(), sourceAccount, "hook must run AS the account");
+
+        // Escrow returned to the keeper.
+        assertEq(tokenA.balanceOf(keeper), balA + MINT_AMOUNT);
+        assertEq(
+            uint256(intentSource.getRewardStatus(_hashIntent(intent))),
+            uint256(IIntentSource.Status.Refunded)
+        );
+    }
+
+    // --- empty hooks (the common case) --------------------------------------------------------------
+
+    function test_hooks_emptyHooksSettleUnaffected() public {
+        // Default intent carries empty hooks.
+        assertEq(intent.reward.hooks.length, 0);
+        _fundProveIntent();
+
+        uint256 balA = tokenA.balanceOf(claimant);
+        _settleDefault();
+
+        assertEq(beacon.rewardPings(), 0);
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+    }
+
+    function test_hooks_emptyHooksRefundUnaffected() public {
+        _publishAndFund(intent, false);
+        _timeTravel(intent.reward.deadline + 1);
+        uint256 balA = tokenA.balanceOf(keeper);
+        _refundDefault();
+        assertEq(beacon.refundPings(), 0);
+        assertEq(tokenA.balanceOf(keeper), balA + MINT_AMOUNT);
+    }
+
+    // --- failure semantics: best-effort, never strands money ----------------------------------------
+
+    function test_hooks_revertingRewardHookStillPaysSolver() public {
+        intent.reward.hooks = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.boom, ())
+        );
+        bytes32 intentHash = _fundProveIntent();
+
+        uint256 balA = tokenA.balanceOf(claimant);
+        uint256 balB = tokenB.balanceOf(claimant);
+
+        // Settle still succeeds and emits HookReverted for the reward slot (index 0).
+        _expectEmit();
+        emit IIntentSource.HookReverted(intentHash, 0);
+        _settleDefault();
+
+        // Solver was paid the full reward despite the reverting hook.
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+        assertEq(tokenB.balanceOf(claimant), balB + MINT_AMOUNT * 2);
+        assertEq(
+            uint256(intentSource.getRewardStatus(intentHash)),
+            uint256(IIntentSource.Status.Withdrawn)
+        );
+    }
+
+    function test_hooks_revertingRefundHookDoesNotLockRefund() public {
+        intent.reward.hooks = _refundHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.boom, ())
+        );
+        _publishAndFund(intent, false);
+        bytes32 intentHash = _hashIntent(intent);
+        _timeTravel(intent.reward.deadline + 1);
+
+        uint256 balA = tokenA.balanceOf(keeper);
+
+        _expectEmit();
+        emit IIntentSource.HookReverted(intentHash, 1);
+        _refundDefault();
+
+        // Keeper's refund completed despite the reverting refund hook.
+        assertEq(tokenA.balanceOf(keeper), balA + MINT_AMOUNT);
+        assertEq(
+            uint256(intentSource.getRewardStatus(intentHash)),
+            uint256(IIntentSource.Status.Refunded)
+        );
+    }
+
+    function test_hooks_malformedHooksCaughtOnSettle() public {
+        // Non-empty hooks that are NOT a valid abi.encode(Hook[2]) => decode reverts in the Account, caught.
+        intent.reward.hooks = hex"deadbeef";
+        bytes32 intentHash = _fundProveIntent();
+
+        uint256 balA = tokenA.balanceOf(claimant);
+
+        _expectEmit();
+        emit IIntentSource.HookReverted(intentHash, 0);
+        _settleDefault();
+
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+        assertEq(
+            uint256(intentSource.getRewardStatus(intentHash)),
+            uint256(IIntentSource.Status.Withdrawn)
+        );
+    }
+
+    // --- reentrancy containment ---------------------------------------------------------------------
+
+    function test_hooks_hookCannotReinvokeAccountExecute() public {
+        // Reward hook tries to re-drive the Account's runHook (execute machinery) directly. It runs AS the
+        // account, so msg.sender to runHook is the account, not the Portal => onlyPortal blocks it => the
+        // hook reverts and is caught; the solver is still paid exactly once.
+        bytes memory inner = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.reward, (address(beacon)))
+        );
+        intent.reward.hooks = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.reinvokeExecute, (inner))
+        );
+        bytes32 intentHash = _fundProveIntent();
+
+        uint256 balA = tokenA.balanceOf(claimant);
+
+        _expectEmit();
+        emit IIntentSource.HookReverted(intentHash, 0);
+        _settleDefault();
+
+        assertEq(beacon.rewardPings(), 0, "inner re-invocation must be blocked");
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+    }
+
+    function test_hooks_reentrantSettleOnTerminalStatusRevertsNoDoubleSpend()
+        public
+    {
+        // Intent A: plain (empty hooks) — funded, proven, settled first so its status is terminal.
+        Intent memory intentA = intent;
+        intentA.route.salt = keccak256("A");
+        // fresh escrow for A
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        vm.prank(keeper);
+        intentSource.publishAndFund(intentA, false);
+        bytes32 hashA = _hashIntent(intentA);
+        _addProof(hashA, CHAIN_ID, claimant);
+        vm.prank(otherPerson);
+        intentSource.settle(
+            intentA.source,
+            intentA.destination,
+            keccak256(abi.encode(intentA.route)),
+            intentA.reward,
+            bytes32(uint256(uint160(claimant))),
+            _defaultFulfilled()
+        );
+        uint256 claimantAafter = tokenA.balanceOf(claimant);
+
+        // Intent B: reward hook reenters settle(A). A is already Withdrawn => the reentrant settle reverts
+        // (InvalidStatusForWithdrawal) => B's hook reverts => caught. A is NOT double-paid.
+        bytes memory reenterCd = abi.encodeCall(
+            IIntentSource.settle,
+            (
+                intentA.source,
+                intentA.destination,
+                keccak256(abi.encode(intentA.route)),
+                intentA.reward,
+                bytes32(uint256(uint160(claimant))),
+                _defaultFulfilled()
+            )
+        );
+        Intent memory intentB = intent;
+        intentB.route.salt = keccak256("B");
+        intentB.reward.hooks = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(HookLogic.reenter, (address(intentSource), reenterCd))
+        );
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        vm.prank(keeper);
+        intentSource.publishAndFund(intentB, false);
+        bytes32 hashB = _hashIntent(intentB);
+        _addProof(hashB, CHAIN_ID, claimant);
+
+        _expectEmit();
+        emit IIntentSource.HookReverted(hashB, 0);
+        vm.prank(otherPerson);
+        intentSource.settle(
+            intentB.source,
+            intentB.destination,
+            keccak256(abi.encode(intentB.route)),
+            intentB.reward,
+            bytes32(uint256(uint160(claimant))),
+            _defaultFulfilled()
+        );
+
+        // A was not double-paid by the reentrant settle; B paid once.
+        assertEq(
+            tokenA.balanceOf(claimant),
+            claimantAafter + MINT_AMOUNT,
+            "A must not be double-paid; B paid once"
+        );
+    }
+
+    // --- per-intent isolation -----------------------------------------------------------------------
+
+    function test_hooks_cannotTouchAnotherIntentsEscrow() public {
+        // Intent Y: a LIVE, funded intent whose escrow must be untouchable by another intent's hook.
+        Intent memory intentY = intent;
+        intentY.route.salt = keccak256("Y");
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        vm.prank(keeper);
+        intentSource.publishAndFund(intentY, false);
+        address accountY = intentSource.intentAccountAddress(intentY);
+        uint256 accountYbalB = tokenB.balanceOf(accountY);
+        assertGt(accountYbalB, 0);
+
+        // Intent X: reward hook attempts to pull Y's tokenB escrow. It runs AS X's account, which has no
+        // allowance over Y's account, so the transferFrom reverts => caught. Y's escrow is untouched.
+        intent.route.salt = keccak256("X");
+        intent.reward.hooks = _rewardHookOnly(
+            address(hookLogic),
+            abi.encodeCall(
+                HookLogic.steal,
+                (address(tokenB), accountY, otherPerson, accountYbalB)
+            )
+        );
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        vm.prank(keeper);
+        intentSource.publishAndFund(intent, false);
+        bytes32 hashX = _hashIntent(intent);
+        _addProof(hashX, CHAIN_ID, claimant);
+
+        uint256 balA = tokenA.balanceOf(claimant);
+        _expectEmit();
+        emit IIntentSource.HookReverted(hashX, 0);
+        _settleDefault();
+
+        // Y's escrow intact; X's solver paid.
+        assertEq(
+            tokenB.balanceOf(accountY),
+            accountYbalB,
+            "Y escrow must be intact"
+        );
+        assertEq(tokenA.balanceOf(claimant), balA + MINT_AMOUNT);
+    }
+
+    // --- Account entrypoint gating ------------------------------------------------------------------
+
+    function test_hooks_runHookIsOnlyPortal() public {
+        _fundProveIntent();
+        address sourceAccount = intentSource.intentAccountAddress(intent);
+        // Settle first so the account is deployed.
+        _settleDefault();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccount.NotPortalCaller.selector,
+                address(this)
+            )
+        );
+        IAccount(sourceAccount).runHook(
+            _rewardHookOnly(
+                address(hookLogic),
+                abi.encodeCall(HookLogic.reward, (address(beacon)))
+            ),
+            0
+        );
+    }
+}

--- a/test/core/RewardLegs.t.sol
+++ b/test/core/RewardLegs.t.sol
@@ -68,7 +68,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
 
         _intent = Intent({
@@ -113,7 +114,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(expiry),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
 
         uint256[] memory fulfilled = new uint256[](1);
@@ -132,7 +134,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(expiry),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
         uint256[] memory fulfilled = new uint256[](1);
         fulfilled[0] = 10;
@@ -354,7 +357,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(expiry),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
         Intent memory _intent = Intent({
             source: uint64(block.chainid),
@@ -388,7 +392,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(expiry),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
         Intent memory _intent = Intent({
             source: uint64(block.chainid),
@@ -432,7 +437,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(prover),
-            tokens: legs
+            tokens: legs,
+            hooks: ""
         });
         Intent memory _intent = Intent({
             source: uint64(block.chainid),
@@ -474,7 +480,8 @@ contract RewardLegsTest is BaseTest {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(prover),
-            tokens: new RewardToken[](0)
+            tokens: new RewardToken[](0),
+            hooks: ""
         });
         Intent memory _intent = Intent({
             source: uint64(block.chainid),

--- a/test/core/SameChainAndGates.t.sol
+++ b/test/core/SameChainAndGates.t.sol
@@ -96,7 +96,8 @@ contract SameChainAndGatesTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: prover,
-                    tokens: legs
+                    tokens: legs,
+                    hooks: ""
                 })
             });
     }
@@ -237,7 +238,8 @@ contract SameChainAndGatesTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(localPolicy),
-                tokens: legs
+                tokens: legs,
+                hooks: ""
             })
         });
         _fund(_intent);

--- a/test/deposit/DepositIntegration_CCTPMint.t.sol
+++ b/test/deposit/DepositIntegration_CCTPMint.t.sol
@@ -459,7 +459,8 @@ contract DepositIntegration_CCTPMintTest is Test {
                     deadline: rewardDeadline,
                     keeper: keeper,
                     prover: proverAddr,
-                    tokens: rewardTokens
+                    tokens: rewardTokens,
+                    hooks: ""
                 });
 
                 break; // first IntentPublished = Intent 2

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -102,7 +102,8 @@ contract LocalProverTest is Test {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: proverAddress,
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         return
@@ -347,7 +348,8 @@ contract LocalProverTest is Test {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(localProver),
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         Intent memory _intent = Intent({
@@ -418,7 +420,8 @@ contract LocalProverTest is Test {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(localProver),
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         Intent memory _intent = Intent({
@@ -490,7 +493,8 @@ contract LocalProverTest is Test {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(localProver),
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         Intent memory _intent = Intent({
@@ -842,7 +846,8 @@ contract LocalProverTest is Test {
             deadline: uint64(block.timestamp + 2000),
             keeper: keeper,
             prover: address(localProver),
-            tokens: rewardTokens
+            tokens: rewardTokens,
+            hooks: ""
         });
 
         Intent memory _intent = Intent({

--- a/test/source/IntentSource.t.sol
+++ b/test/source/IntentSource.t.sol
@@ -1116,7 +1116,8 @@ contract IntentSourceTest is BaseTest {
                     deadline: _evmIntent.reward.deadline,
                     keeper: _evmIntent.reward.keeper,
                     prover: _evmIntent.reward.prover,
-                    tokens: evmRewardTokens
+                    tokens: evmRewardTokens,
+                    hooks: ""
                 })
             });
     }

--- a/utils/EcoERC7683.ts
+++ b/utils/EcoERC7683.ts
@@ -47,7 +47,7 @@ export type OnchainCrosschainOrder = {
   orderData: OnchainCrosschainOrderData
 }
 
-// v3 Reward struct: (uint64 deadline, address keeper, address prover, RewardToken[] tokens)
+// v3 Reward struct: (uint64 deadline, address keeper, address prover, RewardToken[] tokens, bytes hooks)
 // where RewardToken is (address token, uint256 rate, uint256 flat).
 const RewardStructComponents = [
   { name: 'deadline', type: 'uint64' },
@@ -62,6 +62,7 @@ const RewardStructComponents = [
       { name: 'flat', type: 'uint256' },
     ],
   },
+  { name: 'hooks', type: 'bytes' },
 ]
 
 // ERC-7683 Output struct: (bytes32 token, uint256 amount, bytes32 recipient, uint256 chainId)

--- a/utils/intent.ts
+++ b/utils/intent.ts
@@ -33,11 +33,20 @@ export type Route = {
   minTokens: TokenAmount[]
 }
 
+// A single delegate hook: `target` is delegatecalled by the intent's Vault with `data`.
+export type Hook = {
+  target: string
+  data: string
+}
+
 export type Reward = {
   keeper: string
   prover: string
   deadline: number | bigint
   tokens: RewardToken[]
+  // Opaque creator-committed delegate-hook data (hash-affecting). Empty ('0x') = no hooks.
+  // Default encoding is abi.encode(Hook[2]): index 0 = reward hook (settle), index 1 = refund hook.
+  hooks: string
 }
 
 // v3 / Model C Intent: gained a `source` field (origin chain id), hashed FIRST (before `destination`)
@@ -80,6 +89,11 @@ const RouteStruct = [
   },
 ]
 
+const HookComponents = [
+  { name: 'target', type: 'address' },
+  { name: 'data', type: 'bytes' },
+]
+
 const RewardStruct = [
   { name: 'deadline', type: 'uint64' },
   { name: 'keeper', type: 'address' },
@@ -89,7 +103,25 @@ const RewardStruct = [
     type: 'tuple[]',
     components: RewardTokenComponents,
   },
+  { name: 'hooks', type: 'bytes' },
 ]
+
+/**
+ * Encodes the default `Reward.hooks` payload: `abi.encode(Hook[2])` with
+ * index 0 = the reward hook (invoked on settle) and index 1 = the refund hook (invoked on refund).
+ * A `{ target: ZeroAddress, data: '0x' }` slot is a skipped no-op.
+ */
+export function encodeHooks(rewardHook: Hook, refundHook: Hook) {
+  return AbiCoder.defaultAbiCoder().encode(
+    [
+      {
+        type: 'tuple[2]',
+        components: HookComponents,
+      },
+    ],
+    [[rewardHook, refundHook]],
+  )
+}
 
 const IntentStruct = [
   {

--- a/utils/intent.ts
+++ b/utils/intent.ts
@@ -33,7 +33,7 @@ export type Route = {
   minTokens: TokenAmount[]
 }
 
-// A single delegate hook: `target` is delegatecalled by the intent's Vault with `data`.
+// A single delegate hook: `target` is delegatecalled by the intent's Account with `data`.
 export type Hook = {
   target: string
   data: string


### PR DESCRIPTION
## Summary
Stacked on PR4 (#399). Adds `Reward.hooks` (bytes) — an opaque, keeper-committed field consulted on settle and refund:

- Default encoding is `abi.encode(Hook[2])`, `Hook{address target; bytes data}` — index 0 runs after a successful settle (post-payout), index 1 after a refund (post-refund).
- `Account.runHook(hooks, index)` (onlyPortal) delegatecalls the hook, mirroring `Account.execute`'s in-execute-slot + gated-fallback mechanism.
- Invocation is strictly CEI-last: status is already terminal and core effects (payout/refund) already committed before the hook runs, via `try/catch` — a reverting or malformed hook can never undo or block the already-committed settle/refund (`HookReverted` event on failure).
- No reentrancy guard by design: CEI ordering + terminal status + `onlyPortal` + an already-drained account make one unnecessary, and this was independently re-verified during the adversarial sweep (no reentrancy or cross-intent contamination found).
- Hooks are keeper-authored and committed inside `rewardHash` — solver-inspectable before fulfilling, self-harm only if malicious.

## Test plan
- [x] `forge build` clean
- [x] `forge test`: 621 passed / 0 failed
- [x] `npx hardhat test`: 112 passing
- [x] `jest`: 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N25m45iFpZQEycqw7YFNsK