### PR TITLE
v3 PR6: lean content-addressed streaming policy + H2 anti-poison

### DIFF
--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -289,6 +289,15 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
             revert ProvidedAmountsLengthMismatch(providedAmounts.length, inLen);
         }
 
+        // H2 anti-poison: an intent with NO input legs AND NO reward asks a solver to provide nothing for
+        // no pay, so there is no honest fulfill — and recording one would permanently occupy the prover's
+        // fulfillment store, bricking a REUSABLE deposit address for every later deposit. The only
+        // legitimate way to run such an Account's committed `runtime(payload)` is the owner-gated
+        // {Inbox-executeAsOwner} (cross-chain) / {IIntentSource-executeAsOwner} (source). Reject it here.
+        if (route.minTokens.length == 0 && reward.tokens.length == 0) {
+            revert NothingToFulfill();
+        }
+
         emit IntentFulfilled(intentHash, claimant);
 
         // The DESTINATION (execution) Account is keyed by this chain id (== intent.destination). For a

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -7,6 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {IPolicy} from "./interfaces/IPolicy.sol";
+import {IStreamingPolicy} from "./interfaces/IStreamingPolicy.sol";
 import {IIntentSource} from "./interfaces/IIntentSource.sol";
 import {IAccount} from "./interfaces/IAccount.sol";
 import {IPermit} from "./interfaces/IPermit.sol";
@@ -757,6 +758,91 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         // Operate on the SOURCE (escrow) account — the keeper's own funds.
         address account = _getOrDeployAccount(intentHash, intent.source);
         return IAccount(account).execute{value: msg.value}(runtime, payload);
+    }
+
+    /**
+     * @notice Settles one or more STREAMING batches, paying each slice's committed claimant its reward.
+     * @dev See {IIntentSource-settleStream}. Thin wrapper: the {IStreamingPolicy} verifies + CONSUMES the
+     *      supplied batches (recomputing each `batchHash` / slice hash against its own store) and returns
+     *      the per-slice payouts; the SOURCE (escrow) Account then pays each slice in FULL (reverting if
+     *      under-funded, so a batch is never partially consumed — L1) WITHOUT sweeping the residual (it
+     *      funds later slices). The intent stays `Funded` (re-fulfillable); the policy's batch consumption
+     *      is the anti-replay, so no status transition is needed.
+     */
+    function settleStream(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward,
+        bytes calldata batchData
+    ) external onlySourceChain(source) {
+        (bytes32 intentHash, , ) = getIntentHash(
+            source,
+            destination,
+            routeHash,
+            reward
+        );
+
+        Status status = rewardStatuses[intentHash];
+        if (status != Status.Initial && status != Status.Funded) {
+            revert InvalidStatusForWithdrawal(status);
+        }
+
+        // The policy verifies + consumes the batches and returns the payout table as opaque bytes; the
+        // Account decodes + pays. The Portal never touches the nested StreamBatch[]/payout types (keeps its
+        // bytecode footprint tiny).
+        bytes memory payoutData = IStreamingPolicy(reward.prover)
+            .consumeStreamClaims(intentHash, reward, batchData);
+
+        IAccount(_getOrDeployAccount(intentHash, source)).withdrawStream(
+            reward,
+            payoutData
+        );
+
+        emit StreamSettled(intentHash);
+    }
+
+    /**
+     * @notice Closes a stream and reclaims the remaining escrow to the keeper (terminal, keeper-only).
+     * @dev See {IIntentSource-closeStream}. C2 anti-rug: gated on
+     *      {IStreamingPolicy-hasUnsettledFulfillment} being FALSE — it can NEVER sweep escrow owed to a
+     *      solver with a proven-but-unsettled batch (the keeper must let those settle first; settlement
+     *      is permissionless). Marks the stream closed on the policy, terminates the intent, and refunds
+     *      the remaining escrow. The refund hook is intentionally not invoked (this is the streaming
+     *      reclaim path, distinct from {refund}).
+     */
+    function closeStream(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward
+    ) external onlySourceChain(source) {
+        if (msg.sender != reward.keeper) {
+            revert NotKeeperCaller(msg.sender);
+        }
+
+        (bytes32 intentHash, , ) = getIntentHash(
+            source,
+            destination,
+            routeHash,
+            reward
+        );
+
+        if (
+            IStreamingPolicy(reward.prover).hasUnsettledFulfillment(intentHash)
+        ) {
+            revert PendingProofBlocksClose(intentHash);
+        }
+
+        IStreamingPolicy(reward.prover).markClosed(intentHash);
+        rewardStatuses[intentHash] = Status.Refunded;
+
+        IAccount(_getOrDeployAccount(intentHash, source)).refund(
+            reward,
+            reward.keeper
+        );
+
+        emit StreamClosed(intentHash, reward.keeper);
     }
 
     /**

--- a/contracts/account/Account.sol
+++ b/contracts/account/Account.sol
@@ -154,6 +154,75 @@ contract Account is IAccount {
     }
 
     /**
+     * @notice Pays streaming slices to their claimants in full, WITHOUT sweeping the residual
+     * @dev The streaming analogue of {withdraw}. The streaming policy has already verified + consumed the
+     *      batches and computed the per-leg payouts, so this only moves money: each slice's leg is paid in
+     *      FULL to its claimant. If the account cannot cover a leg the call reverts
+     *      ({StreamSlicePayoutExceedsBalance}) so the whole settle rolls back and the batch is never
+     *      partially consumed — the shortfall is recoverable after the keeper tops up (L1). The residual
+     *      is deliberately NOT swept: it funds later slices, and the keeper reclaims it via
+     *      {IIntentSource-closeStream}/{IIntentSource-refund}.
+     * @param reward The reward structure (its `tokens` legs define the payout columns)
+     * @param payoutData `abi.encode(address[] claimants, uint256[][] payouts)` from the streaming policy
+     *        (forwarded verbatim by the Portal; decoded here so the Portal never handles the nested type)
+     */
+    function withdrawStream(
+        Reward calldata reward,
+        bytes calldata payoutData
+    ) external onlyPortal {
+        // Decode the nested payout table HERE (not in the Portal). The streaming policy produced it.
+        (address[] memory claimants, uint256[][] memory payouts) = abi.decode(
+            payoutData,
+            (address[], uint256[][])
+        );
+
+        uint256 sliceCount = claimants.length;
+        if (payouts.length != sliceCount) {
+            revert StreamArrayLengthMismatch();
+        }
+        uint256 legCount = reward.tokens.length;
+
+        for (uint256 s; s < sliceCount; ++s) {
+            uint256[] memory slicePay = payouts[s];
+            address claimant = claimants[s];
+
+            for (uint256 j; j < legCount; ++j) {
+                uint256 pay = slicePay[j];
+                if (pay == 0) {
+                    continue;
+                }
+
+                address tokenAddr = reward.tokens[j].token;
+                if (tokenAddr == address(0)) {
+                    uint256 bal = address(this).balance;
+                    if (pay > bal) {
+                        revert StreamSlicePayoutExceedsBalance(
+                            address(0),
+                            pay,
+                            bal
+                        );
+                    }
+                    (bool ok, ) = claimant.call{value: pay}("");
+                    if (!ok) {
+                        revert NativeTransferFailed(claimant, pay);
+                    }
+                } else {
+                    IERC20 token = IERC20(tokenAddr);
+                    uint256 bal = token.balanceOf(address(this));
+                    if (pay > bal) {
+                        revert StreamSlicePayoutExceedsBalance(
+                            tokenAddr,
+                            pay,
+                            bal
+                        );
+                    }
+                    _transferToken(token, claimant, pay);
+                }
+            }
+        }
+    }
+
+    /**
      * @notice Refunds all account contents to a specified address
      * @param reward The reward structure containing the leg tokens
      * @param refundee Address to receive the refunded rewards

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -24,6 +24,22 @@ interface IAccount {
     /// @param caller The address whose callback was rejected
     error FallbackNotInExecute(address caller);
 
+    /// @notice Thrown when a streaming slice payout exceeds the account's live balance for a leg
+    /// @dev Streaming settlement is all-or-nothing per call: a batch is paid in full or reverts, so an
+    ///      under-funded batch is never partially consumed and its shortfall stays recoverable after a
+    ///      top-up (L1). `token == address(0)` denotes native.
+    /// @param token The under-funded leg token (native as address(0))
+    /// @param owed The amount owed
+    /// @param balance The live account balance
+    error StreamSlicePayoutExceedsBalance(
+        address token,
+        uint256 owed,
+        uint256 balance
+    );
+
+    /// @notice Streaming settle input arrays are mismatched in length
+    error StreamArrayLengthMismatch();
+
     /**
      * @notice Runs a runtime against this Account's own funds via `delegatecall`
      * @dev Delegatecalls `runtime` with `payload` (forwarded verbatim), bubbling the raw return/revert.
@@ -76,6 +92,24 @@ interface IAccount {
         Reward calldata reward,
         address claimant,
         uint256[] calldata fulfilled
+    ) external;
+
+    /**
+     * @notice Pays a set of streaming slices to their claimants, in full, WITHOUT sweeping the residual
+     * @dev The streaming analogue of {withdraw}: the policy ({IStreamingPolicy-consumeStreamClaims}) has
+     *      already verified + consumed the batches and computed the per-leg payouts, so this only moves
+     *      money. Each slice's leg is paid in FULL to its claimant; if the account cannot cover a leg the
+     *      call reverts ({StreamSlicePayoutExceedsBalance}), so the whole settle rolls back and the batch
+     *      is never partially consumed (L1: the shortfall is recoverable after the keeper tops up). The
+     *      residual is NOT swept — it funds later slices; the keeper reclaims it via
+     *      {IIntentSource-closeStream}/{IIntentSource-refund}.
+     * @param reward The reward structure (its `tokens` legs define the payout columns)
+     * @param payoutData `abi.encode(address[] claimants, uint256[][] payouts)` from the streaming policy
+     *        (forwarded verbatim by the Portal; decoded HERE so the Portal never handles the nested type)
+     */
+    function withdrawStream(
+        Reward calldata reward,
+        bytes calldata payoutData
     ) external;
 
     /**

--- a/contracts/interfaces/IInbox.sol
+++ b/contracts/interfaces/IInbox.sol
@@ -81,11 +81,11 @@ interface IInbox {
     error IntentNotFulfilled(bytes32 intentHash);
 
     /**
-     * @notice The intent has NOTHING to fulfill — both `Route.minOut` and `Reward.tokens` are empty.
+     * @notice The intent has NOTHING to fulfill — both `Route.minTokens` and `Reward.tokens` are empty.
      * @dev Such an intent asks a solver to deliver nothing for no reward, so no honest fulfill exists; the
      *      only legitimate way to run its committed `runtime(payload)` is the owner-gated
      *      {IIntentSource-executeAsOwner}. Rejecting it in {IInbox-fulfill} closes the deposit-address
-     *      griefing vector (H2): a third party front-runs an owner-cook (empty-reward, empty-minOut)
+     *      griefing vector (H2): a third party front-runs an owner-cook (empty-reward, empty-minTokens)
      *      intent to record a permanent fulfillment on the prover, which would lock the Account against
      *      re-fulfill/refund/executeAsOwner — bricking a REUSABLE deposit address for every later deposit.
      */

--- a/contracts/interfaces/IInbox.sol
+++ b/contracts/interfaces/IInbox.sol
@@ -81,6 +81,17 @@ interface IInbox {
     error IntentNotFulfilled(bytes32 intentHash);
 
     /**
+     * @notice The intent has NOTHING to fulfill — both `Route.minOut` and `Reward.tokens` are empty.
+     * @dev Such an intent asks a solver to deliver nothing for no reward, so no honest fulfill exists; the
+     *      only legitimate way to run its committed `runtime(payload)` is the owner-gated
+     *      {IIntentSource-executeAsOwner}. Rejecting it in {IInbox-fulfill} closes the deposit-address
+     *      griefing vector (H2): a third party front-runs an owner-cook (empty-reward, empty-minOut)
+     *      intent to record a permanent fulfillment on the prover, which would lock the Account against
+     *      re-fulfill/refund/executeAsOwner — bricking a REUSABLE deposit address for every later deposit.
+     */
+    error NothingToFulfill();
+
+    /**
      * @notice Chain ID is too large to fit in uint64
      * @param chainId The chain ID that is too large
      */

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -65,6 +65,13 @@ interface IIntentSource {
     /// @notice Thrown when caller is not the reward keeper
     error NotKeeperCaller(address caller);
 
+    /// @notice Thrown when {closeStream} is attempted while a proven-but-unsettled batch/slice exists
+    /// @dev C2 anti-rug: {closeStream} is a terminal keeper sweep, so — like {refund}/{executeAsOwner} —
+    ///      it must not drain escrow owed to a solver whose fulfillment is proven but not yet settled. The
+    ///      keeper must let the pending batch(es) settle first (settlement is permissionless).
+    /// @param intentHash The hash of the intent whose stream cannot yet be closed
+    error PendingProofBlocksClose(bytes32 intentHash);
+
     /**
      * @notice A source-side operation was attempted on a chain whose id is not the intent's committed
      *         `source`
@@ -150,6 +157,19 @@ interface IIntentSource {
      * @param index Which hook slot reverted (0 = reward hook on settle, 1 = refund hook on refund)
      */
     event HookReverted(bytes32 indexed intentHash, uint256 index);
+
+    /**
+     * @notice Signals a streaming settle paid out one or more slices to their claimants
+     * @param intentHash The hash of the streamed intent
+     */
+    event StreamSettled(bytes32 indexed intentHash);
+
+    /**
+     * @notice Signals the keeper closed a stream and reclaimed the remaining escrow
+     * @param intentHash The hash of the streamed intent
+     * @param keeper The keeper that received the remaining escrow
+     */
+    event StreamClosed(bytes32 indexed intentHash, address indexed keeper);
 
     /**
      * @notice Signals successful token recovery from an intent account
@@ -474,4 +494,47 @@ interface IIntentSource {
         address runtime,
         bytes calldata payload
     ) external payable returns (bytes memory);
+
+    /**
+     * @notice Settles one or more STREAMING batches, paying each slice's committed claimant its reward
+     * @dev The streaming analogue of {settle}. Delegates verification + consumption to the
+     *      {IStreamingPolicy}: it recomputes each supplied batch's commitment against the accumulated
+     *      unsettled set (cross-chain) or the destination slice array (same-chain), REMOVES the matched
+     *      entries (consume+delete), and returns the per-slice payouts. The (source/escrow) Account then
+     *      pays each slice in full (reverting if under-funded, so a batch is never partially consumed —
+     *      L1) WITHOUT sweeping the residual (it funds later slices). Permissionless: anyone may relay the
+     *      preimages; the money always goes to the committed claimants. The intent stays `Funded` (the
+     *      keeper reclaims the remainder via {closeStream}/{refund}).
+     * @param source Origin chain ID for the intent
+     * @param destination Destination chain ID for the intent
+     * @param routeHash The hash of the intent's route component
+     * @param reward The reward specification (must name a {IStreamingPolicy} at `reward.prover`)
+     * @param batchData `abi.encode(IStreamingPolicy.StreamBatch[])` — the unsettled batches with their
+     *        slice preimages (opaque to the Portal; decoded by the policy)
+     */
+    function settleStream(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward,
+        bytes calldata batchData
+    ) external;
+
+    /**
+     * @notice Closes a stream and reclaims the remaining escrow to the keeper (terminal, keeper-only)
+     * @dev C2 anti-rug: gated on {IStreamingPolicy-hasUnsettledFulfillment} being FALSE, so it can NEVER
+     *      sweep escrow owed to a solver whose batch is proven-but-unsettled — the keeper must let those
+     *      settle first (settlement is permissionless). Marks the stream closed on the policy, refunds the
+     *      remaining escrow to the keeper, and terminates the intent.
+     * @param source Origin chain ID for the intent
+     * @param destination Destination chain ID for the intent
+     * @param routeHash The hash of the intent's route component
+     * @param reward The reward specification (must name a {IStreamingPolicy} at `reward.prover`)
+     */
+    function closeStream(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward
+    ) external;
 }

--- a/contracts/interfaces/IStreamingPolicy.sol
+++ b/contracts/interfaces/IStreamingPolicy.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPolicy} from "./IPolicy.sol";
+import {Reward} from "../types/Intent.sol";
+
+/**
+ * @title IStreamingPolicy
+ * @notice Settlement-policy surface for STREAMING intents — a standing intent fulfilled in successive
+ *         SLICES that draw down a replenishable reward escrow, rather than the one-shot atomic settle.
+ * @dev The lean streaming model (PR6). Re-fulfillability is the POLICY's STORAGE SHAPE, not a core flag:
+ *
+ *      DESTINATION — {IPolicy-recordFulfillment} is overridden to APPEND each slice's `fulfillmentHash`
+ *      to a per-intent array instead of the one-slot atomic store, so a second fulfill never reverts.
+ *
+ *      CROSS-CHAIN DISPATCH — {IPolicy-prove} hashes the whole accumulated slice array into ONE
+ *      `batchHash = keccak256(abi.encode(intentHash, batchNonce, sliceHashes))` (the monotonic
+ *      `batchNonce` makes every batch globally unique), sends `batchHash` cross-chain, and DELETES the
+ *      destination array (storage consumed — a later fulfill starts a fresh batch).
+ *
+ *      SOURCE RECEIPT — {recordBatch} APPENDS the bridged `batchHash` to a per-intent array
+ *      (content-addressed, NO FIFO ordering) and dedups a re-delivered `batchHash` (M1: never wedge).
+ *
+ *      SETTLE — {consumeStreamClaims} takes the slice PREIMAGES for the unsettled batches, verifies each
+ *      recomputed `batchHash` against the stored set (or, same-chain, each slice hash against the
+ *      destination array), REMOVES the settled batch (consume+delete), and returns the per-slice payouts
+ *      (rate+flat, `flat` charged once). Because batches are content-addressed and removed by value there
+ *      is no FIFO head to strand (H1) or wedge (M1).
+ */
+interface IStreamingPolicy is IPolicy {
+    /**
+     * @notice One fulfilled slice's settle preimage.
+     * @param claimant Cross-VM claimant identifier committed at fulfillment (EVM address in low 20 bytes).
+     * @param fulfilled Per-leg delivered amounts committed at fulfillment (paired prefix).
+     */
+    struct StreamSlice {
+        bytes32 claimant;
+        uint256[] fulfilled;
+    }
+
+    /**
+     * @notice One proven batch's settle preimage: its `batchNonce` plus every slice it grouped.
+     * @dev Cross-chain: the policy recomputes `batchHash = keccak256(abi.encode(intentHash, nonce,
+     *      sliceHashes))` and matches it against the accumulated unsettled set. Same-chain (no bridge, no
+     *      batch): `nonce` is ignored and each slice hash is matched against the destination array.
+     * @param nonce The batch nonce assigned at {IPolicy-prove} time (ignored for the same-chain path).
+     * @param slices The slice preimages that made up this batch.
+     */
+    struct StreamBatch {
+        uint256 nonce;
+        StreamSlice[] slices;
+    }
+
+    /// @notice A supplied batch does not match any unsettled batch recorded for the intent.
+    /// @param intentHash The intent being settled.
+    error UnknownBatch(bytes32 intentHash);
+
+    /// @notice A supplied same-chain slice does not match any unsettled destination slice for the intent.
+    /// @param intentHash The intent being settled.
+    error UnknownSlice(bytes32 intentHash);
+
+    /// @notice {recordBatch}/{markClosed}/{consumeStreamClaims} caller is not authorized.
+    /// @param caller The unauthorized caller.
+    error NotAuthorized(address caller);
+
+    /// @notice A streaming settle supplied no batches/slices to consume.
+    error NothingToSettle();
+
+    /// @notice Emitted on each destination fulfillment slice (re-fulfillable append).
+    /// @param intentHash The streamed intent.
+    /// @param seq The slice's index within the current (unproven) destination batch.
+    /// @param fulfillmentHash The slice commitment `keccak256(abi.encode(intentHash, claimant, fulfilled))`.
+    event StreamSliceFulfilled(
+        bytes32 indexed intentHash,
+        uint256 seq,
+        bytes32 fulfillmentHash
+    );
+
+    /// @notice Emitted when a destination batch is hashed and dispatched cross-chain (destination array
+    ///         consumed).
+    /// @param intentHash The streamed intent.
+    /// @param batchNonce The monotonic nonce folded into `batchHash`.
+    /// @param batchHash The dispatched batch commitment.
+    /// @param sliceHashes The slice hashes the batch grouped (so off-chain can reconstruct the preimages).
+    event StreamBatchProven(
+        bytes32 indexed intentHash,
+        uint256 batchNonce,
+        bytes32 batchHash,
+        bytes32[] sliceHashes
+    );
+
+    /// @notice Emitted when a bridged batch is accumulated on the source chain.
+    /// @param intentHash The streamed intent.
+    /// @param destination The fulfilling chain id the batch was proven on.
+    /// @param batchHash The accumulated batch commitment.
+    event StreamBatchAccumulated(
+        bytes32 indexed intentHash,
+        uint64 destination,
+        bytes32 batchHash
+    );
+
+    /// @notice Emitted when the keeper closes a stream (terminal).
+    /// @param intentHash The streamed intent.
+    event StreamMarkedClosed(bytes32 indexed intentHash);
+
+    /**
+     * @notice Accumulates a bridged batch commitment on the source chain (the cross-chain receipt).
+     * @dev Only a whitelisted relay may call. Dedups a re-delivered `(intentHash, batchHash)` (M1) so a
+     *      duplicate can never wedge settlement; otherwise appends `batchHash` to the intent's unsettled
+     *      set. A zero `batchHash` is ignored.
+     * @param intentHash The streamed intent.
+     * @param destination The fulfilling chain id the batch was proven on.
+     * @param batchHash The batch commitment from the destination {IPolicy-prove}.
+     */
+    function recordBatch(
+        bytes32 intentHash,
+        uint64 destination,
+        bytes32 batchHash
+    ) external;
+
+    /**
+     * @notice Verifies and CONSUMES the supplied unsettled batches, returning the per-slice payouts.
+     * @dev Only the Portal may call (it is a settlement effect that mutates the unsettled set + the
+     *      `flatCharged` ledger). The batches + the payouts cross the Portal as OPAQUE `bytes` so the
+     *      Portal never ABI-decodes the deeply-nested {StreamBatch}[] type (that unrolls into ~2 KB of
+     *      Portal bytecode); the decode/encode happens HERE (in the policy, which has headroom). For each
+     *      decoded batch it recomputes the `batchHash` (cross-chain) or each slice hash (same-chain),
+     *      verifies membership in the unsettled store, REMOVES it (consume+delete), and accumulates the
+     *      slice payouts. Reverts {UnknownBatch}/{UnknownSlice} if a batch/slice is not recorded (or
+     *      already settled). The returned payouts are UNCAPPED (rate+flat, `flat` charged at most once per
+     *      intent); the Account pays them in full or reverts, so an under-funded batch is never partially
+     *      consumed (the whole settle rolls back and stays recoverable after a top-up — L1).
+     * @param intentHash The streamed intent.
+     * @param reward The reward spec (defines the per-leg rate/flat curve).
+     * @param batchData `abi.encode(StreamBatch[])` — the unsettled batches with their slice preimages.
+     * @return payoutData `abi.encode(address[] claimants, uint256[][] payouts)` — the per-slice EVM
+     *         claimant + per-leg uncapped payout, forwarded verbatim by the Portal to the Account.
+     */
+    function consumeStreamClaims(
+        bytes32 intentHash,
+        Reward calldata reward,
+        bytes calldata batchData
+    ) external returns (bytes memory payoutData);
+
+    /**
+     * @notice Whether a proven-but-unsettled fulfillment exists for `intentHash` (the {closeStream}
+     *         anti-rug signal — C2).
+     * @dev True while any bridged batch is unsettled on the source, OR any destination slice is
+     *      unsettled same-chain. The keeper's terminal {closeStream} sweep is gated on this being FALSE
+     *      so it can never rug a solver owed for a proven-but-unsettled batch.
+     * @param intentHash The streamed intent.
+     * @return True iff a solver is still owed for a proven-but-unsettled batch/slice.
+     */
+    function hasUnsettledFulfillment(
+        bytes32 intentHash
+    ) external view returns (bool);
+
+    /**
+     * @notice Marks a stream CLOSED (terminal). Only the Portal (via {closeStream}) may call.
+     * @param intentHash The streamed intent.
+     */
+    function markClosed(bytes32 intentHash) external;
+}

--- a/contracts/prover/StreamingPolicy.sol
+++ b/contracts/prover/StreamingPolicy.sol
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import {IPolicy} from "../interfaces/IPolicy.sol";
+import {IStreamingPolicy} from "../interfaces/IStreamingPolicy.sol";
+import {Semver} from "../libs/Semver.sol";
+import {Whitelist} from "../libs/Whitelist.sol";
+import {AddressConverter} from "../libs/AddressConverter.sol";
+import {RewardMath} from "../libs/RewardMath.sol";
+import {Reward, RewardToken, IntentLib} from "../types/Intent.sol";
+
+/**
+ * @title StreamingPolicy
+ * @notice The STREAMING settlement policy — a standing intent fulfilled in successive SLICES that draw
+ *         down a replenishable reward escrow (PR6, the lean batch-hash + preimage model). A streaming
+ *         intent simply names this policy at `reward.prover`; the atomic policies stay one-shot.
+ * @dev Standalone (like {LocalPolicy}) — NOT a {BasePolicy} subclass — because re-fulfillability changes
+ *      the STORAGE SHAPE, not a flag. All streaming logic lives HERE (a separate contract with ~18 KB of
+ *      headroom); the Portal only wires two thin entry points ({IntentSource-settleStream}/{closeStream}).
+ *
+ *      LIFECYCLE (lean, content-addressed):
+ *        DEST fulfill  — {recordFulfillment} APPENDS the slice's `fulfillmentHash` to `_destHashes` and
+ *                        emits {StreamSliceFulfilled}. Re-fulfillable: a second fulfill never reverts.
+ *        DISPATCH      — {prove} hashes the whole `_destHashes` array into ONE
+ *                        `batchHash = keccak256(abi.encode(intentHash, batchNonce, sliceHashes))`, emits
+ *                        it, and DELETES `_destHashes` (storage consumed; the monotonic `batchNonce`
+ *                        makes every batch globally unique). The dispatch is event-is-proof (Polymer
+ *                        style) — a relay picks up {StreamBatchProven} and calls {recordBatch} on the
+ *                        source chain (a concrete bridge subclass can override to push over a mailbox).
+ *        SOURCE receipt— {recordBatch} (whitelisted relay) APPENDS the bridged `batchHash` to
+ *                        `_srcBatches` and dedups a re-delivered one (M1).
+ *        SETTLE        — {consumeStreamClaims} takes the slice preimages, recomputes each `batchHash`
+ *                        (cross-chain) or slice hash (same-chain), REMOVES the matched entry by VALUE
+ *                        (swap-pop; NO FIFO), and returns the per-slice payouts. Content-addressing +
+ *                        remove-by-value structurally avoid H1 (no head to strand) and M1 (no head to
+ *                        wedge). The Portal's Account pays the payouts in full or reverts, so an
+ *                        under-funded batch is never partially consumed (L1: recoverable after top-up).
+ *        CLOSE         — the keeper's {closeStream} is gated on {hasUnsettledFulfillment} (C2): it can
+ *                        never sweep escrow owed to a solver with a proven-but-unsettled batch.
+ */
+contract StreamingPolicy is IStreamingPolicy, Whitelist, Semver, ERC165 {
+    using AddressConverter for address;
+    using AddressConverter for bytes32;
+
+    /// @notice Identifies this policy's settlement mechanism.
+    string public constant PROOF_TYPE = "Streaming";
+
+    /// @notice The local Portal (the only caller allowed to record fulfillments / consume / close).
+    address public immutable PORTAL;
+
+    /// @notice Local chain id (the destination id stamped on same-chain facts).
+    uint64 public immutable CHAIN_ID;
+
+    /// @notice DESTINATION unproven slice array: intent hash -> ordered slice `fulfillmentHash`es.
+    /// @dev Appended by {recordFulfillment}; DELETED by {prove} (consumed into a batch). Also the
+    ///      same-chain settle store (consumed by {consumeStreamClaims} when no bridged batches exist).
+    mapping(bytes32 => bytes32[]) internal _destHashes;
+
+    /// @notice DESTINATION monotonic batch nonce per intent, folded into `batchHash` so every dispatched
+    ///         batch is globally unique (identical slice content across two prove cycles never collides,
+    ///         so the source dedup never false-positives).
+    mapping(bytes32 => uint256) public destBatchNonce;
+
+    /// @notice SOURCE accumulated unsettled batch commitments (content-addressed; NO FIFO ordering).
+    mapping(bytes32 => bytes32[]) internal _srcBatches;
+
+    /// @notice SOURCE dedup guard: intent hash -> batch hash -> already accumulated (M1). Permanent, so a
+    ///         re-delivered batch (or one already settled and removed) is never re-appended.
+    mapping(bytes32 => mapping(bytes32 => bool)) public batchSeen;
+
+    /// @notice SOURCE fulfilling chain id recorded for an intent's bridged batches (challenge/refund gate).
+    mapping(bytes32 => uint64) public srcDestination;
+
+    /// @notice Whether the one-time `flat` reward has already been charged for an intent (anti-dust).
+    mapping(bytes32 => bool) public flatCharged;
+
+    /// @notice Whether the keeper has CLOSED the stream (terminal record; set via {markClosed}).
+    mapping(bytes32 => bool) public closed;
+
+    /**
+     * @notice Wires the Portal and the whitelisted cross-chain relays.
+     * @param portal The local Portal/Inbox (records fulfillments, consumes claims, closes streams).
+     * @param relays Relays authorized to push bridged batches via {recordBatch} (as bytes32, cross-VM).
+     */
+    constructor(
+        address portal,
+        bytes32[] memory relays
+    ) Whitelist(relays) {
+        if (portal == address(0)) revert ZeroPortal();
+        PORTAL = portal;
+        if (block.chainid > type(uint64).max) {
+            revert ChainIdTooLarge(block.chainid);
+        }
+        CHAIN_ID = uint64(block.chainid);
+    }
+
+    /// @inheritdoc IPolicy
+    function getProofType() external pure returns (string memory) {
+        return PROOF_TYPE;
+    }
+
+    // ---------------------------------------------------------------------
+    // DESTINATION — re-fulfillable record + batch dispatch
+    // ---------------------------------------------------------------------
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev STREAMING override of the one-slot atomic record: APPENDS the slice's `fulfillmentHash` to the
+     *      per-intent array so a second fulfill NEVER reverts (that is the streaming property). Only the
+     *      Portal may call. The `destination` argument is implied by {CHAIN_ID}. Emits the slice's array
+     *      index (`seq`) + hash so an off-chain indexer can reconstruct the batch grouping.
+     */
+    function recordFulfillment(
+        bytes32 intentHash,
+        uint64 /* destination */,
+        bytes32 fulfillmentHash
+    ) external {
+        if (msg.sender != PORTAL) revert NotPortal(msg.sender);
+        uint256 seq = _destHashes[intentHash].length;
+        _destHashes[intentHash].push(fulfillmentHash);
+        emit StreamSliceFulfilled(intentHash, seq, fulfillmentHash);
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev DISPATCH: for each intent, hash the whole accumulated `_destHashes` array into ONE `batchHash`
+     *      (with the monotonic `destBatchNonce`), emit {StreamBatchProven}, and DELETE `_destHashes`
+     *      (storage consumed — a later fulfill starts a fresh batch). Reverts {IntentNotFulfilled} for an
+     *      intent with no unproven slices. Event-is-proof: a relay reads the event and calls {recordBatch}
+     *      on the source chain; any `msg.value` (a bridge fee for subclasses) is refunded to `sender`.
+     */
+    function prove(
+        address sender,
+        uint64 /* sourceChainDomainID */,
+        bytes32[] calldata intentHashes,
+        bytes calldata /* data */
+    ) external payable {
+        uint256 size = intentHashes.length;
+        for (uint256 i; i < size; ++i) {
+            bytes32 ih = intentHashes[i];
+            bytes32[] storage arr = _destHashes[ih];
+            uint256 n = arr.length;
+            if (n == 0) revert IntentNotFulfilled(ih);
+
+            bytes32[] memory sliceHashes = new bytes32[](n);
+            for (uint256 s; s < n; ++s) {
+                sliceHashes[s] = arr[s];
+            }
+
+            uint256 nonce = destBatchNonce[ih]++;
+            bytes32 batchHash = keccak256(
+                abi.encode(ih, nonce, sliceHashes)
+            );
+            delete _destHashes[ih];
+
+            emit StreamBatchProven(ih, nonce, batchHash, sliceHashes);
+        }
+
+        if (msg.value > 0) {
+            payable(sender).transfer(msg.value);
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // SOURCE — accumulate bridged batches (dedup)
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IStreamingPolicy
+    function recordBatch(
+        bytes32 intentHash,
+        uint64 destination,
+        bytes32 batchHash
+    ) external {
+        validateWhitelisted(msg.sender.toBytes32());
+        if (batchHash == bytes32(0)) return;
+        // M1 dedup: a re-delivered (or already-settled-and-removed) batch is skipped, never re-appended,
+        // so a duplicate can never wedge settlement.
+        if (batchSeen[intentHash][batchHash]) {
+            emit IntentAlreadyProven(intentHash);
+            return;
+        }
+        batchSeen[intentHash][batchHash] = true;
+        _srcBatches[intentHash].push(batchHash);
+        srcDestination[intentHash] = destination;
+        emit StreamBatchAccumulated(intentHash, destination, batchHash);
+    }
+
+    // ---------------------------------------------------------------------
+    // SETTLE — verify + consume + compute payouts
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IStreamingPolicy
+    function consumeStreamClaims(
+        bytes32 intentHash,
+        Reward calldata reward,
+        bytes calldata batchData
+    ) external returns (bytes memory payoutData) {
+        if (msg.sender != PORTAL) revert NotAuthorized(msg.sender);
+
+        // Decode the deeply-nested batches HERE (not in the Portal, which would unroll ~2 KB of bytecode).
+        StreamBatch[] memory batches = abi.decode(batchData, (StreamBatch[]));
+
+        uint256 nb = batches.length;
+        uint256 total;
+        for (uint256 b; b < nb; ++b) {
+            total += batches[b].slices.length;
+        }
+        if (total == 0) revert NothingToSettle();
+
+        address[] memory claimants = new address[](total);
+        uint256[][] memory payouts = new uint256[][](total);
+
+        // CROSS-CHAIN when bridged batches were accumulated; else SAME-CHAIN (consume the local
+        // destination slices directly).
+        bool crossChain = _srcBatches[intentHash].length != 0;
+
+        // `flat` is charged at most once per intent (anti-dust); only the first slice of the first settle
+        // that ever pays out carries it.
+        bool chargeFlat = !flatCharged[intentHash];
+
+        uint256 k;
+        for (uint256 b; b < nb; ++b) {
+            StreamSlice[] memory slices = batches[b].slices;
+            uint256 ns = slices.length;
+            bytes32[] memory sliceHashes = new bytes32[](ns);
+
+            for (uint256 s; s < ns; ++s) {
+                StreamSlice memory slice = slices[s];
+                sliceHashes[s] = IntentLib.fulfillmentHash(
+                    intentHash,
+                    slice.claimant,
+                    slice.fulfilled
+                );
+                claimants[k] = slice.claimant.toAddress();
+                payouts[k] = _slicePayout(reward, slice.fulfilled, chargeFlat);
+                chargeFlat = false;
+                ++k;
+            }
+
+            if (crossChain) {
+                bytes32 batchHash = keccak256(
+                    abi.encode(intentHash, batches[b].nonce, sliceHashes)
+                );
+                _removeBatch(intentHash, batchHash);
+            } else {
+                _removeSlices(intentHash, sliceHashes);
+            }
+        }
+
+        if (!flatCharged[intentHash]) {
+            flatCharged[intentHash] = true;
+        }
+
+        payoutData = abi.encode(claimants, payouts);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views + close
+    // ---------------------------------------------------------------------
+
+    /// @inheritdoc IStreamingPolicy
+    function hasUnsettledFulfillment(
+        bytes32 intentHash
+    ) external view returns (bool) {
+        return
+            _srcBatches[intentHash].length != 0 ||
+            _destHashes[intentHash].length != 0;
+    }
+
+    /// @inheritdoc IStreamingPolicy
+    function markClosed(bytes32 intentHash) external {
+        if (msg.sender != PORTAL) revert NotAuthorized(msg.sender);
+        closed[intentHash] = true;
+        emit StreamMarkedClosed(intentHash);
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev Returns a NON-ZERO fact whenever a proven-but-unsettled batch/slice exists (so the source
+     *      {IntentSource-_validateRefund} gate blocks a pre-deadline refund of an owed stream). The
+     *      `fulfillmentHash` returned is a BATCH commitment, NOT a single slice's hash, so the generic
+     *      {IntentSource-settle} preimage check fails on a streaming intent — streaming must settle via
+     *      {IntentSource-settleStream}.
+     */
+    function provenIntents(
+        bytes32 intentHash
+    ) external view returns (ProofData memory) {
+        bytes32[] storage src = _srcBatches[intentHash];
+        uint256 n = src.length;
+        if (n != 0) {
+            return
+                ProofData({
+                    destination: srcDestination[intentHash],
+                    fulfillmentHash: src[n - 1]
+                });
+        }
+        bytes32[] storage dst = _destHashes[intentHash];
+        uint256 m = dst.length;
+        if (m != 0) {
+            return
+                ProofData({destination: CHAIN_ID, fulfillmentHash: dst[m - 1]});
+        }
+        return ProofData({destination: 0, fulfillmentHash: bytes32(0)});
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev Wrong-destination scrub: if the intent's accumulated bridged batches were recorded for a chain
+     *      other than the intent commits to, drop them all (they can never legitimately settle).
+     */
+    function challengeIntentProof(
+        uint64 source,
+        uint64 destination,
+        bytes32 routeHash,
+        bytes32 rewardHash
+    ) external {
+        bytes32 intentHash = IntentLib.hashIntent(
+            source,
+            destination,
+            routeHash,
+            rewardHash
+        );
+        if (
+            _srcBatches[intentHash].length != 0 &&
+            srcDestination[intentHash] != destination
+        ) {
+            delete _srcBatches[intentHash];
+            emit IntentProofInvalidated(intentHash);
+        }
+    }
+
+    /**
+     * @inheritdoc IPolicy
+     * @dev The atomic single-slice curve, provided to satisfy {IPolicy}. Streaming never routes through
+     *      the generic Account `withdraw`/`previewRelease` path (it uses {consumeStreamClaims} +
+     *      `withdrawStream`); this is a harmless view for interface completeness.
+     */
+    function previewRelease(
+        Reward calldata reward,
+        uint256[] calldata fulfilled
+    ) external pure returns (uint256[] memory payNow) {
+        return _slicePayout(reward, fulfilled, true);
+    }
+
+    /// @notice The unproven destination slice hashes for an intent (indexer/test view).
+    function destSlices(
+        bytes32 intentHash
+    ) external view returns (bytes32[] memory) {
+        return _destHashes[intentHash];
+    }
+
+    /// @notice The unsettled accumulated source batch hashes for an intent (indexer/test view).
+    function srcBatches(
+        bytes32 intentHash
+    ) external view returns (bytes32[] memory) {
+        return _srcBatches[intentHash];
+    }
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IPolicy).interfaceId ||
+            interfaceId == type(IStreamingPolicy).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal
+    // ---------------------------------------------------------------------
+
+    /**
+     * @notice One slice's per-leg uncapped payout (rate + one-time flat).
+     * @dev PAIRED legs (`j < fulfilled.length`): `fulfilled[j]*rate/WAD` (+ `leg.flat` if `chargeFlat`).
+     *      EXTRA flat-only legs: `leg.flat` if `chargeFlat`, else 0. Index-aligned with `reward.tokens`.
+     */
+    function _slicePayout(
+        Reward calldata reward,
+        uint256[] memory fulfilled,
+        bool chargeFlat
+    ) internal pure returns (uint256[] memory payNow) {
+        uint256 legCount = reward.tokens.length;
+        uint256 fulfilledLen = fulfilled.length;
+        payNow = new uint256[](legCount);
+        for (uint256 j; j < legCount; ++j) {
+            RewardToken calldata leg = reward.tokens[j];
+            if (j < fulfilledLen) {
+                payNow[j] = RewardMath.reward(
+                    fulfilled[j],
+                    leg.rate,
+                    chargeFlat ? leg.flat : 0
+                );
+            } else {
+                payNow[j] = chargeFlat ? leg.flat : 0;
+            }
+        }
+    }
+
+    /// @notice Removes a settled batch by value (swap-pop). Reverts {UnknownBatch} if absent.
+    function _removeBatch(bytes32 intentHash, bytes32 batchHash) internal {
+        bytes32[] storage arr = _srcBatches[intentHash];
+        uint256 n = arr.length;
+        for (uint256 i; i < n; ++i) {
+            if (arr[i] == batchHash) {
+                arr[i] = arr[n - 1];
+                arr.pop();
+                return;
+            }
+        }
+        revert UnknownBatch(intentHash);
+    }
+
+    /// @notice Removes each same-chain slice by value (swap-pop). Reverts {UnknownSlice} if any absent.
+    function _removeSlices(
+        bytes32 intentHash,
+        bytes32[] memory sliceHashes
+    ) internal {
+        bytes32[] storage arr = _destHashes[intentHash];
+        uint256 ns = sliceHashes.length;
+        for (uint256 s; s < ns; ++s) {
+            bytes32 target = sliceHashes[s];
+            uint256 n = arr.length;
+            bool found;
+            for (uint256 i; i < n; ++i) {
+                if (arr[i] == target) {
+                    arr[i] = arr[n - 1];
+                    arr.pop();
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) revert UnknownSlice(intentHash);
+        }
+    }
+}

--- a/docs/v3/06-streaming-and-deposits.md
+++ b/docs/v3/06-streaming-and-deposits.md
@@ -54,13 +54,25 @@ lockstep). Bytecode SIZE plateaus at the ceiling for high runs; below the platea
 little runtime gas for real bytecode headroom. Externalizing the struct-heavy decode to the policy/Account
 (opaque `bytes` at the Portal boundary) already recovered ~1 KB; the valve closes the rest.
 
-## 5. Deposit-address migration — DEFERRED (PR6b)
+## 5. Accepted residual: relay-mistag wipe via `challengeIntentProof`
+
+`challengeIntentProof` is permissionless and deletes all of an intent's `_srcBatches` when the recorded
+`srcDestination` doesn't match the intent's real `destination`. `recordBatch` takes `intentHash` and
+`destination` as independent arguments, so a **whitelisted** relay that records a genuine batch under the
+wrong `destination` lets anyone permissionlessly wipe that intent's accumulated, proven-but-unsettled
+batches — the solver only recovers by re-proving. This requires an already-trusted relay to misbehave or
+have a bug (the same trust bar the relay whitelist already assumes for censorship-resistance), not an
+unprivileged attacker, and it's the wrong-destination scrub working as designed for the honest case — but
+it's a sharp correctness dependency on relay-supplied metadata worth calling out explicitly rather than
+leaving implicit.
+
+## 6. Deposit-address migration — DEFERRED (PR6b)
 
 Migrating the reusable deposit-address templates onto standing streaming intents is deferred to a PR6b
 follow-up. In the meantime the H2 guard protects every reusable deposit address, and all deposit families
 stay functional. See `migration-loss-inventory.md`.
 
-## 6. Tests
+## 7. Tests
 
 `test/core/Streaming.t.sol` (10): batch flow, `settleStream` full-or-revert (L1), dedup (M1), no-stranding
 (H1), `closeStream` C2 anti-rug, keeper reclaim; plus the H2 `NothingToFulfill` cases in

--- a/docs/v3/06-streaming-and-deposits.md
+++ b/docs/v3/06-streaming-and-deposits.md
@@ -1,0 +1,67 @@
+# PR6 — lean streaming policy + Portal settle/close + H2 anti-poison
+
+> Adds a content-addressed `StreamingPolicy` for standing (re-fulfillable) intents, the source-side
+> `settleStream`/`closeStream` entry points, `Account.withdrawStream`, and the H2 anti-poison guard in the
+> core Inbox. Re-authored onto PR5 (rename-clean; the streaming policy calls into the Account, not a Vault).
+
+## 1. StreamingPolicy (content-addressed, NOT FIFO)
+
+A standing intent (reusable deposit address) is fulfilled MANY times. The policy is content-addressed, not
+a FIFO queue:
+
+- **Destination**: each `recordFulfillment` appends the slice's `fulfillmentHash` to `_destHashes[ih]`
+  (never reverts → the intent is re-fulfillable) and emits the preimage.
+- **prove**: hashes the accumulated dest slice list into ONE `batchHash`
+  (`keccak(intentHash, batchNonce, sliceHashes[])`, monotonic `batchNonce` prevents collision) and
+  DELETES `_destHashes[ih]`.
+- **Source**: records each `batchHash` with PERMANENT dedup (`batchSeen` — fixes the M1 re-record wedge).
+- **settle**: the caller supplies the batch's slice preimages; the policy verifies them against the stored
+  `batchHash`, removes consumed slices by swap-pop (no FIFO → fixes H1 stranding), and returns the per-leg
+  payout table.
+- **close**: `closeStream` is gated on `!hasUnsettledFulfillment` (fixes the C2 rug — a keeper can't
+  reclaim escrow owed to a solver whose batch is proven-but-unsettled).
+
+## 2. Source entry points
+
+- `IntentSource.settleStream(source, destination, routeHash, reward, batchData)` — source-chain-gated.
+  The `StreamingPolicy.consumeStreamClaims` verifies + consumes the batches and returns the payout table
+  as opaque `bytes`; `Account.withdrawStream` decodes it and pays each slice's leg IN FULL or reverts
+  (`StreamSlicePayoutExceedsBalance`) — so an under-funded batch is never partially consumed and its
+  shortfall is recoverable after a top-up (L1). The residual is NOT swept (it funds later slices). The
+  intent stays `Funded` (re-fulfillable). Emits `StreamSettled`.
+- `IntentSource.closeStream(source, destination, routeHash, reward)` — keeper-only (`reward.keeper`),
+  source-chain-gated, C2-gated on `!hasUnsettledFulfillment` (`PendingProofBlocksClose`). Marks the stream
+  closed on the policy, sets the intent `Refunded`, and returns the remaining escrow to the keeper. Emits
+  `StreamClosed`. (The refund hook is intentionally not run here — this is the streaming reclaim path.)
+
+The Portal handles the nested `StreamBatch[]` / payout-table types ONLY as opaque `bytes` at its boundary
+— the decode lives in `StreamingPolicy` + `Account` — keeping the tight Portal small.
+
+## 3. H2 anti-poison (core Inbox)
+
+`Inbox._fulfill` reverts `NothingToFulfill` when `route.minTokens.length == 0 && reward.tokens.length == 0`.
+Such an intent asks a solver to provide nothing for no pay, so there is no honest fulfill — and recording
+one would permanently occupy the prover's fulfillment store, bricking a REUSABLE deposit address for every
+later deposit. The only legitimate way to run such an Account's committed `runtime(payload)` is the
+owner-gated `executeAsOwner`.
+
+## 4. Size budget
+
+Portal / PortalTron = 23,649 B (headroom 927) at `optimizer_runs = 1,000`. The streaming settle/close
+entry points (their two extra `getIntentHash` inlines each ABI-encode the nested `Reward`) push the Portal
+to 25,058 B at 20,000 runs, so the optimizer valve is lowered (foundry.toml + hardhat.config.ts in
+lockstep). Bytecode SIZE plateaus at the ceiling for high runs; below the plateau, lower runs trade a
+little runtime gas for real bytecode headroom. Externalizing the struct-heavy decode to the policy/Account
+(opaque `bytes` at the Portal boundary) already recovered ~1 KB; the valve closes the rest.
+
+## 5. Deposit-address migration — DEFERRED (PR6b)
+
+Migrating the reusable deposit-address templates onto standing streaming intents is deferred to a PR6b
+follow-up. In the meantime the H2 guard protects every reusable deposit address, and all deposit families
+stay functional. See `migration-loss-inventory.md`.
+
+## 6. Tests
+
+`test/core/Streaming.t.sol` (10): batch flow, `settleStream` full-or-revert (L1), dedup (M1), no-stranding
+(H1), `closeStream` C2 anti-rug, keeper reclaim; plus the H2 `NothingToFulfill` cases in
+Inbox/InboxAdvanced. Full suite green: forge 630, hardhat 112, jest 42.

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = "out"
 fs_permissions = [{ access = "read-write", path = "./out"}]
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 20000
+optimizer_runs = 1000
 via_ir = true
 retries = 2
 evm_version = "paris"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,10 @@ const config: HardhatUserConfig = {
           viaIR: true,
           optimizer: {
             enabled: true,
-            runs: 20000,
+            // Kept in lockstep with foundry.toml `optimizer_runs`. PR6 lowered this from 20000 to 1000
+            // so the Portal (which gained the streaming settle/close entry points) stays under the
+            // 24,576 B EIP-170 limit. See docs/v3/06-streaming-and-deposits.md ("Size budget").
+            runs: 1000,
           },
         },
       },

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -29,6 +29,13 @@ contract InboxTest is BaseTest {
         vm.stopPrank();
     }
 
+    /// @notice A single zero-value reward leg so a delivery-via-calls intent is not "nothing to fulfill"
+    ///         (H2: {IInbox-NothingToFulfill} rejects an empty-minTokens AND empty-reward intent).
+    function _rw0() internal view returns (RewardToken[] memory rw) {
+        rw = new RewardToken[](1);
+        rw[0] = RewardToken({token: address(tokenA), rate: 0, flat: 0});
+    }
+
     function testInboxExists() public view {
         assertTrue(address(portal) != address(0));
     }
@@ -203,7 +210,7 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -264,7 +271,7 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -345,7 +352,7 @@ contract InboxTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -664,7 +671,7 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0),
+                    tokens: _rw0(),
                     hooks: ""
                 })
             });
@@ -734,7 +741,7 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0),
+                    tokens: _rw0(),
                     hooks: ""
                 })
             });
@@ -819,7 +826,7 @@ contract InboxTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0),
+                    tokens: _rw0(),
                     hooks: ""
                 })
             });

--- a/test/core/InboxAdvanced.t.sol
+++ b/test/core/InboxAdvanced.t.sol
@@ -53,6 +53,13 @@ contract InboxAdvancedTest is BaseTest {
         vm.stopPrank();
     }
 
+    /// @notice A single zero-value reward leg so a delivery-via-calls intent is not "nothing to fulfill"
+    ///         (H2: {IInbox-NothingToFulfill} rejects an empty-minTokens AND empty-reward intent).
+    function _rw0() internal view returns (RewardToken[] memory rw) {
+        rw = new RewardToken[](1);
+        rw[0] = RewardToken({token: address(tokenA), rate: 0, flat: 0});
+    }
+
     // ===== MESSAGE ROUTING TESTS =====
 
     function testMessageRoutingWithMultipleRecipients() public {
@@ -104,7 +111,7 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -164,7 +171,7 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -229,7 +236,7 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -478,7 +485,7 @@ contract InboxAdvancedTest is BaseTest {
                 deadline: uint64(expiry),
                 keeper: keeper,
                 prover: address(prover),
-                tokens: new RewardToken[](0),
+                tokens: _rw0(),
                 hooks: ""
             })
         });
@@ -610,7 +617,7 @@ contract InboxAdvancedTest is BaseTest {
                     deadline: uint64(expiry),
                     keeper: keeper,
                     prover: address(prover),
-                    tokens: new RewardToken[](0),
+                    tokens: _rw0(),
                     hooks: ""
                 })
             });

--- a/test/core/Streaming.t.sol
+++ b/test/core/Streaming.t.sol
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {BaseTest} from "../BaseTest.sol";
+import {StreamingPolicy} from "../../contracts/prover/StreamingPolicy.sol";
+import {IStreamingPolicy} from "../../contracts/interfaces/IStreamingPolicy.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {IAccount} from "../../contracts/interfaces/IAccount.sol";
+import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib, WAD} from "../../contracts/types/Intent.sol";
+import {Call} from "../../contracts/interfaces/IRuntime.sol";
+
+/**
+ * @title StreamingTest
+ * @notice End-to-end coverage of the lean streaming model (PR6): re-fulfillable destination record,
+ *         batch-hash dispatch + delete, content-addressed source accumulation, preimage settle with
+ *         consume+delete, closeStream anti-rug (C2), duplicate-batch no-wedge (M1), no-stranding (H1),
+ *         and under-funded recoverability (L1).
+ */
+contract StreamingTest is BaseTest {
+    StreamingPolicy internal stream;
+
+    address internal recipient;
+    address internal solver;
+    address internal claimant1;
+    address internal claimant2;
+
+    uint64 internal constant FOREIGN = 2;
+    uint256 internal constant DELIVER = 100;
+    uint256 internal constant BUDGET = 1000;
+
+    function setUp() public override {
+        super.setUp();
+        recipient = makeAddr("streamRecipient");
+        solver = makeAddr("streamSolver");
+        claimant1 = makeAddr("claimant1");
+        claimant2 = makeAddr("claimant2");
+
+        // The StreamingPolicy trusts the Portal (records + consumes + closes) and whitelists this test
+        // contract as the cross-chain relay (so it can push bridged batches via recordBatch).
+        bytes32[] memory relays = new bytes32[](1);
+        relays[0] = bytes32(uint256(uint160(address(this))));
+        vm.prank(deployer);
+        stream = new StreamingPolicy(address(portal), relays);
+    }
+
+    // ---------------------------------------------------------------------
+    // Intent construction: solver provides DELIVER tokenB as input, the committed multicall runtime
+    // delivers it to `recipient`; reward is a 1:1 rate leg on tokenA (each slice pays
+    // `fulfilled * WAD / WAD == fulfilled` tokenA). The tokenA budget is over-funded directly into the
+    // account (rate legs are not pre-funded).
+    // ---------------------------------------------------------------------
+
+    function _streamIntent(
+        uint64 source,
+        uint64 destination
+    ) internal view returns (Intent memory _intent) {
+        TokenAmount[] memory mo = new TokenAmount[](1);
+        mo[0] = TokenAmount({token: address(tokenB), amount: DELIVER});
+
+        Call[] memory c = new Call[](1);
+        c[0] = Call({
+            target: address(tokenB),
+            data: abi.encodeWithSignature(
+                "transfer(address,uint256)",
+                recipient,
+                DELIVER
+            ),
+            value: 0
+        });
+
+        Route memory r = Route({
+            salt: keccak256(abi.encodePacked("stream", source, destination)),
+            deadline: uint64(expiry),
+            portal: address(portal),
+            keeper: keeper,
+            runtime: address(multicallRuntime),
+            payload: abi.encode(c),
+            minTokens: mo
+        });
+
+        RewardToken[] memory rw = new RewardToken[](1);
+        rw[0] = RewardToken({token: address(tokenA), rate: WAD, flat: 0});
+
+        Reward memory rew = Reward({
+            deadline: uint64(expiry),
+            keeper: keeper,
+            prover: address(stream),
+            tokens: rw,
+            hooks: ""
+        });
+
+        _intent = Intent({
+            source: source,
+            destination: destination,
+            route: r,
+            reward: rew
+        });
+    }
+
+    /// @notice Publishes/funds a streaming intent (rate leg funds 0) and over-funds the account budget.
+    function _publishAndBudget(
+        Intent memory _intent,
+        uint256 budget
+    ) internal returns (bytes32 intentHash, address account) {
+        vm.prank(keeper);
+        (intentHash, account) = intentSource.publishAndFund(_intent, false);
+        tokenA.mint(account, budget);
+    }
+
+    /// @notice Same-chain fulfill of one slice by `who` naming `claimant`. Returns the measured fulfilled.
+    function _fulfillSlice(
+        Intent memory _intent,
+        address who,
+        address slotClaimant
+    ) internal returns (uint256[] memory fulfilled) {
+        tokenB.mint(who, DELIVER);
+        vm.startPrank(who);
+        tokenB.approve(address(portal), DELIVER);
+        uint256[] memory provided = new uint256[](1);
+        provided[0] = DELIVER;
+        inbox.fulfill(
+            _intent.source,
+            _intent.destination,
+            _intent.route,
+            _intent.reward,
+            bytes32(uint256(uint160(slotClaimant))),
+            provided,
+            address(stream)
+        );
+        vm.stopPrank();
+        fulfilled = provided;
+    }
+
+    function _slice(
+        address slotClaimant,
+        uint256 amount
+    ) internal pure returns (IStreamingPolicy.StreamSlice memory s) {
+        uint256[] memory f = new uint256[](1);
+        f[0] = amount;
+        s = IStreamingPolicy.StreamSlice({
+            claimant: bytes32(uint256(uint160(slotClaimant))),
+            fulfilled: f
+        });
+    }
+
+    function _oneBatch(
+        uint256 nonce,
+        IStreamingPolicy.StreamSlice[] memory slices
+    ) internal pure returns (bytes memory) {
+        IStreamingPolicy.StreamBatch[]
+            memory batches = new IStreamingPolicy.StreamBatch[](1);
+        batches[0] = IStreamingPolicy.StreamBatch({nonce: nonce, slices: slices});
+        return abi.encode(batches);
+    }
+
+    // ---------------------------------------------------------------------
+    // SAME-CHAIN streaming end-to-end (multi-slice)
+    // ---------------------------------------------------------------------
+
+    function test_sameChain_multiSlice_settlesAllSlices() public {
+        Intent memory it = _streamIntent(CHAIN_ID, CHAIN_ID);
+        (bytes32 intentHash, address account) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        // Two slices fulfilled by two different solvers to two different claimants.
+        _fulfillSlice(it, solver, claimant1);
+        _fulfillSlice(it, otherPerson, claimant2);
+
+        // The destination store now holds both slice hashes (re-fulfillable: the 2nd fulfill did not
+        // revert).
+        assertEq(stream.destSlices(intentHash).length, 2);
+
+        // Settle both slices in one call (same-chain: consumed directly from _destHashes).
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](2);
+        slices[0] = _slice(claimant1, DELIVER);
+        slices[1] = _slice(claimant2, DELIVER);
+
+        intentSource.settleStream(
+            CHAIN_ID,
+            CHAIN_ID,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+
+        assertEq(tokenA.balanceOf(claimant1), DELIVER, "claimant1 paid");
+        assertEq(tokenA.balanceOf(claimant2), DELIVER, "claimant2 paid");
+        // Store consumed; no residual sweep (budget stays for future slices).
+        assertEq(stream.destSlices(intentHash).length, 0, "slices consumed");
+        assertEq(tokenA.balanceOf(account), BUDGET - 2 * DELIVER, "residual kept");
+        // Re-fulfillable: the intent stays Funded.
+        assertEq(
+            uint256(intentSource.getRewardStatus(intentHash)),
+            uint256(IIntentSource.Status.Funded)
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // CROSS-CHAIN streaming end-to-end: dest batch -> dispatch -> source accumulate -> settle
+    // ---------------------------------------------------------------------
+
+    /// @notice Builds the batchHash exactly as StreamingPolicy.prove would, for the given slices/nonce.
+    function _batchHash(
+        bytes32 intentHash,
+        uint256 nonce,
+        IStreamingPolicy.StreamSlice[] memory slices
+    ) internal pure returns (bytes32) {
+        bytes32[] memory sh = new bytes32[](slices.length);
+        for (uint256 i; i < slices.length; ++i) {
+            sh[i] = IntentLib.fulfillmentHash(
+                intentHash,
+                slices[i].claimant,
+                slices[i].fulfilled
+            );
+        }
+        return keccak256(abi.encode(intentHash, nonce, sh));
+    }
+
+    function test_crossChain_batch_accumulate_settle() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        (bytes32 intentHash, address account) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        // Simulate the destination batch (fulfilled on FOREIGN): two slices, dispatched as batch nonce 0.
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](2);
+        slices[0] = _slice(claimant1, DELIVER);
+        slices[1] = _slice(claimant2, DELIVER);
+        bytes32 bh = _batchHash(intentHash, 0, slices);
+
+        // Relay pushes the bridged batch onto the source policy.
+        stream.recordBatch(intentHash, FOREIGN, bh);
+        assertEq(stream.srcBatches(intentHash).length, 1);
+
+        // Settle the batch: pays both claimants from the SOURCE account.
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+
+        assertEq(tokenA.balanceOf(claimant1), DELIVER);
+        assertEq(tokenA.balanceOf(claimant2), DELIVER);
+        assertEq(stream.srcBatches(intentHash).length, 0, "batch consumed");
+        assertEq(tokenA.balanceOf(account), BUDGET - 2 * DELIVER);
+    }
+
+    // ---------------------------------------------------------------------
+    // DESTINATION prove: hashes + deletes _destHashes; monotonic nonce
+    // ---------------------------------------------------------------------
+
+    function test_prove_hashesAndDeletesDestStore_monotonicNonce() public {
+        // A standalone StreamingPolicy where THIS test acts as the Portal (records) and dispatcher.
+        StreamingPolicy dst = new StreamingPolicy(
+            address(this),
+            new bytes32[](0)
+        );
+        bytes32 ih = keccak256("some-intent");
+
+        bytes32 sh0 = keccak256("slice0");
+        bytes32 sh1 = keccak256("slice1");
+        dst.recordFulfillment(ih, FOREIGN, sh0);
+        dst.recordFulfillment(ih, FOREIGN, sh1);
+        assertEq(dst.destSlices(ih).length, 2);
+        assertEq(dst.destBatchNonce(ih), 0);
+
+        bytes32[] memory ihs = new bytes32[](1);
+        ihs[0] = ih;
+        dst.prove(address(this), 0, ihs, "");
+
+        // Store consumed (deleted); nonce advanced.
+        assertEq(dst.destSlices(ih).length, 0, "dest store deleted after prove");
+        assertEq(dst.destBatchNonce(ih), 1, "nonce advanced");
+
+        // A fresh fulfill after prove starts a new (empty) batch and the next prove uses nonce 1.
+        dst.recordFulfillment(ih, FOREIGN, keccak256("slice2"));
+        dst.prove(address(this), 0, ihs, "");
+        assertEq(dst.destBatchNonce(ih), 2);
+    }
+
+    // ---------------------------------------------------------------------
+    // M1: duplicate batch delivery is deduped and never wedges
+    // ---------------------------------------------------------------------
+
+    function test_M1_duplicateBatchDelivery_noWedge() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        (bytes32 intentHash, ) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](1);
+        slices[0] = _slice(claimant1, DELIVER);
+        bytes32 bh = _batchHash(intentHash, 0, slices);
+
+        // Relay delivers the SAME batch twice — the duplicate is skipped.
+        stream.recordBatch(intentHash, FOREIGN, bh);
+        stream.recordBatch(intentHash, FOREIGN, bh);
+        assertEq(stream.srcBatches(intentHash).length, 1, "dedup: one batch");
+
+        // Settle it once; re-delivery afterwards stays deduped (batchSeen permanent) so nothing wedges.
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(tokenA.balanceOf(claimant1), DELIVER);
+        assertEq(stream.srcBatches(intentHash).length, 0);
+
+        stream.recordBatch(intentHash, FOREIGN, bh); // re-delivery of settled batch
+        assertEq(
+            stream.srcBatches(intentHash).length,
+            0,
+            "settled batch not re-added"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // H1: content-addressed batches settle in ANY order with no stranding
+    // ---------------------------------------------------------------------
+
+    function test_H1_multiBatch_outOfOrderSettle_noStranding() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        (bytes32 intentHash, ) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        IStreamingPolicy.StreamSlice[]
+            memory s0 = new IStreamingPolicy.StreamSlice[](1);
+        s0[0] = _slice(claimant1, DELIVER);
+        IStreamingPolicy.StreamSlice[]
+            memory s1 = new IStreamingPolicy.StreamSlice[](1);
+        s1[0] = _slice(claimant2, DELIVER);
+
+        bytes32 b0 = _batchHash(intentHash, 0, s0);
+        bytes32 b1 = _batchHash(intentHash, 1, s1);
+        stream.recordBatch(intentHash, FOREIGN, b0);
+        stream.recordBatch(intentHash, FOREIGN, b1);
+        assertEq(stream.srcBatches(intentHash).length, 2);
+
+        // Settle the SECOND batch first (content-addressed, no FIFO): removes b1 by value, b0 remains.
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(1, s1)
+        );
+        assertEq(tokenA.balanceOf(claimant2), DELIVER);
+        assertEq(stream.srcBatches(intentHash).length, 1, "b0 not stranded");
+
+        // Then settle the first batch.
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, s0)
+        );
+        assertEq(tokenA.balanceOf(claimant1), DELIVER);
+        assertEq(stream.srcBatches(intentHash).length, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // C2: closeStream cannot rug a proven-but-unsettled batch
+    // ---------------------------------------------------------------------
+
+    function test_C2_closeStream_blockedWhileBatchUnsettled_thenAllowed() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        (bytes32 intentHash, address account) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](1);
+        slices[0] = _slice(claimant1, DELIVER);
+        bytes32 bh = _batchHash(intentHash, 0, slices);
+        stream.recordBatch(intentHash, FOREIGN, bh);
+
+        // Keeper's close is BLOCKED while a proven batch is unsettled (anti-rug).
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.PendingProofBlocksClose.selector,
+                intentHash
+            )
+        );
+        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+
+        // The batch is settled to the solver's claimant first.
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(tokenA.balanceOf(claimant1), DELIVER);
+
+        // Now the keeper can close and reclaim the remainder.
+        uint256 keeperBefore = tokenA.balanceOf(keeper);
+        vm.prank(keeper);
+        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+        assertEq(
+            tokenA.balanceOf(keeper),
+            keeperBefore + (BUDGET - DELIVER),
+            "keeper reclaims remainder"
+        );
+        assertEq(tokenA.balanceOf(account), 0);
+        assertTrue(stream.closed(intentHash), "marked closed");
+    }
+
+    function test_C2_closeStream_onlyKeeper() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        vm.prank(otherPerson);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.NotKeeperCaller.selector,
+                otherPerson
+            )
+        );
+        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+    }
+
+    // ---------------------------------------------------------------------
+    // L1: under-funded settle reverts (atomic); shortfall recoverable after top-up
+    // ---------------------------------------------------------------------
+
+    function test_L1_underfunded_reverts_thenRecoverableAfterTopUp() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        // Budget only covers ONE slice; the batch has TWO.
+        (bytes32 intentHash, address account) = _publishAndBudget(it, DELIVER);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](2);
+        slices[0] = _slice(claimant1, DELIVER);
+        slices[1] = _slice(claimant2, DELIVER);
+        bytes32 bh = _batchHash(intentHash, 0, slices);
+        stream.recordBatch(intentHash, FOREIGN, bh);
+
+        // Under-funded: the second slice can't be paid -> whole settle reverts, batch NOT consumed.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccount.StreamSlicePayoutExceedsBalance.selector,
+                address(tokenA),
+                DELIVER,
+                0
+            )
+        );
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(stream.srcBatches(intentHash).length, 1, "batch preserved");
+        assertEq(tokenA.balanceOf(claimant1), 0, "nothing paid (atomic)");
+
+        // Keeper tops up; the same batch now settles fully -> shortfall recovered, not forfeited.
+        tokenA.mint(account, DELIVER);
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(tokenA.balanceOf(claimant1), DELIVER);
+        assertEq(tokenA.balanceOf(claimant2), DELIVER);
+        assertEq(stream.srcBatches(intentHash).length, 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // Wrong preimage / unknown batch reverts
+    // ---------------------------------------------------------------------
+
+    function test_settleStream_unknownBatch_reverts() public {
+        Intent memory it = _streamIntent(CHAIN_ID, FOREIGN);
+        (bytes32 intentHash, ) = _publishAndBudget(it, BUDGET);
+        bytes32 routeHash = keccak256(abi.encode(it.route));
+
+        IStreamingPolicy.StreamSlice[]
+            memory real = new IStreamingPolicy.StreamSlice[](1);
+        real[0] = _slice(claimant1, DELIVER);
+        stream.recordBatch(intentHash, FOREIGN, _batchHash(intentHash, 0, real));
+
+        // A settle whose slices/nonce do not reproduce a recorded batch reverts.
+        IStreamingPolicy.StreamSlice[]
+            memory wrong = new IStreamingPolicy.StreamSlice[](1);
+        wrong[0] = _slice(claimant2, DELIVER);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStreamingPolicy.UnknownBatch.selector,
+                intentHash
+            )
+        );
+        intentSource.settleStream(
+            CHAIN_ID,
+            FOREIGN,
+            routeHash,
+            it.reward,
+            _oneBatch(0, wrong)
+        );
+    }
+
+    function test_recordBatch_onlyWhitelistedRelay() public {
+        bytes32 ih = keccak256("x");
+        vm.prank(otherPerson);
+        vm.expectRevert();
+        stream.recordBatch(ih, FOREIGN, keccak256("b"));
+    }
+}


### PR DESCRIPTION
## Summary
Stacked on PR5 (#400). Adds `StreamingPolicy` for standing (re-fulfillable) intents — content-addressed, not a FIFO queue:

- Destination: each `recordFulfillment` appends the slice's `fulfillmentHash` to a per-intent array (never reverts — re-fulfillable) and emits the preimage; `prove` hashes the accumulated array into one `batchHash` (`keccak(intentHash, batchNonce, sliceHashes[])`, monotonic nonce prevents collision) and deletes the array.
- Source: accumulates each received `batchHash` with permanent dedup.
- `settleStream` takes the claimant-supplied slice preimages, verifies against the stored `batchHash`, removes it by value (swap-pop — no FIFO ordering requirement), and pays. `closeStream` is gated on `!hasUnsettledFulfillment` so a keeper can never sweep escrow owed to a proven-but-unsettled batch.
- `Account.withdrawStream` pays each slice's leg in full or reverts — an under-funded batch is never partially consumed, so its shortfall is recoverable after a top-up rather than forfeited.
- **H2 anti-poison**: `Inbox._fulfill` rejects an intent with both empty `minTokens` and empty `reward` — such an intent asks a solver to provide nothing for no pay, and recording one would permanently brick a reusable deposit address for every later deposit.
- Deposit-address migration onto standing streaming intents is **deferred** to a follow-up PR — the H2 guard and all three existing deposit families remain functional in the meantime.
- Adversarial-sweep note: `challengeIntentProof` (permissionless) can wipe an intent's accumulated batches if a *whitelisted* relay records one under the wrong destination — documented as an accepted residual (requires an already-trusted relay to misbehave, not an unprivileged attacker).

## Test plan
- [x] `forge build` clean
- [x] `forge test`: 631 passed / 0 failed
- [x] `npx hardhat test`: 112 passing
- [x] `jest`: 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N25m45iFpZQEycqw7YFNsK