### PR TITLE
v3 PR8: deploy script, release pipeline, TS SDK, umbrella docs

### DIFF
--- a/docs/v3/00-overview.md
+++ b/docs/v3/00-overview.md
@@ -1,0 +1,45 @@
+# Eco Routes v3 — overview & reading order
+
+> Umbrella for the v3 reauthoring. v3 is delivered as **8 stacked PRs**, each building on the previous.
+> Read them in order; each PR's design doc is linked below. The user-facing upgrade story from v2 is in
+> [`migration-from-v2.md`](./migration-from-v2.md); the list of deliberate narrowings is in
+> [`migration-loss-inventory.md`](./migration-loss-inventory.md); deploy + release + SDK is
+> [`08-deploy-and-release.md`](./08-deploy-and-release.md).
+
+## What v3 is
+
+v3 keeps the ERC-7683 cross-chain intent model and the combined **Portal** (source `IntentSource` +
+destination `Inbox`) but reshapes three things:
+
+1. **Unopinionated core** — the protocol no longer delivers to a `recipient` or auto-sweeps. An intent
+   names a `runtime` + opaque `payload`; a per-intent **Account** (renamed from Vault) executes the
+   payload by `delegatecall`. Leftover input stays in the Account; the **keeper** retrieves it later.
+2. **Reward legs, not fixed amounts** — rewards are `rate`+`flat` legs paired to a `minTokens` **input
+   floor**; the reward scales on what the solver actually provided.
+3. **Policies, not provers** — the settlement/proof surface is a `Policy` (renamed from Prover). Each
+   transport (`Hyper`/`LayerZero`/`Meta`/`CCIP`/`Polymer`) is BOTH transport and settlement in one
+   contract; schedule policies (`Vesting`/`Milestone`/`DutchDecay`/`Streaming`) add release schedules.
+
+## The 8 PRs, in reading order
+
+| PR | Doc | What it does |
+|----|-----|--------------|
+| 1 | [01 — policy owns fulfillment](./01-policy-owns-fulfillment.md) | Moves destination fulfillment storage out of `Inbox` into the policy. `fulfill(...)` names its policy; the policy records the fulfillment (one-shot, `onlyPortal`) and builds/dispatches its own proof. |
+| 2 | [02 — reward legs & policy](./02-reward-legs-and-policy.md) | Replaces fixed reward amounts with `rate`+`flat` **reward legs** paired to `route.minTokens` (solver **input** floor). Hash-only proof facts (`ProofData{destination, fulfillmentHash}`), preimage-gated settle, `Account.withdraw` consults `IPolicy.previewRelease` (view). Repo-wide **Prover→Policy** and **Vault→Account** / `.creator`→`.keeper` renames. |
+| 3 | [03 — dual account + runtime](./03-dual-vault-runtime.md) | **Model C**: chain-parameterized dual Account salt `keccak(intentHash, roleChainId)` — source (escrow) vs destination (execution), collapsing to one on same-chain. `route.calls[]` → `(runtime, payload)`; `Account.execute` delegatecalls the runtime under an in-execute guard. Adds `intent.source` to the hash. `MulticallRuntime` is the default runtime. |
+| 4 | [04 — same-chain & gates](./04-same-chain-and-gates.md) | Reward-conservation postcondition (a runtime cannot touch reward escrow), `block.chainid` gates (`WrongSourceChain`/`WrongDestinationChain`), `fulfillAndSettle` one-tx same-chain solve. Destination `executeAsOwner` restricted to cross-chain. |
+| 5 | [05 — policy hooks](./05-policy-hooks.md) | Adds `reward.hooks` (opaque `bytes`, default `abi.encode(Hook[2])`): a reward hook post-settle and a refund hook post-refund, `delegatecall`ed by the Account CEI-last via try/catch (a reverting/malformed hook can never revert the committed settle/refund). |
+| 6 | [06 — streaming & deposits](./06-streaming-and-deposits.md) | Content-addressed `StreamingPolicy` for standing (re-fulfillable) intents; source-side settle/close; `H2` `NothingToFulfill` anti-poison guard protecting reusable deposit addresses; `Account.withdrawStream` (full-or-revert per slice). |
+| 7 | [07 — schedule policies](./07-schedule-policies.md) | Standalone `VestingPolicy`/`MilestonePolicy`/`DutchDecayPolicy` (own size budget, no Portal bytecode). Released-ledger advances by amount **paid** (balance-capped), never entitled, so an under-funded shortfall stays recoverable after top-up. |
+| 8 | [08 — deploy & release](./08-deploy-and-release.md) | `scripts/DeployV3.s.sol` (deterministic CREATE2/CREATE3, the **C1** right-aligned self-reference fix), release-pipeline retarget to the renamed contract set, and the TS SDK port. |
+
+## Vocabulary map (v2 → v3)
+
+| v2 | v3 | note |
+|----|----|------|
+| `Vault` | `Account` | per-intent identity/execution primitive, not just static escrow |
+| `Prover` | `Policy` | proof + settlement surface |
+| `Route.creator` / `Reward.creator` | `Route.keeper` / `Reward.keeper` | the owner/retrieval authority |
+| fixed `Reward` amounts | `RewardToken{rate, flat}` legs | scales on provided input |
+| `route.recipient` + auto-sweep | (removed) | unopinionated core: keeper retrieves via payload |
+| `route.calls[]` | `route.runtime` + `route.payload` | delegatecall execution |

--- a/docs/v3/08-deploy-and-release.md
+++ b/docs/v3/08-deploy-and-release.md
@@ -1,0 +1,92 @@
+# PR8 — deploy script, release pipeline, TS SDK
+
+> Ships the operational layer for v3: a deterministic Foundry deploy script (with the **C1** self-reference
+> fix), the npm release-pipeline retarget to the renamed contract set, and a minimal TypeScript SDK. Part
+> of the [v3 stack](./00-overview.md); user-facing upgrade story in
+> [`migration-from-v2.md`](./migration-from-v2.md).
+
+## 1. `scripts/DeployV3.s.sol` — deterministic deploy
+
+`deploy(Config)` brings up the full v3 set for one chain. It is env-free (a test drives it with a struct);
+`run()` / `runTron()` read env, `vm.startBroadcast`, and call it.
+
+### Two address families
+
+| Family | Contracts | Method | Why the address is identical on every chain |
+|--------|-----------|--------|---------------------------------------------|
+| **CREATE2** (SingletonFactory `0xce00…cf9f`) | `Portal`/`PortalTron`, `MulticallRuntime` | no ctor args ⇒ fixed creation bytecode | CREATE2 = f(factory, salt, bytecode). Same bytecode + salt ⇒ same address (EVM; TVM uses the `0x41` prefix, so its family differs by construction). |
+| **CREATE3** (canonical deployer `0xC6BAd1…66814`) | all policies (`Local`, `Hyper`, `Meta`, `LayerZero`, `CCIP`, `Polymer`, `Streaming`, `Vesting`, `Milestone`, `DutchDecay`) | chain-specific ctor args | CREATE3 = f(deployer, salt) **only** — independent of bytecode/ctor-args — so differing bridge endpoints per chain still land on one address. |
+
+Per-contract salt: `keccak256(abi.encode(SALT, keccak256(name)))`; the Portal uses the bare `SALT`. Same
+`DEPLOYER_PRIVATE_KEY` + `SALT` must be used on every chain. The script bootstraps the CREATE3 deployer via
+the SingletonFactory when absent.
+
+### C1 — the right-aligned self-reference (safety-critical)
+
+Each transport policy (`Hyper`/`Meta`/`LayerZero`/`CCIP`) bakes an IMMUTABLE peer whitelist at
+construction that lists its OWN CREATE3 address (its peer on every other chain) plus the configured non-EVM
+peers. That self-reference **must** be stored RIGHT-aligned:
+
+```solidity
+provers[0] = self.toBytes32();          // bytes32(uint256(uint160(self)))   ✓ correct
+// NOT: bytes32(bytes20(self))          // left-aligned                       ✗ C1 bug
+```
+
+The transports deliver the cross-chain sender right-aligned (`MessageBridgePolicy._handleCrossChainMessage`
+checks `isWhitelisted(messageSender)` against that form). A left-aligned self-reference makes the immutable
+`==` never match, so **every EVM↔EVM proof is rejected and solver funds lock**. This encoding mismatch has
+appeared before in this codebase's deploy tooling — `DeployV3` uses `AddressConverter.toBytes32` consistently
+to avoid it.
+
+`test/v3/deploy/DeployV3.t.sol` asserts, for every transport policy:
+`getWhitelist()[0] == self.toBytes32()`, `isWhitelisted(rightAligned) == true`, and — the regression guard
+— `isWhitelisted(bytes32(bytes20(self))) == false`. Plus existence, CREATE2/CREATE3 re-derivation,
+idempotent re-deploy, and portal wiring. (7 tests, all green.)
+
+Polymer's whitelist is the configured cross-VM peers only (no self-reference) — it authenticates the origin
+policy on the source chain via source-emitted events, mirroring the production pattern.
+
+### Env vars
+
+`SALT`, `DEPLOYER_PRIVATE_KEY` (falls back to `PRIVATE_KEY`); per-transport endpoints
+(`MAILBOX_CONTRACT`, `ROUTER_CONTRACT`, `LAYERZERO_ENDPOINT` [+ `LAYERZERO_DELEGATE`], `CCIP_ROUTER`,
+`POLYMER_CROSS_L2_PROVER_V2` [+ `POLYMER_MAX_LOG_DATA_SIZE`]) — a zero endpoint skips that policy; per-bridge
+cross-VM peer lists (`HYPER_CROSS_VM_PROVERS`, `META_CROSS_VM_PROVERS`, `LAYERZERO_CROSS_VM_PROVERS`,
+`CCIP_CROSS_VM_PROVERS`, `POLYMER_CROSS_VM_PROVERS`); `MIN_GAS_LIMIT`; `DEPLOY_LOCAL_POLICY` (default true),
+`DEPLOY_SCHEDULE_POLICIES` (default false) + `SCHEDULE_RELAYS`; `DEPLOY_FILE` for the address CSV.
+
+### TRON
+
+`runTron()` uses `PortalTron`/`AccountTron`/`LocalPolicyTron` and the `0x41` CREATE2 prefix. As with main,
+`forge` cannot broadcast to the TVM — `runTron()` produces the authoritative deploy logic + address
+prediction, but a TVM-native harness for the actual broadcast is a remaining follow-up (see loss
+inventory).
+
+## 2. Release pipeline
+
+`scripts/semantic-release/sr-build-package.ts` `CONTRACT_TYPES` is retargeted to the full v3 deployed set
+(the address-CSV/JSON columns + generated TS types): `Portal`, `MulticallRuntime`, `LocalPolicy`,
+`HyperPolicy`, `MetaPolicy`, `LayerZeroPolicy`, `CCIPPolicy`, `PolymerPolicy`, `StreamingPolicy`,
+`VestingPolicy`, `MilestonePolicy`, `DutchDecayPolicy`. `gen-bytecode.ts` (CREATE2 bytecode prediction)
+covers the two no-ctor-arg contracts (`Portal`, `MulticallRuntime`); the transport policies are CREATE3
+(address independent of bytecode) so are not bytecode-derived there. The build-package spec test was
+updated to assert the real (not mocked-stale) set.
+
+## 3. TypeScript SDK (`src/`)
+
+A minimal, dependency-light SDK (viem) matching the FINAL structs and hash scheme:
+
+- `src/types.ts` — `Route`/`Reward`/`Intent`/`TokenAmount`/`RewardToken`/`Hook` (+ `WAD`).
+- `src/hashing.ts` — `hashRoute`/`hashReward`/`hashIntent`/`hashFulfillment` (source-in-hash; ABI tuple
+  strings mirror `contracts/types/Intent.sol`).
+- `src/addresses.ts` — `accountSalt(intentHash, roleChainId)` and `predictAccountAddress(...)`. The Account
+  is a CREATE2 clone deployed by the Portal; prediction takes the deployment-specific
+  `proxyInitCodeHash = keccak256(Proxy.creationCode ++ abi.encode(accountImplementation))` as input.
+
+Parity is proven by a golden vector: `test/v3/sdk/GoldenVector.t.sol` emits the route/reward/intent hashes
+of a fixed intent from Solidity; `src/__tests__/hashing.test.ts` builds the same intent in TS and asserts
+byte-identical hashes (jest `testMatch` extended to `src/__tests__`).
+
+**Status / scope:** this is a lightweight port — hashing + account-salt + address prediction with a
+golden-vector spot-check, not a full parity harness or a published-ABI/addresses bundle. Broader SDK
+surface (ABIs, per-chain address exports, ERC-7683 order encoding) is left as follow-up.

--- a/docs/v3/migration-from-v2.md
+++ b/docs/v3/migration-from-v2.md
@@ -1,0 +1,128 @@
+# Migrating from v2 (main) to v3
+
+> The full user-facing upgrade story: what changed in the structs, the renames, and the new models. For
+> the reading order of the design docs see [`00-overview.md`](./00-overview.md); for deliberate narrowings
+> see [`migration-loss-inventory.md`](./migration-loss-inventory.md).
+
+## 1. Struct changes
+
+### Route
+```solidity
+// v2
+struct Route { bytes32 salt; uint64 deadline; uint64 source; uint64 destination;
+               address inbox; TokenAmount[] tokens; Call[] calls; }
+// v3
+struct Route { bytes32 salt; uint64 deadline; address portal; address keeper;
+               address runtime; bytes payload; TokenAmount[] minTokens; }
+```
+- `inbox` → `portal` (the combined contract).
+- `calls[]` → `runtime` + `payload`. Execution is now a single `delegatecall` into a keeper-chosen
+  runtime with an opaque payload; `MulticallRuntime` reproduces the old `Call[]` behavior (its payload is
+  `abi.encode(Call[])`).
+- `tokens[]` → `minTokens[]`. These are a **solver INPUT floor**, not an output guarantee (see §4).
+- new `keeper` — the destination-side Account owner (authenticates `executeAsOwner` on the destination,
+  which does not have the `Reward`). Distinct from `reward.keeper` (may differ cross-VM).
+- `source`/`destination` moved OUT of `Route` and up to `Intent` (see below).
+
+### Reward
+```solidity
+// v2
+struct Reward { uint64 deadline; address creator; address prover; address nativeAmount?;
+                TokenAmount[] tokens; }
+// v3
+struct Reward { uint64 deadline; address keeper; address prover;
+                RewardToken[] tokens; bytes hooks; }
+```
+- `creator` → `keeper`.
+- fixed `TokenAmount` rewards → `RewardToken{token, rate, flat}` **legs** (see §3).
+- native is no longer a separate field — it folds in as a `RewardToken` leg with `token == address(0)`.
+- new `hooks` — opaque `bytes` (default `abi.encode(Hook[2])`: a post-settle reward hook and a post-refund
+  refund hook).
+
+### Intent
+```solidity
+// v3
+struct Intent { uint64 source; uint64 destination; Route route; Reward reward; }
+```
+- `source`/`destination` are now top-level and are folded into the intent hash (Model C, §5).
+
+### Hashing
+```
+routeHash       = keccak256(abi.encode(route))
+rewardHash      = keccak256(abi.encode(reward))
+intentHash      = keccak256(abi.encodePacked(uint64 source, uint64 destination, routeHash, rewardHash))
+fulfillmentHash = keccak256(abi.encode(intentHash, claimant, fulfilled))
+```
+`intentHash` now commits `source`+`destination` — a v2 hash will NOT match a v3 hash even for the "same"
+intent. Off-chain tooling must recompute (see the TS SDK in [`08`](./08-deploy-and-release.md)).
+
+## 2. Renames (Vault→Account, Prover→Policy, creator→keeper)
+
+| v2 | v3 |
+|----|----|
+| `Vault` / `IVault` / `VaultDeployer` | `Account` / `IAccount` / `AccountDeployer` |
+| `contracts/vault/*` | `contracts/account/*` (+ `contracts/tron/AccountTron.sol`) |
+| `Prover` / `HyperProver` / … | `Policy` / `HyperPolicy` / … |
+| `Route.creator`, `Reward.creator` | `Route.keeper`, `Reward.keeper` |
+| `NotCreatorCaller` etc. | `NotKeeperCaller` etc. |
+
+The rename is branding for the ephemeral/streaming **"eco accounts"** model: `Vault` implied static
+custodial escrow; `Account` signals a general per-intent identity/execution primitive.
+
+## 3. Reward legs (rate + flat) vs fixed amounts
+
+v2 paid a fixed `TokenAmount` per reward token. v3 pays per-leg:
+
+```
+payout_j = flat_j + rate_j * provided_j / WAD          (WAD = 1e18)
+```
+capped at the escrowed balance. `provided_j` is what the solver actually delivered for the paired
+`minTokens` leg. A `rate` of one WAD is 1:1 with provided input; a pure `flat` leg (rate 0) is a fixed
+tip (e.g. `{address(0), 0, gasAmount}` for a native gas reward). This lets one funded intent serve a
+range of fill sizes and scales the reward with the solver's actual contribution.
+
+## 4. minTokens: an INPUT floor, not an output guarantee
+
+v2's `route.tokens[]` were measured as a recipient balance-delta (an OUTPUT guarantee). v3's
+`route.minTokens[]` are the minimum the **solver must provide as input**; the solver may provide more, and
+`fulfilled[j] = provided[j]`. There is **no on-chain output guarantee** — delivery correctness rests
+entirely on the keeper-committed `runtime`/`payload` being honest, which the solver inspects before
+filling. This is a deliberate, signed-off narrowing (see loss inventory). Reward-conservation still
+protects the solver's escrow from a malicious runtime during same-chain execution.
+
+## 5. Unopinionated core: no recipient, no sweep, keeper + payload
+
+v2 delivered route output to a `route.recipient` and swept leftovers. v3 removes both:
+- **No `recipient`.** There is no protocol-level delivery target.
+- **No auto-sweep.** Unconsumed solver input stays in the intent's own Account.
+- **Keeper retrieval.** `route.keeper` (destination) / `reward.keeper` (source) retrieve funds later via
+  `executeAsOwner(runtime, payload)` — any "delivery" is expressed in the payload, not the protocol.
+
+> Note: a two-owner model with `route.recipient` + a `rescueDestination` path existed BRIEFLY mid-develop
+> and was then REMOVED by the unopinionated-core decision. `route.keeper` is the sole destination
+> authority now; there is no recipient role.
+
+### Model C dual Account (source-in-hash)
+The per-intent Account salt is chain-parameterized: `keccak256(abi.encode(intentHash, roleChainId))` where
+`roleChainId` is `intent.source` for the escrow account and `intent.destination` for the execution
+account. Cross-chain these are two distinct addresses (escrow on source, execution on destination);
+same-chain (`source == destination`) they collapse to ONE. This fixes the A→B vs B→B account confusion
+and cross-chain replay by construction.
+
+## 6. Streaming intents & schedule policies
+
+- **Streaming** ([06](./06-streaming-and-deposits.md)): a standing, re-fulfillable intent settled by a
+  content-addressed `StreamingPolicy`; per-fulfillment slices proven in batches, paid full-or-revert.
+- **Schedule policies** ([07](./07-schedule-policies.md)): `VestingPolicy`/`MilestonePolicy`/
+  `DutchDecayPolicy` gate release over time/milestones/decay. Standalone contracts (no Portal bytecode).
+
+## 7. What a v2 integrator must change
+
+1. Rebuild intents with the v3 structs (keeper, minTokens, runtime/payload, source/destination on Intent,
+   reward legs, hooks).
+2. Recompute hashes and predicted Account addresses (source-in-hash; use the v3 SDK).
+3. Replace `recipient`-based delivery with a `runtime`+`payload` (e.g. `MulticallRuntime` +
+   `abi.encode(Call[])`), and plan keeper-side retrieval of any leftover.
+4. Name a `Policy` (not a Prover) in `reward.prover`; for same-chain use `fulfillAndSettle`.
+5. Solvers: supply route input capital (no zero-capital flash) and inspect the runtime/payload since there
+   is no on-chain output guarantee.

--- a/docs/v3/migration-loss-inventory.md
+++ b/docs/v3/migration-loss-inventory.md
@@ -32,8 +32,57 @@ committed claimant, so the anti-griefing guarantee (a bad-claimant fulfillment c
 keeper's funds) is preserved by the deadline instead: after `reward.deadline` an unsettled intent is
 always refundable. Accepted (documented in `IntentSource._validateRefund`).
 
+## batchWithdraw removed
+v2 exposed a `batchWithdraw` to settle many intents in one call. v3 does not carry it — settlement is
+per-intent (and, for streaming, per-batch inside one policy). Accepted: the multi-intent convenience is out
+of scope; a caller batches at the tx level instead. (The generated `contracts/README.md` still documents
+`batchWithdraw`; that file is stale and regenerated in PR8.)
+
+## Destination prove-time `IntentProven` event dropped
+In v2 the destination emitted an `IntentProven` at prove time. Under the v3 hash-only model the source-side
+`IntentProven(intentHash, destination, fulfillmentHash)` (emitted by the policy on the source when the fact
+lands — see `BasePolicy`/`PolymerPolicy`/`ScheduledPolicy`) is the authoritative proof event; the separate
+destination prove-time event was removed as redundant. Accepted (an observability change, not a
+correctness one).
+
+## `IntentPublished` not extended with `hooks` (observability gap)
+PR5 added `reward.hooks` but did NOT add the hooks bytes to the `IntentPublished` event. Off-chain indexers
+that want the hooks must read them from the funding calldata / the committed `rewardHash` preimage rather
+than the event. Accepted as a low-priority observability gap; flagged as a follow-up (extend
+`IntentPublished` with `hooks`).
+
+## Two-owner model reversed by the unopinionated core
+A `route.recipient` + a separate `rescueDestination` retrieval path existed BRIEFLY during development (the
+"two-owner model", a.k.a. earlier diff-review "finding #8"). The unopinionated-core decision REMOVED both:
+there is no recipient, and destination retrieval is `route.keeper` via `executeAsOwner`. Recorded here so
+the reversal is explicit — any reference to `route.recipient`/`rescueDestination` is stale.
+
+## Arc kept (not deprecated)
+The CCTPMint **Arc** deposit family was KEPT (alongside CCTPMint_GatewayERC20 and USDCTransfer_Solana), not
+deprecated. Decision recorded so a future cleanup does not assume it was dropped.
+
+## optimizer_runs per branch (downstream gas expectations)
+`optimizer_runs` is NOT uniform across the stack — the streaming settle/close paths genuinely need a lower
+value to keep `Portal`/`PortalTron` under the 24,576-byte limit. Final per-branch values (foundry.toml +
+hardhat.config.ts kept in lockstep):
+
+| branch | optimizer_runs | Portal size |
+|--------|---------------:|------------:|
+| v3/03 | 1,000,000 | 24,380 |
+| v3/04 | 20,000 | 22,880 |
+| v3/05 | 20,000 | 23,536 |
+| v3/06 | 1,000 | 23,649 |
+| v3/07, v3/08 | 1,000 | 23,649 |
+
+Downstream gas/size expectations should use the per-branch value, not a single global one.
+
 ## Deferred (tracked, not lost)
 - Deposit-address migration onto standing streaming intents — deferred to a PR6b follow-up; the H2
   anti-poison guard and all deposit families stay functional in the meantime.
-- Generated `contracts/README.md` and the root docs still carry v2/pre-rename wording — regenerated in the
-  deploy/docs stage (PR8).
+- Root/generated docs (`README.md`, `contracts/README.md`, `localprover_flows.md`,
+  `deposit_address_userflow.md`, and the `CLAUDE.md`/`SECURITY.md` policy docs) still carry v2/pre-rename
+  wording (`Vault`, `Prover`, `.creator`) and pre-v3 architecture. PR8 authors the NEW v3 docs
+  (`docs/v3/*`) but does NOT rewrite these — a safe rewrite (esp. the generated `contracts/README.md` and
+  the governance docs) is a doc-only follow-up larger than PR8's budget. The canonical v3 reference is
+  `docs/v3/` (see [`00-overview.md`](./00-overview.md)).
+- TVM broadcast tooling for `runTron()` (see [`08-deploy-and-release.md`](./08-deploy-and-release.md)).

--- a/docs/v3/migration-loss-inventory.md
+++ b/docs/v3/migration-loss-inventory.md
@@ -86,3 +86,20 @@ Downstream gas/size expectations should use the per-branch value, not a single g
   the governance docs) is a doc-only follow-up larger than PR8's budget. The canonical v3 reference is
   `docs/v3/` (see [`00-overview.md`](./00-overview.md)).
 - TVM broadcast tooling for `runTron()` (see [`08-deploy-and-release.md`](./08-deploy-and-release.md)).
+
+## Accepted residual risk: anti-lock refund vs. cross-chain in-flight window
+`IntentSource._validateRefund` makes the reward **always refundable after `reward.deadline`**, regardless of
+proof state (a terminal/proven intent still allows a dust-recovery refund). This is a deliberate trade: the
+hash-only fact model gives the source no way to introspect a fulfillment's claimant before settlement, so a
+bad-claimant fulfillment could otherwise permanently lock the keeper's funds — the deadline is the one
+definitive settlement window instead.
+
+The trade's edge case: a solver who fulfills a **cross-chain** intent shortly before `reward.deadline`, whose
+proof has not yet been bridged and settled back to the source chain by the time the deadline passes, can be
+refunded out by the keeper — the solver delivered but is not paid. (Same-chain and already-settled intents are
+unaffected; streaming intents are additionally protected pre-deadline by `StreamingPolicy.provenIntents`
+correctly reporting an unsettled batch as a valid proof, which blocks the generic `refund()` path the same way
+`closeStream`'s explicit gate does.) Mitigation is operational, not code: **`reward.deadline` should be set
+with enough margin over the slowest bridge's expected settlement time** for the intent's route. This narrow
+window is unchanged in spirit from the pre-v3 design and was reviewed and accepted, not newly introduced by
+this train.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,10 @@
 module.exports = {
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/'],
-  testMatch: ['**/scripts/semantic-release/tests/**/*.spec.ts'],
+  testMatch: [
+    '**/scripts/semantic-release/tests/**/*.spec.ts',
+    '**/src/__tests__/**/*.test.ts',
+  ],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {}],
   },

--- a/scripts/DeployV3.s.sol
+++ b/scripts/DeployV3.s.sol
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Forge
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+
+// Deterministic-deploy infra
+import {SingletonFactory} from "../contracts/tools/SingletonFactory.sol";
+import {ICreate3Deployer} from "../contracts/tools/ICreate3Deployer.sol";
+
+// Address encoding (the C1-critical helper: RIGHT-aligned bytes32)
+import {AddressConverter} from "../contracts/libs/AddressConverter.sol";
+
+// Core (no ctor args => CREATE2, identical address on every chain)
+import {Portal} from "../contracts/Portal.sol";
+import {PortalTron} from "../contracts/tron/PortalTron.sol";
+import {MulticallRuntime} from "../contracts/runtime/MulticallRuntime.sol";
+
+// Same-chain settlement (portal-only ctor)
+import {LocalPolicy} from "../contracts/prover/LocalPolicy.sol";
+import {LocalPolicyTron} from "../contracts/tron/LocalPolicyTron.sol";
+
+// Transport+settlement policies (chain-specific ctor args => CREATE3; self-referencing peer whitelist)
+import {HyperPolicy} from "../contracts/prover/HyperPolicy.sol";
+import {MetaPolicy} from "../contracts/prover/MetaPolicy.sol";
+import {LayerZeroPolicy} from "../contracts/prover/LayerZeroPolicy.sol";
+import {CCIPPolicy} from "../contracts/prover/CCIPPolicy.sol";
+import {PolymerPolicy} from "../contracts/prover/PolymerPolicy.sol";
+
+// Schedule / streaming settlement policies (portal + off-chain relayer whitelist)
+import {StreamingPolicy} from "../contracts/prover/StreamingPolicy.sol";
+import {VestingPolicy} from "../contracts/prover/VestingPolicy.sol";
+import {MilestonePolicy} from "../contracts/prover/MilestonePolicy.sol";
+import {DutchDecayPolicy} from "../contracts/prover/DutchDecayPolicy.sol";
+
+/**
+ * @title DeployV3
+ * @notice Deterministic, env-driven Foundry deployer for the Eco Routes v3 contract set.
+ *
+ * @dev Deterministic-address strategy (why addresses line up on every chain):
+ *
+ *   - Portal / PortalTron + MulticallRuntime take NO constructor args, so their creation bytecode is
+ *     fixed and CREATE2 (via the EIP-2470 SingletonFactory at {SINGLETON_FACTORY}) yields an IDENTICAL
+ *     address on every EVM chain for a given salt (TVM uses the 0x41 CREATE2 prefix, so its family
+ *     differs from the EVM family by construction).
+ *   - Every policy takes chain-specific constructor args (bridge endpoints, peer lists). Their addresses
+ *     must STILL match across chains, so they deploy via CREATE3 (canonical ICreate3Deployer at
+ *     {CREATE3_DEPLOYER}). A CREATE3 address is a pure function of (deployer, salt) — INDEPENDENT of
+ *     bytecode and ctor args — so the same (deployer, per-contract salt) resolves to the same address on
+ *     every chain despite differing endpoints. A transport policy predicts its OWN CREATE3 address first
+ *     and stores it as peer[0] of its immutable whitelist (its peer on every other chain == its own
+ *     address here).
+ *
+ *   C1 (critical): a transport policy's self-reference in its peer whitelist MUST be stored RIGHT-aligned
+ *   as `AddressConverter.toBytes32(self) == bytes32(uint256(uint160(self)))` — the exact form every
+ *   transport delivers the cross-chain sender in (see {MessageBridgePolicy._handleCrossChainMessage}).
+ *   The LEFT-aligned `bytes32(bytes20(self))` form silently makes the immutable `==` never match, so
+ *   every EVM<->EVM proof is rejected and solver funds lock. This script uses ONLY the right-aligned
+ *   form; {test/v3/deploy/DeployV3.t.sol} asserts it and rejects the left-aligned regression.
+ *
+ *   Per-contract salt: `keccak256(abi.encode(SALT, keccak256(bytes(name))))` (the v2 getContractSalt
+ *   rule). The Portal uses the bare SALT.
+ *
+ *   Deployer identity: a CREATE3 address depends on the msg.sender of the deployer's `deploy` call. Under
+ *   `vm.startBroadcast` that is the deployer EOA, so the SAME deployer key + SALT must be used on every
+ *   chain for the addresses to line up.
+ */
+contract DeployV3 is Script {
+    using AddressConverter for address;
+
+    // --- Canonical deterministic-deploy infra -------------------------------
+
+    SingletonFactory internal constant CREATE2_SINGLETON =
+        SingletonFactory(0xce0042B868300000d44A59004Da54A005ffdcf9f);
+    ICreate3Deployer internal constant CREATE3_DEPLOYER_C =
+        ICreate3Deployer(0xC6BAd1EbAF366288dA6FB5689119eDd695a66814);
+
+    // CREATE3 deployer creation code (bootstrapped via the SingletonFactory when absent).
+    bytes internal constant CREATE3_DEPLOYER_BYTECODE =
+        hex"60a060405234801561001057600080fd5b5060405161002060208201610044565b601f1982820381018352601f90910116604052805160209190910120608052610051565b6101a080610ccf83390190565b608051610c5c610073600039600081816103d701526105410152610c5c6000f3fe6080604052600436106100345760003560e01c80634af63f0214610039578063c2b1041c14610075578063cf4d643214610095575b600080fd5b61004c6100473660046108b7565b6100a8565b60405173ffffffffffffffffffffffffffffffffffffffff909116815260200160405180910390f35b34801561008157600080fd5b5061004c6100903660046108fc565b61018c565b61004c6100a336600461096f565b6101e5565b6040805133602082015290810182905260009081906060016040516020818303038152906040528051906020012090506100e28482610372565b9150341561010a5761010a73ffffffffffffffffffffffffffffffffffffffff83163461048b565b61011484826104d5565b9150823373ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fd579261046780ec80c4dae1bc57abdb62c58df8af1531e63b4e8bcc08bcf46ec878051906020012060405161017d91815260200190565b60405180910390a45092915050565b6040805173ffffffffffffffffffffffffffffffffffffffff8416602082015290810182905260009081906060016040516020818303038152906040528051906020012090506101dc8582610372565b95945050505050565b60408051336020820152908101849052600090819060600160405160208183030381529060405280519060200120905061021f8682610372565b915034156102475761024773ffffffffffffffffffffffffffffffffffffffff83163461048b565b61025186826104d5565b9150843373ffffffffffffffffffffffffffffffffffffffff168373ffffffffffffffffffffffffffffffffffffffff167fd579261046780ec80c4dae1bc57abdb62c58df8af1531e63b4e8bcc08bcf46ec89805190602001206040516102ba91815260200190565b60405180910390a460008273ffffffffffffffffffffffffffffffffffffffff1685856040516102eb929190610a0a565b6000604051808303816000865af19150503d8060008114610328576040519150601f19603f3d011682016040523d82523d6000602084013e61032d565b606091505b5050905080610368576040517f139c636700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5050949350505050565b604080517fff000000000000000000000000000000000000000000000000000000000000006020808301919091527fffffffffffffffffffffffffffffffffffffffff00000000000000000000000030606090811b82166021850152603584018690527f0000000000000000000000000000000000000000000000000000000000000000605580860191909152855180860390910181526075850186528051908401207fd6940000000000000000000000000000000000000000000000000000000000006095860152901b1660978301527f010000000000000000000000000000000000000000000000000000000000000060ab8301528251808303608c01815260ac90920190925280519101206000905b9392505050565b600080600080600085875af19050806104d0576040517ff4b3b1bc00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b505050565b60006104848383604080517fff000000000000000000000000000000000000000000000000000000000000006020808301919091527fffffffffffffffffffffffffffffffffffffffff00000000000000000000000030606090811b82166021850152603584018690527f0000000000000000000000000000000000000000000000000000000000000000605580860191909152855180860390910181526075850186528051908401207fd6940000000000000000000000000000000000000000000000000000000000006095860152901b1660978301527f010000000000000000000000000000000000000000000000000000000000000060ab8301528251808303608c01815260ac90920190925280519101208251600003610625576040517f21744a5900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6106448173ffffffffffffffffffffffffffffffffffffffff16610783565b1561067b576040517fa6ef0ba100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60008260405161068a906107d0565b8190604051809103906000f59050801580156106aa573d6000803e3d6000fd5b50905073ffffffffffffffffffffffffffffffffffffffff81166106fa576040517fb4f5411100000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6040517e77436000000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff821690627743609061074a908790600401610a1a565b600060405180830381600087803b15801561076457600080fd5b505af1158015610778573d6000803e3d6000fd5b505050505092915050565b600073ffffffffffffffffffffffffffffffffffffffff82163f801580159061048457507fc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470141592915050565b6101a080610a8783390190565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b600082601f83011261081d57600080fd5b813567ffffffffffffffff80821115610838576108386107dd565b604051601f83017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f0116810190828211818310171561087e5761087e6107dd565b8160405283815286602085880101111561089757600080fd5b836020870160208301376000602085830101528094505050505092915050565b600080604083850312156108ca57600080fd5b823567ffffffffffffffff8111156108e157600080fd5b6108ed8582860161080c565b95602094909401359450505050565b60008060006060848603121561091157600080fd5b833567ffffffffffffffff81111561092857600080fd5b6109348682870161080c565b935050602084013573ffffffffffffffffffffffffffffffffffffffff8116811461095e57600080fd5b929592945050506040919091013590565b6000806000806060858703121561098557600080fd5b843567ffffffffffffffff8082111561099d57600080fd5b6109a98883890161080c565b95506020870135945060408701359150808211156109c657600080fd5b818701915087601f8301126109da57600080fd5b8135818111156109e957600080fd5b8860208285010111156109fb57600080fd5b95989497505060200194505050565b8183823760009101908152919050565b600060208083528351808285015260005b81811015610a4757858101830151858201604001528201610a2b565b5060006040828601015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f830116850101925050509291505056fe608060405234801561001057600080fd5b50610180806100206000396000f3fe60806040526004361061001d5760003560e01c806277436014610022575b600080fd5b61003561003036600461007b565b610037565b005b8051602082016000f061004957600080fd5b50565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b60006020828403121561008d57600080fd5b813567ffffffffffffffff808211156100a557600080fd5b818401915084601f8301126100b957600080fd5b8135818111156100cb576100cb61004c565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f011681019083821181831017156101115761011161004c565b8160405282815287602084870101111561012a57600080fd5b82602086016020830137600092810160200192909252509594505050505056fea2646970667358221220a30aa0b079a504f6336b7e339659f909f468dcfe513766d3086e1efce2657d5164736f6c63430008130033a26469706673582212203a8a2818751a76f13bac296ad23080c23254ec57b82f46e2953af00c5cc5ecb464736f6c63430008130033608060405234801561001057600080fd5b50610180806100206000396000f3fe60806040526004361061001d5760003560e01c806277436014610022575b600080fd5b61003561003036600461007b565b610037565b005b8051602082016000f061004957600080fd5b50565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b60006020828403121561008d57600080fd5b813567ffffffffffffffff808211156100a557600080fd5b818401915084601f8301126100b957600080fd5b8135818111156100cb576100cb61004c565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f011681019083821181831017156101115761011161004c565b8160405282815287602084870101111561012a57600080fd5b82602086016020830137600092810160200192909252509594505050505056fea2646970667358221220a30aa0b079a504f6336b7e339659f909f468dcfe513766d3086e1efce2657d5164736f6c63430008130033";
+
+    uint256 internal constant DEFAULT_MIN_GAS_LIMIT = 200_000;
+    uint256 internal constant DEFAULT_POLYMER_MAX_LOG_DATA_SIZE = 8_192;
+
+    uint256 internal constant TRON_MAINNET_CHAIN_ID = 728126428;
+    uint256 internal constant TRON_SHASTA_CHAIN_ID = 2494104990;
+    uint256 internal constant TRON_NILE_CHAIN_ID = 3448148188;
+
+    // --- Config / output structs -------------------------------------------
+
+    struct Config {
+        bytes32 salt; // root CREATE2/CREATE3 salt (identical across chains)
+        address deployer; // CREATE3 sender (== broadcasting EOA)
+        bool isTron; // use PortalTron/AccountTron/LocalPolicyTron + 0x41 CREATE2 prefix
+        // transport endpoints (zero => that transport policy is skipped)
+        address mailbox; // Hyperlane
+        address router; // Metalayer
+        address lzEndpoint; // LayerZero v2
+        address lzDelegate; // LayerZero delegate (defaults to deployer)
+        address ccipRouter; // Chainlink CCIP
+        address polymerCrossL2Prover; // Polymer CrossL2ProverV2
+        uint256 polymerMaxLogDataSize; // Polymer log guard (defaults to 8192)
+        uint256 minGasLimit; // Meta/LZ/CCIP min gas (defaults to 200000)
+        // non-EVM peer policy addresses (bytes32), appended after the EVM self-reference
+        bytes32[] hyperCrossVm;
+        bytes32[] metaCrossVm;
+        bytes32[] lzCrossVm;
+        bytes32[] ccipCrossVm;
+        bytes32[] polymerCrossVm;
+        // schedule/streaming settlement policies
+        bool deploySchedulePolicies;
+        bytes32[] scheduleRelays; // authorized off-chain relayer addrs (bytes32, right-aligned)
+        // same-chain settlement policy
+        bool deployLocalPolicy;
+    }
+
+    struct Deployment {
+        address portal;
+        address runtime;
+        address localPolicy;
+        address hyperPolicy;
+        address metaPolicy;
+        address layerZeroPolicy;
+        address ccipPolicy;
+        address polymerPolicy;
+        address streamingPolicy;
+        address vestingPolicy;
+        address milestonePolicy;
+        address dutchDecayPolicy;
+    }
+
+    // --- Entry points -------------------------------------------------------
+
+    function run() external returns (Deployment memory dep) {
+        Config memory cfg = _readConfig(false);
+        vm.startBroadcast(cfg.deployer);
+        dep = deploy(cfg);
+        vm.stopBroadcast();
+        _writeDeployFile(cfg, dep);
+    }
+
+    function runTron() external returns (Deployment memory dep) {
+        Config memory cfg = _readConfig(true);
+        vm.startBroadcast(cfg.deployer);
+        dep = deploy(cfg);
+        vm.stopBroadcast();
+        _writeDeployFile(cfg, dep);
+    }
+
+    /**
+     * @notice Deploy + wire the full v3 set for one chain. Env-free so a test can drive it with a struct.
+     * @dev Idempotent: re-running with the same (salt, deployer) returns the same addresses (already-deployed
+     *      contracts are detected and skipped).
+     */
+    function deploy(Config memory cfg) public returns (Deployment memory dep) {
+        _ensureCreate3Deployer(cfg.isTron);
+
+        // 1. Core (CREATE2, no ctor args).
+        dep.portal = _deployCreate2(
+            cfg.isTron
+                ? type(PortalTron).creationCode
+                : type(Portal).creationCode,
+            cfg.salt,
+            cfg.isTron
+        );
+        console.log("Portal:", dep.portal);
+
+        dep.runtime = _deployCreate2(
+            type(MulticallRuntime).creationCode,
+            _contractSalt(cfg.salt, "MULTICALL_RUNTIME"),
+            cfg.isTron
+        );
+        console.log("MulticallRuntime:", dep.runtime);
+
+        // 2. Same-chain settlement (portal-only ctor, CREATE3).
+        if (cfg.deployLocalPolicy) {
+            bytes memory code = cfg.isTron
+                ? abi.encodePacked(
+                    type(LocalPolicyTron).creationCode,
+                    abi.encode(dep.portal)
+                )
+                : abi.encodePacked(
+                    type(LocalPolicy).creationCode,
+                    abi.encode(dep.portal)
+                );
+            dep.localPolicy = _deployCreate3(
+                code,
+                cfg.deployer,
+                _contractSalt(cfg.salt, "LOCAL_POLICY")
+            );
+            console.log("LocalPolicy:", dep.localPolicy);
+        }
+
+        // 3. Transport policies (CREATE3, self-referencing right-aligned whitelist).
+        _deployTransports(cfg, dep);
+
+        // 4. Schedule / streaming settlement policies (CREATE3, off-chain relayer whitelist).
+        if (cfg.deploySchedulePolicies) {
+            _deploySchedulePolicies(cfg, dep);
+        }
+    }
+
+    // --- Transport policies -------------------------------------------------
+
+    function _deployTransports(
+        Config memory cfg,
+        Deployment memory dep
+    ) internal {
+        uint256 minGas = cfg.minGasLimit == 0
+            ? DEFAULT_MIN_GAS_LIMIT
+            : cfg.minGasLimit;
+
+        if (cfg.mailbox != address(0)) {
+            bytes32 salt = _contractSalt(cfg.salt, "HYPER_POLICY");
+            bytes32[] memory provers = _selfPlusPeers(salt, cfg.deployer, cfg.hyperCrossVm);
+            bytes memory code = abi.encodePacked(
+                type(HyperPolicy).creationCode,
+                abi.encode(cfg.mailbox, dep.portal, provers)
+            );
+            dep.hyperPolicy = _deployCreate3(code, cfg.deployer, salt);
+            console.log("HyperPolicy:", dep.hyperPolicy);
+        }
+
+        if (cfg.router != address(0)) {
+            bytes32 salt = _contractSalt(cfg.salt, "META_POLICY");
+            bytes32[] memory provers = _selfPlusPeers(salt, cfg.deployer, cfg.metaCrossVm);
+            bytes memory code = abi.encodePacked(
+                type(MetaPolicy).creationCode,
+                abi.encode(cfg.router, dep.portal, provers, minGas)
+            );
+            dep.metaPolicy = _deployCreate3(code, cfg.deployer, salt);
+            console.log("MetaPolicy:", dep.metaPolicy);
+        }
+
+        if (cfg.lzEndpoint != address(0)) {
+            bytes32 salt = _contractSalt(cfg.salt, "LAYERZERO_POLICY");
+            bytes32[] memory provers = _selfPlusPeers(salt, cfg.deployer, cfg.lzCrossVm);
+            address delegate = cfg.lzDelegate == address(0)
+                ? cfg.deployer
+                : cfg.lzDelegate;
+            bytes memory code = abi.encodePacked(
+                type(LayerZeroPolicy).creationCode,
+                abi.encode(cfg.lzEndpoint, delegate, dep.portal, provers, minGas)
+            );
+            dep.layerZeroPolicy = _deployCreate3(code, cfg.deployer, salt);
+            console.log("LayerZeroPolicy:", dep.layerZeroPolicy);
+        }
+
+        if (cfg.ccipRouter != address(0)) {
+            bytes32 salt = _contractSalt(cfg.salt, "CCIP_POLICY");
+            bytes32[] memory provers = _selfPlusPeers(salt, cfg.deployer, cfg.ccipCrossVm);
+            bytes memory code = abi.encodePacked(
+                type(CCIPPolicy).creationCode,
+                abi.encode(cfg.ccipRouter, dep.portal, provers, minGas)
+            );
+            dep.ccipPolicy = _deployCreate3(code, cfg.deployer, salt);
+            console.log("CCIPPolicy:", dep.ccipPolicy);
+        }
+
+        if (cfg.polymerCrossL2Prover != address(0)) {
+            bytes32 salt = _contractSalt(cfg.salt, "POLYMER_POLICY");
+            // Polymer's proof is source-emitted-event based; its whitelist authenticates the ORIGIN
+            // policy address on the source chain. Following the production pattern its peer list is the
+            // configured cross-VM peers only (no self-reference).
+            uint256 maxLog = cfg.polymerMaxLogDataSize == 0
+                ? DEFAULT_POLYMER_MAX_LOG_DATA_SIZE
+                : cfg.polymerMaxLogDataSize;
+            bytes memory code = abi.encodePacked(
+                type(PolymerPolicy).creationCode,
+                abi.encode(
+                    dep.portal,
+                    cfg.polymerCrossL2Prover,
+                    maxLog,
+                    cfg.polymerCrossVm
+                )
+            );
+            dep.polymerPolicy = _deployCreate3(code, cfg.deployer, salt);
+            console.log("PolymerPolicy:", dep.polymerPolicy);
+        }
+    }
+
+    /**
+     * @dev Build a transport policy's immutable peer whitelist: its OWN CREATE3 address (predicted from
+     *      salt+deployer) RIGHT-aligned as peer[0], then the configured non-EVM peers. Right-alignment via
+     *      {AddressConverter.toBytes32} is the C1-critical form — see the contract-level note.
+     */
+    function _selfPlusPeers(
+        bytes32 salt,
+        address deployer,
+        bytes32[] memory crossVm
+    ) internal view returns (bytes32[] memory provers) {
+        address self = CREATE3_DEPLOYER_C.deployedAddress(bytes(""), deployer, salt);
+        provers = new bytes32[](1 + crossVm.length);
+        provers[0] = self.toBytes32(); // RIGHT-aligned self-reference (C1)
+        for (uint256 i; i < crossVm.length; ++i) {
+            provers[i + 1] = crossVm[i];
+        }
+    }
+
+    // --- Schedule / streaming policies -------------------------------------
+
+    function _deploySchedulePolicies(
+        Config memory cfg,
+        Deployment memory dep
+    ) internal {
+        dep.streamingPolicy = _deployCreate3(
+            abi.encodePacked(
+                type(StreamingPolicy).creationCode,
+                abi.encode(dep.portal, cfg.scheduleRelays)
+            ),
+            cfg.deployer,
+            _contractSalt(cfg.salt, "STREAMING_POLICY")
+        );
+        console.log("StreamingPolicy:", dep.streamingPolicy);
+
+        dep.vestingPolicy = _deployCreate3(
+            abi.encodePacked(
+                type(VestingPolicy).creationCode,
+                abi.encode(dep.portal, cfg.scheduleRelays)
+            ),
+            cfg.deployer,
+            _contractSalt(cfg.salt, "VESTING_POLICY")
+        );
+        console.log("VestingPolicy:", dep.vestingPolicy);
+
+        dep.milestonePolicy = _deployCreate3(
+            abi.encodePacked(
+                type(MilestonePolicy).creationCode,
+                abi.encode(dep.portal, cfg.scheduleRelays)
+            ),
+            cfg.deployer,
+            _contractSalt(cfg.salt, "MILESTONE_POLICY")
+        );
+        console.log("MilestonePolicy:", dep.milestonePolicy);
+
+        dep.dutchDecayPolicy = _deployCreate3(
+            abi.encodePacked(
+                type(DutchDecayPolicy).creationCode,
+                abi.encode(dep.portal, cfg.scheduleRelays)
+            ),
+            cfg.deployer,
+            _contractSalt(cfg.salt, "DUTCH_DECAY_POLICY")
+        );
+        console.log("DutchDecayPolicy:", dep.dutchDecayPolicy);
+    }
+
+    // --- Deterministic-deploy primitives -----------------------------------
+
+    function _contractSalt(
+        bytes32 rootSalt,
+        string memory name
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(rootSalt, keccak256(abi.encodePacked(name))));
+    }
+
+    function _ensureCreate3Deployer(bool isTron) internal {
+        if (address(CREATE3_DEPLOYER_C).code.length == 0) {
+            address deployed = _deployCreate2(
+                CREATE3_DEPLOYER_BYTECODE,
+                bytes32(0),
+                isTron
+            );
+            require(
+                deployed == address(CREATE3_DEPLOYER_C),
+                "unexpected CREATE3 deployer address"
+            );
+            console.log("Bootstrapped CREATE3 deployer:", deployed);
+        }
+    }
+
+    function _deployCreate2(
+        bytes memory bytecode,
+        bytes32 salt,
+        bool isTron
+    ) internal returns (address addr) {
+        addr = _predictCreate2(bytecode, salt, isTron);
+        if (addr.code.length > 0) {
+            return addr;
+        }
+        address justDeployed = CREATE2_SINGLETON.deploy(bytecode, salt);
+        require(addr == justDeployed, "CREATE2 address mismatch");
+        require(addr.code.length > 0, "CREATE2 deploy failed");
+    }
+
+    function _predictCreate2(
+        bytes memory bytecode,
+        bytes32 salt,
+        bool isTron
+    ) internal pure returns (address) {
+        bytes1 prefix = isTron ? bytes1(0x41) : bytes1(0xff);
+        return
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                prefix,
+                                address(CREATE2_SINGLETON),
+                                salt,
+                                keccak256(bytecode)
+                            )
+                        )
+                    )
+                )
+            );
+    }
+
+    function _deployCreate3(
+        bytes memory bytecode,
+        address sender,
+        bytes32 salt
+    ) internal returns (address addr) {
+        addr = CREATE3_DEPLOYER_C.deployedAddress(bytecode, sender, salt);
+        if (addr.code.length > 0) {
+            return addr;
+        }
+        address justDeployed = CREATE3_DEPLOYER_C.deploy(bytecode, salt);
+        require(addr == justDeployed, "CREATE3 address mismatch");
+        require(addr.code.length > 0, "CREATE3 deploy failed");
+    }
+
+    // --- Env / output -------------------------------------------------------
+
+    function _readConfig(bool isTron) internal returns (Config memory cfg) {
+        cfg.isTron = isTron;
+        cfg.salt = vm.envBytes32("SALT");
+        cfg.deployer = vm.rememberKey(
+            vm.envOr("DEPLOYER_PRIVATE_KEY", vm.envUint("PRIVATE_KEY"))
+        );
+        cfg.mailbox = vm.envOr("MAILBOX_CONTRACT", address(0));
+        cfg.router = vm.envOr("ROUTER_CONTRACT", address(0));
+        cfg.lzEndpoint = vm.envOr("LAYERZERO_ENDPOINT", address(0));
+        cfg.lzDelegate = vm.envOr("LAYERZERO_DELEGATE", cfg.deployer);
+        cfg.ccipRouter = vm.envOr("CCIP_ROUTER", address(0));
+        cfg.polymerCrossL2Prover = vm.envOr(
+            "POLYMER_CROSS_L2_PROVER_V2",
+            address(0)
+        );
+        cfg.polymerMaxLogDataSize = vm.envOr(
+            "POLYMER_MAX_LOG_DATA_SIZE",
+            DEFAULT_POLYMER_MAX_LOG_DATA_SIZE
+        );
+        cfg.minGasLimit = vm.envOr("MIN_GAS_LIMIT", DEFAULT_MIN_GAS_LIMIT);
+        cfg.hyperCrossVm = _envPeers("HYPER_CROSS_VM_PROVERS");
+        cfg.metaCrossVm = _envPeers("META_CROSS_VM_PROVERS");
+        cfg.lzCrossVm = _envPeers("LAYERZERO_CROSS_VM_PROVERS");
+        cfg.ccipCrossVm = _envPeers("CCIP_CROSS_VM_PROVERS");
+        cfg.polymerCrossVm = _envPeers("POLYMER_CROSS_VM_PROVERS");
+        cfg.deployLocalPolicy = vm.envOr("DEPLOY_LOCAL_POLICY", true);
+        cfg.deploySchedulePolicies = vm.envOr(
+            "DEPLOY_SCHEDULE_POLICIES",
+            false
+        );
+        cfg.scheduleRelays = _envPeers("SCHEDULE_RELAYS");
+    }
+
+    function _envPeers(
+        string memory name
+    ) internal view returns (bytes32[] memory list) {
+        try vm.envBytes32(name, ",") returns (bytes32[] memory v) {
+            list = v;
+        } catch {
+            list = new bytes32[](0);
+        }
+    }
+
+    function _writeDeployFile(Config memory cfg, Deployment memory dep) internal {
+        string memory path = vm.envOr("DEPLOY_FILE", string(""));
+        if (bytes(path).length == 0) {
+            return;
+        }
+        _writeLine(path, dep.portal, "Portal");
+        _writeLine(path, dep.runtime, "MulticallRuntime");
+        _writeLine(path, dep.localPolicy, "LocalPolicy");
+        _writeLine(path, dep.hyperPolicy, "HyperPolicy");
+        _writeLine(path, dep.metaPolicy, "MetaPolicy");
+        _writeLine(path, dep.layerZeroPolicy, "LayerZeroPolicy");
+        _writeLine(path, dep.ccipPolicy, "CCIPPolicy");
+        _writeLine(path, dep.polymerPolicy, "PolymerPolicy");
+        _writeLine(path, dep.streamingPolicy, "StreamingPolicy");
+        _writeLine(path, dep.vestingPolicy, "VestingPolicy");
+        _writeLine(path, dep.milestonePolicy, "MilestonePolicy");
+        _writeLine(path, dep.dutchDecayPolicy, "DutchDecayPolicy");
+    }
+
+    function _writeLine(
+        string memory path,
+        address addr,
+        string memory name
+    ) internal {
+        if (addr == address(0)) {
+            return;
+        }
+        vm.writeLine(
+            path,
+            string(
+                abi.encodePacked(
+                    vm.toString(block.chainid),
+                    ",",
+                    vm.toString(addr),
+                    ",",
+                    name
+                )
+            )
+        );
+    }
+}

--- a/scripts/semantic-release/gen-bytecode.ts
+++ b/scripts/semantic-release/gen-bytecode.ts
@@ -42,19 +42,33 @@ const CREATE_X_ABI = [
 ]
 
 type Contract = {
-  name: 'Portal' | 'HyperPolicy'
+  name:
+    | 'Portal'
+    | 'MulticallRuntime'
+    | 'HyperPolicy'
+    | 'MetaPolicy'
+    | 'LayerZeroPolicy'
+    | 'CCIPPolicy'
+    | 'PolymerPolicy'
   path: string
   args: any[]
 }
 
-// List of contracts to deploy
+// Contracts whose deterministic address is a pure function of (bytecode, salt) via CREATE2 — i.e. the
+// no-constructor-arg core contracts. The transport policies deploy via CREATE3 (address independent of
+// bytecode/ctor-args, a function of deployer+salt only), so their addresses are NOT derived here — see
+// scripts/DeployV3.s.sol and docs/v3/08-deploy-and-release.md.
 const CONTRACTS_TO_DEPLOY: Contract[] = [
   {
     name: 'Portal',
     args: [],
     path: 'contracts/Portal.sol:Portal',
   },
-  // { name: 'HyperPolicy', args: [], path: 'contracts/prover/HyperPolicy.sol:HyperPolicy' },
+  {
+    name: 'MulticallRuntime',
+    args: [],
+    path: 'contracts/runtime/MulticallRuntime.sol:MulticallRuntime',
+  },
 ]
 
 /**

--- a/scripts/semantic-release/sr-build-package.ts
+++ b/scripts/semantic-release/sr-build-package.ts
@@ -35,9 +35,17 @@ import { zeroAddress } from 'viem'
 // This is used for both CSV headers and TypeScript type definitions
 export const CONTRACT_TYPES = [
   'Portal',
+  'MulticallRuntime',
+  'LocalPolicy',
   'HyperPolicy',
   'MetaPolicy',
   'LayerZeroPolicy',
+  'CCIPPolicy',
+  'PolymerPolicy',
+  'StreamingPolicy',
+  'VestingPolicy',
+  'MilestonePolicy',
+  'DutchDecayPolicy',
 ] as const
 
 const execPromise = promisify(exec)

--- a/scripts/semantic-release/tests/sr-build-package.spec.ts
+++ b/scripts/semantic-release/tests/sr-build-package.spec.ts
@@ -8,7 +8,7 @@ jest.mock('../sr-build-package', () => {
   const originalModule = jest.requireActual('../sr-build-package')
   return {
     ...originalModule,
-    CONTRACT_TYPES: ['IntentSource', 'Inbox', 'HyperPolicy'],
+    CONTRACT_TYPES: jest.requireActual('../sr-build-package').CONTRACT_TYPES,
     buildPackage: jest.fn().mockImplementation(async (context) => {
       if (context?.nextRelease) {
         if (context.mock_should_fail) {
@@ -146,11 +146,16 @@ describe('Semantic Release Build Package', () => {
 
   describe('CONTRACT_TYPES constant', () => {
     it('should contain the expected contract types', () => {
-      // Assert: Check CONTRACT_TYPES values
-      expect(CONTRACT_TYPES).toContain('IntentSource')
-      expect(CONTRACT_TYPES).toContain('Inbox')
+      // Assert: the v3 contract set (Prover→Policy rename, full deployed set)
+      expect(CONTRACT_TYPES).toContain('Portal')
+      expect(CONTRACT_TYPES).toContain('MulticallRuntime')
       expect(CONTRACT_TYPES).toContain('HyperPolicy')
-      expect(CONTRACT_TYPES.length).toBe(3)
+      expect(CONTRACT_TYPES).toContain('CCIPPolicy')
+      expect(CONTRACT_TYPES).toContain('PolymerPolicy')
+      expect(CONTRACT_TYPES).toContain('VestingPolicy')
+      // No pre-rename names remain.
+      expect(CONTRACT_TYPES).not.toContain('HyperProver')
+      expect(CONTRACT_TYPES.length).toBe(12)
     })
   })
 })

--- a/src/__tests__/hashing.test.ts
+++ b/src/__tests__/hashing.test.ts
@@ -1,0 +1,98 @@
+import { hashIntent, hashReward, hashRoute } from '../hashing'
+import { accountSalt } from '../addresses'
+import type { Intent } from '../types'
+
+// The SAME fixed intent as test/v3/sdk/GoldenVector.t.sol. The expected hashes below were emitted by that
+// Solidity test (forge test --match-path test/v3/sdk/GoldenVector.t.sol -vv) — this asserts TS<->Solidity
+// byte-parity of the hashing scheme.
+const INTENT: Intent = {
+  source: 8453n,
+  destination: 10n,
+  route: {
+    salt: '0x000000000000000000000000000000000000000000000000000000000000abcd',
+    deadline: 1_700_000_000n,
+    portal: '0x2222222222222222222222222222222222222222',
+    keeper: '0x3333333333333333333333333333333333333333',
+    runtime: '0x4444444444444444444444444444444444444444',
+    payload: '0xdeadbeef',
+    minTokens: [
+      {
+        token: '0x1111111111111111111111111111111111111111',
+        amount: 1_000_000n,
+      },
+    ],
+  },
+  reward: {
+    deadline: 1_700_000_500n,
+    keeper: '0x7777777777777777777777777777777777777777',
+    prover: '0x8888888888888888888888888888888888888888',
+    tokens: [
+      {
+        token: '0x5555555555555555555555555555555555555555',
+        rate: 2_000_000_000_000_000_000n,
+        flat: 500n,
+      },
+    ],
+    // abi.encode(Hook[2]) where hook[0]={0x6666...,0xc0ffee}, hook[1]={address(0),0x}
+    hooks: encodeHooksFixture(),
+  },
+}
+
+const GOLDEN = {
+  routeHash:
+    '0x1f482c9106c98dc34320e7251b1f47a35a8209518c5dc7f86278ee951145a3ea',
+  rewardHash:
+    '0x5435b4137cc49f6627e966eddc3be93118edac8c4732fcff5ded126b22788b81',
+  intentHash:
+    '0xa5fc9f392a4c4f858e79502faa282dc4cc364d9c034138d7a36c54a74caa6db7',
+}
+
+// Build abi.encode(Hook[2]) exactly as the Solidity fixture does.
+function encodeHooksFixture(): `0x${string}` {
+  // Local import to keep the fixture self-contained.
+  const { encodeAbiParameters } = require('viem')
+  return encodeAbiParameters(
+    [
+      {
+        type: 'tuple[2]',
+        components: [
+          { name: 'target', type: 'address' },
+          { name: 'data', type: 'bytes' },
+        ],
+      },
+    ],
+    [
+      [
+        { target: '0x6666666666666666666666666666666666666666', data: '0xc0ffee' },
+        { target: '0x0000000000000000000000000000000000000000', data: '0x' },
+      ],
+    ],
+  )
+}
+
+describe('v3 SDK hashing golden vectors', () => {
+  it('hashRoute matches Solidity', () => {
+    expect(hashRoute(INTENT.route)).toBe(GOLDEN.routeHash)
+  })
+
+  it('hashReward matches Solidity', () => {
+    expect(hashReward(INTENT.reward)).toBe(GOLDEN.rewardHash)
+  })
+
+  it('hashIntent matches Solidity', () => {
+    expect(hashIntent(INTENT)).toBe(GOLDEN.intentHash)
+  })
+
+  it('accountSalt is deterministic and role-parameterized', () => {
+    const escrow = accountSalt(GOLDEN.intentHash as `0x${string}`, INTENT.source)
+    const exec = accountSalt(
+      GOLDEN.intentHash as `0x${string}`,
+      INTENT.destination,
+    )
+    expect(escrow).not.toBe(exec) // cross-chain: distinct accounts
+    // same-chain collapse: same role id => same salt
+    expect(accountSalt(GOLDEN.intentHash as `0x${string}`, INTENT.source)).toBe(
+      escrow,
+    )
+  })
+})

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -1,0 +1,51 @@
+import {
+  concatHex,
+  encodeAbiParameters,
+  getAddress,
+  keccak256,
+  slice,
+  type Address,
+  type Hex,
+} from 'viem'
+
+/**
+ * Model C chain-parameterized Account salt: `keccak256(abi.encode(bytes32 intentHash, uint64 roleChainId))`.
+ * roleChainId is `intent.source` for the escrow account and `intent.destination` for the execution account
+ * (they collapse to one salt when source == destination).
+ */
+export function accountSalt(intentHash: Hex, roleChainId: bigint): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: 'bytes32' }, { type: 'uint64' }],
+      [intentHash, roleChainId],
+    ),
+  )
+}
+
+/**
+ * Predicts a per-intent Account address (a CREATE2 clone deployed BY the Portal).
+ *
+ * @param portal            The Portal (the CREATE2 deployer of the clone).
+ * @param proxyInitCodeHash `keccak256(Proxy.creationCode ++ abi.encode(accountImplementation))`.
+ *   DEPLOYMENT-SPECIFIC: it depends on the compiled `Proxy` creation code and the Account implementation
+ *   address the Portal deployed in its constructor. Capture it once per deployment (e.g. from the deploy
+ *   artifacts) — it is NOT a universal constant.
+ * @param intentHash        The intent hash.
+ * @param roleChainId       `intent.source` (escrow) or `intent.destination` (execution).
+ * @param prefix            CREATE2 prefix: `0xff` on EVM (default), `0x41` on TRON.
+ */
+export function predictAccountAddress(params: {
+  portal: Address
+  proxyInitCodeHash: Hex
+  intentHash: Hex
+  roleChainId: bigint
+  prefix?: Hex
+}): Address {
+  const { portal, proxyInitCodeHash, intentHash, roleChainId } = params
+  const prefix: Hex = params.prefix ?? '0xff'
+  const salt = accountSalt(intentHash, roleChainId)
+  const hash = keccak256(
+    concatHex([prefix, getAddress(portal), salt, proxyInitCodeHash]),
+  )
+  return getAddress(slice(hash, 12)) // last 20 bytes
+}

--- a/src/hashing.ts
+++ b/src/hashing.ts
@@ -1,0 +1,105 @@
+import {
+  encodeAbiParameters,
+  encodePacked,
+  keccak256,
+  type Hex,
+} from 'viem'
+import type { Intent, Reward, Route, TokenAmount } from './types'
+
+// ABI tuple definitions matching contracts/types/Intent.sol exactly (field order & types are
+// load-bearing — abi.encode output must be byte-identical to Solidity).
+const ROUTE_ABI = {
+  type: 'tuple',
+  components: [
+    { name: 'salt', type: 'bytes32' },
+    { name: 'deadline', type: 'uint64' },
+    { name: 'portal', type: 'address' },
+    { name: 'keeper', type: 'address' },
+    { name: 'runtime', type: 'address' },
+    { name: 'payload', type: 'bytes' },
+    {
+      name: 'minTokens',
+      type: 'tuple[]',
+      components: [
+        { name: 'token', type: 'address' },
+        { name: 'amount', type: 'uint256' },
+      ],
+    },
+  ],
+} as const
+
+const REWARD_ABI = {
+  type: 'tuple',
+  components: [
+    { name: 'deadline', type: 'uint64' },
+    { name: 'keeper', type: 'address' },
+    { name: 'prover', type: 'address' },
+    {
+      name: 'tokens',
+      type: 'tuple[]',
+      components: [
+        { name: 'token', type: 'address' },
+        { name: 'rate', type: 'uint256' },
+        { name: 'flat', type: 'uint256' },
+      ],
+    },
+    { name: 'hooks', type: 'bytes' },
+  ],
+} as const
+
+const TOKEN_AMOUNT_ARRAY_ABI = {
+  type: 'tuple[]',
+  components: [
+    { name: 'token', type: 'address' },
+    { name: 'amount', type: 'uint256' },
+  ],
+} as const
+
+/** `keccak256(abi.encode(route))`. */
+export function hashRoute(route: Route): Hex {
+  return keccak256(encodeAbiParameters([ROUTE_ABI], [route]))
+}
+
+/** `keccak256(abi.encode(reward))`. */
+export function hashReward(reward: Reward): Hex {
+  return keccak256(encodeAbiParameters([REWARD_ABI], [reward]))
+}
+
+/** `keccak256(abi.encodePacked(uint64 source, uint64 destination, bytes32 routeHash, bytes32 rewardHash))`. */
+export function hashIntentComponents(
+  source: bigint,
+  destination: bigint,
+  routeHash: Hex,
+  rewardHash: Hex,
+): Hex {
+  return keccak256(
+    encodePacked(
+      ['uint64', 'uint64', 'bytes32', 'bytes32'],
+      [source, destination, routeHash, rewardHash],
+    ),
+  )
+}
+
+/** Full intent hash: hashes the route + reward, then combines with source/destination. */
+export function hashIntent(intent: Intent): Hex {
+  return hashIntentComponents(
+    intent.source,
+    intent.destination,
+    hashRoute(intent.route),
+    hashReward(intent.reward),
+  )
+}
+
+/** `keccak256(abi.encode(bytes32 intentHash, bytes32 claimant, TokenAmount[] fulfilled))`. */
+export function hashFulfillment(
+  intentHash: Hex,
+  claimant: Hex,
+  fulfilled: TokenAmount[],
+): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [{ type: 'bytes32' }, { type: 'bytes32' }, TOKEN_AMOUNT_ARRAY_ABI],
+      [intentHash, claimant, fulfilled],
+    ),
+  )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './hashing'
+export * from './addresses'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,48 @@
+import type { Address, Hex } from 'viem'
+
+/** A `(token, amount)` pair used for `route.minTokens` (solver input floor) and `fulfilled` amounts. */
+export interface TokenAmount {
+  token: Address // address(0) => native
+  amount: bigint
+}
+
+/** A reward leg: payout = flat + rate * provided / WAD (WAD = 1e18), capped at escrow. */
+export interface RewardToken {
+  token: Address // address(0) => native
+  rate: bigint
+  flat: bigint
+}
+
+/** A keeper-committed delegate hook (target + calldata). */
+export interface Hook {
+  target: Address
+  data: Hex
+}
+
+export interface Route {
+  salt: Hex
+  deadline: bigint
+  portal: Address
+  keeper: Address
+  runtime: Address
+  payload: Hex
+  minTokens: TokenAmount[]
+}
+
+export interface Reward {
+  deadline: bigint
+  keeper: Address
+  prover: Address
+  tokens: RewardToken[]
+  hooks: Hex // default encoding: abi.encode(Hook[2])
+}
+
+export interface Intent {
+  source: bigint
+  destination: bigint
+  route: Route
+  reward: Reward
+}
+
+/** Fixed-point scale (1e18) used as the denominator for `RewardToken.rate`. */
+export const WAD = 10n ** 18n

--- a/test/v3/deploy/DeployV3.t.sol
+++ b/test/v3/deploy/DeployV3.t.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test} from "forge-std/Test.sol";
+
+import {DeployV3} from "../../../scripts/DeployV3.s.sol";
+
+import {ICreate3Deployer} from "../../../contracts/tools/ICreate3Deployer.sol";
+import {AddressConverter} from "../../../contracts/libs/AddressConverter.sol";
+
+import {Portal} from "../../../contracts/Portal.sol";
+import {MulticallRuntime} from "../../../contracts/runtime/MulticallRuntime.sol";
+import {HyperPolicy} from "../../../contracts/prover/HyperPolicy.sol";
+import {VestingPolicy} from "../../../contracts/prover/VestingPolicy.sol";
+
+import {MockLayerZeroEndpoint} from "../../../contracts/test/MockLayerZeroEndpoint.sol";
+import {TestMailbox} from "../../../contracts/test/TestMailbox.sol";
+import {TestMetaRouter} from "../../../contracts/test/TestMetaRouter.sol";
+import {TestCCIPRouter} from "../../../contracts/test/TestCCIPRouter.sol";
+
+/**
+ * @title DeployV3Test
+ * @notice In-VM proof that {DeployV3.deploy} brings up the Eco Routes v3 set deterministically, and — the
+ *         C1-critical property — that each transport policy stores its self-reference peer RIGHT-aligned so
+ *         EVM<->EVM proofs authenticate.
+ */
+contract DeployV3Test is Test {
+    using AddressConverter for address;
+
+    address internal constant SINGLETON_FACTORY =
+        0xce0042B868300000d44A59004Da54A005ffdcf9f;
+    address internal constant CREATE3_DEPLOYER =
+        0xC6BAd1EbAF366288dA6FB5689119eDd695a66814;
+
+    bytes32 internal constant SALT = keccak256("ECO_ROUTES_V3_TEST_SALT");
+
+    bytes32 internal constant HYPER_PEER = bytes32(uint256(0xA11CE));
+    bytes32 internal constant META_PEER = bytes32(uint256(0xB0B));
+    bytes32 internal constant LZ_PEER = bytes32(uint256(0xCA11));
+    bytes32 internal constant CCIP_PEER = bytes32(uint256(0xE55E));
+
+    DeployV3 internal script;
+    MockLayerZeroEndpoint internal lz;
+    TestMailbox internal mailbox;
+    TestMetaRouter internal meta;
+    TestCCIPRouter internal ccip;
+    address internal poly = address(0xD00D); // PolymerPolicy ctor only stores it
+
+    function setUp() public {
+        vm.warp(1_000_000);
+
+        // Etch the SingletonFactory at its canonical address; the script bootstraps the CREATE3 deployer.
+        vm.etch(
+            SINGLETON_FACTORY,
+            vm.getDeployedCode(
+                "contracts/tools/SingletonFactory.sol:SingletonFactory"
+            )
+        );
+
+        lz = new MockLayerZeroEndpoint(); // LZ policy makes a live setDelegate call
+        mailbox = new TestMailbox(address(0));
+        meta = new TestMetaRouter(address(0));
+        ccip = new TestCCIPRouter(address(0));
+
+        script = new DeployV3();
+    }
+
+    function _cfg() internal view returns (DeployV3.Config memory c) {
+        c.salt = SALT;
+        c.deployer = address(script); // in-VM CREATE3 msg.sender is the script
+        c.isTron = false;
+        c.mailbox = address(mailbox);
+        c.router = address(meta);
+        c.lzEndpoint = address(lz);
+        c.lzDelegate = address(script);
+        c.ccipRouter = address(ccip);
+        c.polymerCrossL2Prover = poly;
+        c.hyperCrossVm = _one(HYPER_PEER);
+        c.metaCrossVm = _one(META_PEER);
+        c.lzCrossVm = _one(LZ_PEER);
+        c.ccipCrossVm = _one(CCIP_PEER);
+        c.polymerCrossVm = new bytes32[](0);
+        c.deployLocalPolicy = true;
+        c.deploySchedulePolicies = true;
+        c.scheduleRelays = _one(bytes32(uint256(0xF00D)));
+    }
+
+    function _one(bytes32 v) internal pure returns (bytes32[] memory a) {
+        a = new bytes32[](1);
+        a[0] = v;
+    }
+
+    function _contractSalt(
+        bytes32 root,
+        string memory name
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(root, keccak256(abi.encodePacked(name))));
+    }
+
+    // (a) EXISTENCE ---------------------------------------------------------
+
+    function test_a_everyContractDeployed() public {
+        DeployV3.Deployment memory dep = script.deploy(_cfg());
+
+        assertGt(CREATE3_DEPLOYER.code.length, 0, "create3 deployer bootstrapped");
+        assertGt(dep.portal.code.length, 0, "portal");
+        assertGt(dep.runtime.code.length, 0, "runtime");
+        assertGt(dep.localPolicy.code.length, 0, "localPolicy");
+        assertGt(dep.hyperPolicy.code.length, 0, "hyperPolicy");
+        assertGt(dep.metaPolicy.code.length, 0, "metaPolicy");
+        assertGt(dep.layerZeroPolicy.code.length, 0, "layerZeroPolicy");
+        assertGt(dep.ccipPolicy.code.length, 0, "ccipPolicy");
+        assertGt(dep.polymerPolicy.code.length, 0, "polymerPolicy");
+        assertGt(dep.streamingPolicy.code.length, 0, "streamingPolicy");
+        assertGt(dep.vestingPolicy.code.length, 0, "vestingPolicy");
+        assertGt(dep.milestonePolicy.code.length, 0, "milestonePolicy");
+        assertGt(dep.dutchDecayPolicy.code.length, 0, "dutchDecayPolicy");
+    }
+
+    function test_a_zeroEndpointBridgeSkipped() public {
+        DeployV3.Config memory c = _cfg();
+        c.mailbox = address(0);
+        c.ccipRouter = address(0);
+        c.salt = keccak256("SKIP_SALT");
+
+        DeployV3.Deployment memory dep = script.deploy(c);
+
+        assertEq(dep.hyperPolicy, address(0), "hyper skipped");
+        assertEq(dep.ccipPolicy, address(0), "ccip skipped");
+        assertGt(dep.layerZeroPolicy.code.length, 0, "lz still deployed");
+        assertGt(dep.metaPolicy.code.length, 0, "meta still deployed");
+    }
+
+    // (b) DETERMINISM -------------------------------------------------------
+
+    function test_b_create2AddressesReDerivable() public {
+        DeployV3.Deployment memory dep = script.deploy(_cfg());
+
+        assertEq(
+            dep.portal,
+            _predictCreate2(type(Portal).creationCode, SALT),
+            "portal CREATE2"
+        );
+        assertEq(
+            dep.runtime,
+            _predictCreate2(
+                type(MulticallRuntime).creationCode,
+                _contractSalt(SALT, "MULTICALL_RUNTIME")
+            ),
+            "runtime CREATE2"
+        );
+    }
+
+    function test_b_create3AddressesReDerivable() public {
+        DeployV3.Deployment memory dep = script.deploy(_cfg());
+        ICreate3Deployer c3 = ICreate3Deployer(CREATE3_DEPLOYER);
+
+        assertEq(
+            dep.hyperPolicy,
+            c3.deployedAddress(
+                bytes(""),
+                address(script),
+                _contractSalt(SALT, "HYPER_POLICY")
+            ),
+            "hyper CREATE3"
+        );
+        assertEq(
+            dep.vestingPolicy,
+            c3.deployedAddress(
+                bytes(""),
+                address(script),
+                _contractSalt(SALT, "VESTING_POLICY")
+            ),
+            "vesting CREATE3"
+        );
+    }
+
+    function test_b_reDeployIsIdempotent() public {
+        DeployV3.Deployment memory a = script.deploy(_cfg());
+        DeployV3.Deployment memory b = script.deploy(_cfg());
+
+        assertEq(a.portal, b.portal, "portal stable");
+        assertEq(a.hyperPolicy, b.hyperPolicy, "hyper stable");
+        assertEq(a.vestingPolicy, b.vestingPolicy, "vesting stable");
+    }
+
+    // (c) C1 — self-reference RIGHT-aligned ---------------------------------
+
+    function test_c1_selfReferenceIsRightAligned() public {
+        DeployV3.Deployment memory dep = script.deploy(_cfg());
+
+        _assertRightAlignedSelf(dep.hyperPolicy, HYPER_PEER, dep.portal);
+        _assertRightAlignedSelf(dep.metaPolicy, META_PEER, dep.portal);
+        _assertRightAlignedSelf(dep.layerZeroPolicy, LZ_PEER, dep.portal);
+        _assertRightAlignedSelf(dep.ccipPolicy, CCIP_PEER, dep.portal);
+    }
+
+    /**
+     * @dev The self-peer MUST be RIGHT-aligned (AddressConverter.toBytes32) — the form every transport
+     *      delivers the cross-chain sender in. The LEFT-aligned bytes32(bytes20(self)) form would make the
+     *      immutable whitelist `==` never match, rejecting every EVM<->EVM proof (funds lock). Assert the
+     *      canonical form is stored and authenticates, and that the left-aligned form does NOT.
+     */
+    function _assertRightAlignedSelf(
+        address policy,
+        bytes32 crossVmPeer,
+        address portal
+    ) internal view {
+        HyperPolicy p = HyperPolicy(policy); // any transport shares the Whitelist/PORTAL surface
+        assertEq(p.PORTAL(), portal, "PORTAL == portal");
+
+        bytes32 selfRight = policy.toBytes32(); // bytes32(uint256(uint160(policy)))
+        bytes32 selfLeft = bytes32(bytes20(policy)); // the C1 regression form
+
+        bytes32[] memory wl = p.getWhitelist();
+        assertEq(wl.length, 2, "whitelist = self + 1 cross-VM");
+        assertEq(wl[0], selfRight, "peer[0] == right-aligned self");
+        assertEq(wl[1], crossVmPeer, "peer[1] == cross-VM peer");
+
+        assertTrue(p.isWhitelisted(selfRight), "right-aligned self authenticates");
+        assertTrue(p.isWhitelisted(crossVmPeer), "cross-VM peer authenticates");
+        assertFalse(
+            p.isWhitelisted(selfLeft),
+            "left-aligned self must NOT authenticate (C1)"
+        );
+    }
+
+    // (d) wiring spot checks ------------------------------------------------
+
+    function test_d_schedulePortalWiring() public {
+        DeployV3.Deployment memory dep = script.deploy(_cfg());
+        assertEq(
+            VestingPolicy(dep.vestingPolicy).PORTAL(),
+            dep.portal,
+            "vesting PORTAL == portal"
+        );
+    }
+
+    // helpers ---------------------------------------------------------------
+
+    function _predictCreate2(
+        bytes memory bytecode,
+        bytes32 salt
+    ) internal pure returns (address) {
+        return
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff),
+                                SINGLETON_FACTORY,
+                                salt,
+                                keccak256(bytecode)
+                            )
+                        )
+                    )
+                )
+            );
+    }
+}

--- a/test/v3/sdk/GoldenVector.t.sol
+++ b/test/v3/sdk/GoldenVector.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Test, console} from "forge-std/Test.sol";
+import {
+    Intent,
+    Route,
+    Reward,
+    TokenAmount,
+    RewardToken,
+    IntentLib
+} from "../../../contracts/types/Intent.sol";
+import {Hook} from "../../../contracts/types/Intent.sol";
+
+/**
+ * @title GoldenVectorTest
+ * @notice Emits the routeHash / rewardHash / intentHash of a FIXED intent so the TS SDK's Jest golden
+ *         vector (src/__tests__/hashing.test.ts) can assert byte-identical parity with Solidity.
+ * @dev Run: forge test --match-path test/v3/sdk/GoldenVector.t.sol -vv
+ */
+contract GoldenVectorTest is Test {
+    function _fixedIntent() internal pure returns (Intent memory intent) {
+        TokenAmount[] memory minTokens = new TokenAmount[](1);
+        minTokens[0] = TokenAmount({
+            token: address(0x1111111111111111111111111111111111111111),
+            amount: 1_000_000
+        });
+
+        Route memory route = Route({
+            salt: bytes32(uint256(0xABCD)),
+            deadline: 1_700_000_000,
+            portal: address(0x2222222222222222222222222222222222222222),
+            keeper: address(0x3333333333333333333333333333333333333333),
+            runtime: address(0x4444444444444444444444444444444444444444),
+            payload: hex"deadbeef",
+            minTokens: minTokens
+        });
+
+        RewardToken[] memory tokens = new RewardToken[](1);
+        tokens[0] = RewardToken({
+            token: address(0x5555555555555555555555555555555555555555),
+            rate: 2_000_000_000_000_000_000, // 2 WAD
+            flat: 500
+        });
+
+        Hook[2] memory hooks;
+        hooks[0] = Hook({
+            target: address(0x6666666666666666666666666666666666666666),
+            data: hex"c0ffee"
+        });
+        hooks[1] = Hook({target: address(0), data: hex""});
+
+        Reward memory reward = Reward({
+            deadline: 1_700_000_500,
+            keeper: address(0x7777777777777777777777777777777777777777),
+            prover: address(0x8888888888888888888888888888888888888888),
+            tokens: tokens,
+            hooks: abi.encode(hooks)
+        });
+
+        intent = Intent({
+            source: 8453,
+            destination: 10,
+            route: route,
+            reward: reward
+        });
+    }
+
+    function test_emitGoldenVector() public pure {
+        Intent memory intent = _fixedIntent();
+        bytes32 routeHash = keccak256(abi.encode(intent.route));
+        bytes32 rewardHash = keccak256(abi.encode(intent.reward));
+        bytes32 intentHash = IntentLib.hashIntent(
+            intent.source,
+            intent.destination,
+            routeHash,
+            rewardHash
+        );
+
+        console.log("routeHash:");
+        console.logBytes32(routeHash);
+        console.log("rewardHash:");
+        console.logBytes32(rewardHash);
+        console.log("intentHash:");
+        console.logBytes32(intentHash);
+    }
+}


### PR DESCRIPTION
## Summary
Final PR of the v3 stack, stacked on PR7 (#402). Operational layer + documentation:

- **`scripts/DeployV3.s.sol`**: deterministic deploy script for the full v3 contract set — CREATE2 (via the EIP-2470 SingletonFactory) for no-constructor-arg contracts (Portal/PortalTron, MulticallRuntime) so they land at an identical address on every chain; CREATE3 for contracts with chain-specific constructor args (all transport/settlement policies) so a relay/policy's own address is predictable and can be baked in as its own cross-chain peer self-reference.
  - Includes a regression test (`test/v3/deploy/DeployV3.t.sol`) for the C1 lesson: a policy's self-reference in its immutable peer whitelist must be stored **right-aligned** (`AddressConverter.toBytes32`), not left-aligned — the transports deliver the cross-chain sender right-aligned, so a left-aligned self-reference makes every proof permanently rejected.
- **Release pipeline**: `CONTRACT_TYPES` and `gen-bytecode.ts` retargeted from a stale, incomplete list to the full v3 contract set.
- **TS SDK** (`src/`): a new, minimal port — types matching the final structs, hashing matching `IntentLib.hashIntent`, and account-address prediction matching the chain-parameterized salt scheme — with a Solidity↔TS golden-vector parity test.
- **Docs**: `docs/v3/00-overview.md` (umbrella index over PR1–7), `migration-from-v2.md` (the full user-facing upgrade story), and an expanded `migration-loss-inventory.md` covering every accepted narrowing across the stack, including the anti-lock refund's cross-chain in-flight window (a deliberate, documented tradeoff, not new to this train).

Deferred (documented, not blocking): a follow-up PR to migrate the deposit-address templates onto standing streaming intents; a sweep of the root/generated docs (`README.md`, `CLAUDE.md`, etc.) that still use pre-v3 vocabulary; TVM broadcast tooling for `runTron()`; a fuller SDK (ABI bundle, ERC-7683 encoding).

## Test plan
- [x] `forge build` clean
- [x] `forge test`: 652 passed / 0 failed
- [x] `npx hardhat test`: 112 passing
- [x] `jest`: 46 passed
- [x] Portal/PortalTron: 23,714 B (862 B headroom under the 24,576 EIP-170 limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N25m45iFpZQEycqw7YFNsK