### PR TITLE
v3 PR9: protocol versioning — PortalProxy + version registry + expired-version deployer sweep

### DIFF
--- a/contracts/ERC7683/DestinationSettler.sol
+++ b/contracts/ERC7683/DestinationSettler.sol
@@ -26,12 +26,16 @@ abstract contract DestinationSettler is IDestinationSettler {
         bytes calldata originData,
         bytes calldata fillerData
     ) external payable {
-        // originData carries the origin-emitted intent data: the committed `source` chain id (Model C —
-        // hashed into the intent), the encoded route, and the full reward (needed for the reward-leg
-        // authentication + conservation snapshot at fulfill). The `destination` is this chain
-        // (block.chainid) — the fill happens on the destination chain.
-        (uint64 source, bytes memory encodedRoute, Reward memory reward) = abi
-            .decode(originData, (uint64, bytes, Reward));
+        // originData carries the origin-emitted intent data: the creator-declared `protocolVersion` and the
+        // committed `source` chain id (both Model C — hashed into the intent), the encoded route, and the
+        // full reward (needed for the reward-leg authentication + conservation snapshot at fulfill). The
+        // `destination` is this chain (block.chainid) — the fill happens on the destination chain.
+        (
+            uint32 protocolVersion,
+            uint64 source,
+            bytes memory encodedRoute,
+            Reward memory reward
+        ) = abi.decode(originData, (uint32, uint64, bytes, Reward));
 
         emit OrderFilled(orderId, msg.sender);
 
@@ -49,6 +53,7 @@ abstract contract DestinationSettler is IDestinationSettler {
             );
 
         fulfillAndProve(
+            protocolVersion,
             source,
             uint64(block.chainid),
             abi.decode(encodedRoute, (Route)),
@@ -64,6 +69,7 @@ abstract contract DestinationSettler is IDestinationSettler {
     /**
      * @notice Fulfills an intent and initiates proving in one transaction
      * @dev Abstract function to be implemented by concrete settlement contracts
+     * @param protocolVersion Creator-declared Portal implementation version committed in the intent hash
      * @param source The origin chain ID committed in the intent hash (Model C)
      * @param destination The destination chain ID committed in the intent hash (must equal block.chainid)
      * @param route The route information for the intent
@@ -76,6 +82,7 @@ abstract contract DestinationSettler is IDestinationSettler {
      * @return The runtime's raw return data
      */
     function fulfillAndProve(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,

--- a/contracts/ERC7683/OriginSettler.sol
+++ b/contracts/ERC7683/OriginSettler.sol
@@ -24,7 +24,10 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
     using SafeERC20 for IERC20;
 
     /// @notice typehash for gasless crosschain order
-    bytes32 public GASLESS_CROSSCHAIN_ORDER_TYPEHASH =
+    /// @dev `constant` (not a mutable state variable): the implementation runs via `delegatecall` from the
+    ///      {PortalProxy}, so anything in storage would read the proxy's (unwritten) slots. A `constant`
+    ///      lives in code and reads correctly under delegatecall.
+    bytes32 public constant GASLESS_CROSSCHAIN_ORDER_TYPEHASH =
         keccak256(
             "GaslessCrossChainOrder(address originSettler,address user,uint256 nonce,uint256 originChainId,uint32 openDeadline,uint32 fillDeadline,bytes32 orderDataType,bytes32 orderDataHash)"
         );
@@ -52,6 +55,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
         OrderData memory orderData = abi.decode(order.orderData, (OrderData));
 
         (bytes32 orderId, ) = _publishAndFund(
+            orderData.protocolVersion,
             uint64(block.chainid),
             orderData.destination,
             orderData.route,
@@ -106,6 +110,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
         // 2) If intent is Initial, it publishes and funds
         // 3) If intent is Funded, it publishes and does nothing
         (bytes32 orderId, ) = _publishAndFund(
+            orderData.protocolVersion,
             uint64(block.chainid),
             orderData.destination,
             orderData.route,
@@ -211,6 +216,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
         bytes32 routeHash = keccak256(orderData.route);
         bytes32 rewardHash = keccak256(abi.encode(orderData.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            orderData.protocolVersion,
             source,
             orderData.destination,
             routeHash,
@@ -218,10 +224,11 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
         );
 
         FillInstruction[] memory fillInstructions = new FillInstruction[](1);
-        // originData carries the full reward (not just its hash): the destination fill needs the reward
-        // legs to authenticate them against the derived intent hash and to snapshot the reward escrow for
-        // the conservation postcondition.
+        // originData carries the protocol version + full reward (not just its hash): the destination fill
+        // needs the version to re-derive the same intent hash and the reward legs to authenticate them
+        // against it and to snapshot the reward escrow for the conservation postcondition.
         bytes memory originData = abi.encode(
+            orderData.protocolVersion,
             source,
             orderData.route,
             orderData.reward
@@ -257,6 +264,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
      * @dev Provides replay protection through account state checking in funding logic
      * @dev Should handle excess ETH return for optimal user experience
      * @dev Called by both open() and openFor() methods to ensure consistent behavior
+     * @param protocolVersion Creator-declared Portal implementation version committed in the intent hash
      * @param source Origin chain ID (block.chainid at open time) committed in the intent hash
      * @param destination Destination chain ID where the intent should be executed
      * @param route Encoded route data containing execution instructions for destination chain
@@ -267,6 +275,7 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
      * @return account Address of the intent's account contract for reward escrow
      */
     function _publishAndFund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,

--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -7,6 +7,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IPolicy} from "./interfaces/IPolicy.sol";
 import {IInbox} from "./interfaces/IInbox.sol";
 import {IAccount} from "./interfaces/IAccount.sol";
+import {IPortalProxy, isProtocolVersionExpired} from "./interfaces/IPortalProxy.sol";
 
 import {Route, Reward} from "./types/Intent.sol";
 import {IntentLib} from "./types/Intent.sol";
@@ -73,6 +74,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      * @return The runtime's raw return data
      */
     function fulfill(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,
@@ -82,6 +84,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         address prover
     ) external payable returns (bytes memory) {
         (bytes memory result, , ) = _fulfill(
+            protocolVersion,
             source,
             destination,
             route,
@@ -112,6 +115,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      * @return The runtime's raw return data
      */
     function fulfillAndProve(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,
@@ -123,6 +127,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         bytes memory data
     ) public payable override(DestinationSettler, IInbox) returns (bytes memory) {
         (bytes memory result, , bytes32 intentHash) = _fulfill(
+            protocolVersion,
             source,
             destination,
             route,
@@ -186,24 +191,38 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      * @return The runtime's raw return data
      */
     function executeAsOwner(
+        uint32 protocolVersion,
         uint64 source,
         Route memory route,
         bytes32 rewardHash,
         address runtime,
         bytes calldata payload
     ) external payable returns (bytes memory) {
+        // CROSS-CHAIN ONLY, for BOTH authorities: on this chain the CHAIN_ID-keyed Account is / collapses
+        // with the SOURCE escrow Account, which only the reward-aware source-side executeAsOwner may cook.
+        // This restriction is caller-independent — it applies equally to the keeper and the deployer sweep.
         if (source == CHAIN_ID) {
             revert SourceChainOwnerOnly(source);
         }
         if (route.portal != address(this)) {
             revert InvalidPortal(route.portal);
         }
-        if (msg.sender != route.keeper) {
+        // Two independent authorities may cook the destination (leftover) Account: (1) `route.keeper`, any
+        // time; or (2) the PROTOCOL OWNER, but ONLY once this intent's protocol version is EXPIRED (the
+        // deployer sweep for stuck destination leftovers under a retired implementation). The cross-chain
+        // restriction above already guarantees this Account provably holds only unconsumed solver input,
+        // never escrow, so no reward-conservation lock is needed on this path for either authority.
+        bool isKeeper = msg.sender == route.keeper;
+        bool isDeployerSweep = msg.sender ==
+            IPortalProxy(address(this)).owner() &&
+            isProtocolVersionExpired(address(this), protocolVersion);
+        if (!isKeeper && !isDeployerSweep) {
             revert NotAccountKeeper(msg.sender);
         }
 
         bytes32 routeHash = keccak256(abi.encode(route));
         bytes32 intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             CHAIN_ID,
             routeHash,
@@ -238,6 +257,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
      * @return intentHash The derived intent hash
      */
     function _fulfill(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,
@@ -274,6 +294,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         bytes32 routeHash = keccak256(abi.encode(route));
         bytes32 rewardHash = keccak256(abi.encode(reward));
         intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             destination,
             routeHash,

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -11,6 +11,7 @@ import {IStreamingPolicy} from "./interfaces/IStreamingPolicy.sol";
 import {IIntentSource} from "./interfaces/IIntentSource.sol";
 import {IAccount} from "./interfaces/IAccount.sol";
 import {IPermit} from "./interfaces/IPermit.sol";
+import {IPortalProxy, requireValidProtocolVersion, isProtocolVersionExpired} from "./interfaces/IPortalProxy.sol";
 
 import {Intent, Reward, RewardToken, IntentLib} from "./types/Intent.sol";
 import {AddressConverter} from "./libs/AddressConverter.sol";
@@ -107,6 +108,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     {
         return
             getIntentHash(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -116,6 +118,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
 
     /**
      * @notice Calculates the hash of an intent and its components
+     * @param protocolVersion Creator-declared Portal implementation version
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes for cross-VM compatibility
@@ -125,6 +128,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return rewardHash Hash of the reward component
      */
     function getIntentHash(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -135,6 +139,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         returns (bytes32 intentHash, bytes32 routeHash, bytes32 rewardHash)
     {
         (intentHash, routeHash, rewardHash) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             keccak256(route),
@@ -144,6 +149,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
 
     /**
      * @notice Calculates intent hash from route hash and reward components
+     * @param protocolVersion Creator-declared Portal implementation version
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param _routeHash Pre-computed hash of the route component
@@ -153,6 +159,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return rewardHash Hash of the reward component
      */
     function getIntentHash(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 _routeHash,
@@ -165,6 +172,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         routeHash = _routeHash;
         rewardHash = keccak256(abi.encode(reward));
         intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -182,6 +190,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     ) public view returns (address) {
         return
             intentAccountAddress(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -193,6 +202,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @notice Calculates the deterministic address of the intent's SOURCE (escrow) account
      * @dev The source-side account salt uses `intent.source` as the role chain id (Model C). Source-side
      *      operations (fund/settle/refund/recover/executeAsOwner) all resolve to this address.
+     * @param protocolVersion Creator-declared Portal implementation version
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
@@ -200,12 +210,14 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return Address of the source-side escrow account
      */
     function intentAccountAddress(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
         Reward calldata reward
     ) public view returns (address) {
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             route,
@@ -223,6 +235,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     function isIntentFunded(Intent calldata intent) public view returns (bool) {
         return
             isIntentFunded(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -235,16 +248,22 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
+     * @param protocolVersion Creator-declared Portal implementation version
+     * @param source Origin chain ID for the intent
+     * @param destination Destination chain ID for the intent
+     * @param route Encoded route data for the intent as bytes
      * @param reward The reward structure containing distribution details
      * @return True if intent is completely funded, false otherwise
      */
     function isIntentFunded(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
         Reward calldata reward
     ) public view returns (bool) {
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             route,
@@ -274,6 +293,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     ) public returns (bytes32 intentHash, address account) {
         return
             publish(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -283,6 +303,8 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
 
     /**
      * @notice Creates an intent without funding
+     * @param protocolVersion Creator-declared Portal implementation version (must be registered and not
+     *        expired)
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
@@ -291,17 +313,30 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return account Address of the created (source/escrow) account
      */
     function publish(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
         Reward memory reward
     ) public returns (bytes32 intentHash, address account) {
+        // A NEW intent may only be created under a currently-valid protocol version: registered, and not
+        // past its expiry (an expired version is sweepable by the protocol owner, so a fresh intent must
+        // never be created already-sweepable). Read against `address(this)` — behind the {PortalProxy} that
+        // IS the proxy, so this reads the proxy's version registry.
+        requireValidProtocolVersion(address(this), protocolVersion);
+
         // Validate reward legs on the source. The route is treated as opaque bytes (cross-VM
         // compatibility), so only the route-free checks run here (uniqueness + bound); `minTokens` ordering
         // is enforced at the destination fulfill.
         IntentLib.requireUniqueRewardTokens(reward.tokens);
 
-        (intentHash, , ) = getIntentHash(source, destination, route, reward);
+        (intentHash, , ) = getIntentHash(
+            protocolVersion,
+            source,
+            destination,
+            route,
+            reward
+        );
         account = accountAddress(intentHash, source);
 
         _validatePublish(intentHash);
@@ -321,6 +356,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     ) public payable returns (bytes32 intentHash, address account) {
         return
             publishAndFund(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -340,6 +376,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return account Address of the created account
      */
     function publishAndFund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -353,6 +390,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     {
         return
             _publishAndFund(
+                protocolVersion,
                 source,
                 destination,
                 route,
@@ -372,6 +410,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return intentHash Hash of the funded intent
      */
     function fund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -379,6 +418,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bool allowPartial
     ) external payable onlySourceChain(source) returns (bytes32 intentHash) {
         (intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -408,6 +448,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return intentHash Hash of the funded intent
      */
     function fundFor(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -417,6 +458,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         address permitContract
     ) external payable onlySourceChain(source) returns (bytes32 intentHash) {
         (intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -451,6 +493,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     ) public payable returns (bytes32 intentHash, address account) {
         return
             publishAndFundFor(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 abi.encode(intent.route),
@@ -474,6 +517,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return account Address of the created account
      */
     function publishAndFundFor(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -487,7 +531,13 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         onlySourceChain(source)
         returns (bytes32 intentHash, address account)
     {
-        (intentHash, ) = publish(source, destination, route, reward);
+        (intentHash, ) = publish(
+            protocolVersion,
+            source,
+            destination,
+            route,
+            reward
+        );
 
         account = _fundIntentFor(
             reward,
@@ -514,6 +564,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param fulfilled Per-leg delivered amounts committed in the fulfillment (paired prefix)
      */
     function settle(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -521,7 +572,15 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes32 claimant,
         uint256[] calldata fulfilled
     ) public onlySourceChain(source) {
-        _settle(source, destination, routeHash, reward, claimant, fulfilled);
+        _settle(
+            protocolVersion,
+            source,
+            destination,
+            routeHash,
+            reward,
+            claimant,
+            fulfilled
+        );
     }
 
     /**
@@ -537,6 +596,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param fulfilled Per-leg delivered amounts committed in the fulfillment (paired prefix)
      */
     function _settle(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -545,6 +605,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         uint256[] memory fulfilled
     ) internal {
         (bytes32 intentHash, , bytes32 rewardHash) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -561,6 +622,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
             proof.fulfillmentHash != bytes32(0)
         ) {
             IPolicy(reward.prover).challengeIntentProof(
+                protocolVersion,
                 source,
                 destination,
                 routeHash,
@@ -611,12 +673,14 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param reward Reward structure of the intent
      */
     function refund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
         Reward calldata reward
     ) external onlySourceChain(source) {
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -635,6 +699,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param refundee Address to receive the refunded rewards
      */
     function refundTo(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -646,6 +711,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         }
 
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -665,6 +731,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @param token Token address for handling incorrect account transfers
      */
     function recoverToken(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -672,6 +739,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         address token
     ) external onlySourceChain(source) {
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -722,7 +790,20 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         onlySourceChain(intent.source)
         returns (bytes memory)
     {
-        if (msg.sender != intent.reward.keeper) {
+        // Two independent authorities may cook the source (escrow) Account:
+        //   (1) the reward keeper (the account owner), any time; or
+        //   (2) the PROTOCOL OWNER, but ONLY once this intent's protocol version is EXPIRED — the
+        //       narrowly-scoped deployer sweep for stuck funds parked under a retired implementation.
+        // This is only an ALTERNATE authorization: the UNCHANGED AccountLocked escrow/proof lock below runs
+        // identically regardless of which branch authorized the call, so the deployer can never sweep an
+        // account whose intent still has a live reward escrow or an honored-but-unsettled proof — the
+        // sweep is gated on BOTH an expired version AND an independently-dead account, and that second
+        // condition falls out for free from the already-hardened lock (no new, less-reviewed check).
+        bool isKeeper = msg.sender == intent.reward.keeper;
+        bool isDeployerSweep = msg.sender ==
+            IPortalProxy(address(this)).owner() &&
+            isProtocolVersionExpired(address(this), intent.protocolVersion);
+        if (!isKeeper && !isDeployerSweep) {
             revert NotAccountOwner(msg.sender);
         }
 
@@ -770,6 +851,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      *      is the anti-replay, so no status transition is needed.
      */
     function settleStream(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -777,6 +859,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bytes calldata batchData
     ) external onlySourceChain(source) {
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -812,6 +895,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      *      reclaim path, distinct from {refund}).
      */
     function closeStream(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -822,6 +906,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         }
 
         (bytes32 intentHash, , ) = getIntentHash(
+            protocolVersion,
             source,
             destination,
             routeHash,
@@ -881,6 +966,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
      * @return account Address of the created account
      */
     function _publishAndFund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -888,7 +974,13 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         bool allowPartial,
         address funder
     ) internal override returns (bytes32 intentHash, address account) {
-        (intentHash, account) = publish(source, destination, route, reward);
+        (intentHash, account) = publish(
+            protocolVersion,
+            source,
+            destination,
+            route,
+            reward
+        );
 
         _fundIntent(
             intentHash,

--- a/contracts/Portal.sol
+++ b/contracts/Portal.sol
@@ -4,20 +4,25 @@ pragma solidity ^0.8.26;
 
 import {PortalCore} from "./PortalCore.sol";
 import {AccountDeployer} from "./account/AccountDeployer.sol";
-import {Account} from "./account/Account.sol";
 
 /**
  * @title Portal
- * @notice Portal contract combining IntentSource and Inbox functionality
- * @dev Main entry point for intent publishing, fulfillment, and proving. The combined-half logic
- *      (same-chain {PortalCore-fulfillAndSettle}) lives in {PortalCore}; this contract only supplies the
- *      shared {AccountDeployer} constructor args (the Account clone template + CREATE2 prefix) via C3
- *      linearization.
+ * @notice Portal IMPLEMENTATION combining IntentSource and Inbox functionality
+ * @dev A versioned implementation that runs behind the permanent {PortalProxy} (PR9): the proxy
+ *      `delegatecall`s into it, so `address(this)` in this contract is always the PROXY. The combined-half
+ *      logic (same-chain {PortalCore-fulfillAndSettle}) lives in {PortalCore}; this contract only supplies
+ *      the shared {AccountDeployer} constructor args (the Account clone template + CREATE2 prefix) via C3
+ *      linearization. The Account clone template is passed in (a SINGLE shared {Account} implementation,
+ *      bound to the proxy) rather than deployed here, so every registered Portal version derives the SAME
+ *      per-intent Account addresses.
  */
 contract Portal is PortalCore {
     /**
-     * @notice Initializes the Portal contract
-     * @dev Creates a unified entry point combining source and destination chain functionality
+     * @notice Wires the shared Account clone template.
+     * @param accountImplementation The shared {Account} implementation (bound to the proxy) that
+     *        per-intent clones delegate to.
      */
-    constructor() AccountDeployer(address(new Account()), bytes1(0xff)) {}
+    constructor(
+        address accountImplementation
+    ) AccountDeployer(accountImplementation, bytes1(0xff)) {}
 }

--- a/contracts/PortalCore.sol
+++ b/contracts/PortalCore.sol
@@ -53,6 +53,7 @@ abstract contract PortalCore is IntentSource, Inbox, Semver {
         // fulfillment into the keeper-committed prover. For a same-chain intent this recorded fact IS the
         // proof the settle reads below (no relay, no cross-chain round-trip).
         (bytes memory result, uint256[] memory fulfilled, ) = _fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -67,6 +68,7 @@ abstract contract PortalCore is IntentSource, Inbox, Semver {
         // recorded and pays out without a cross-chain hash round-trip.
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         _settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,

--- a/contracts/PortalProxy.sol
+++ b/contracts/PortalProxy.sol
@@ -1,0 +1,312 @@
+/* -*- c-basic-offset: 4 -*- */
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPortalProxy} from "./interfaces/IPortalProxy.sol";
+import {Intent} from "./types/Intent.sol";
+import {OnchainCrossChainOrder, GaslessCrossChainOrder} from "./types/ERC7683.sol";
+
+/**
+ * @title PortalProxy
+ * @notice The PERMANENT, stable-address front for the versioned Portal implementations.
+ * @dev The protocol ships new Portal behaviour by REGISTERING new implementation versions, never by
+ *      changing the address intents and accounts are anchored to. Every call is served by `delegatecall`
+ *      into the implementation registered for the call's `protocolVersion`, so:
+ *
+ *        - The proxy's address is what solvers, keepers and per-intent Accounts trust forever.
+ *        - Per-intent Account addresses derive from `address(this)` (the proxy — `delegatecall` preserves
+ *          it) plus the implementation's Account clone template + CREATE2 prefix immutables. As long as
+ *          every registered implementation is deployed with the SAME Account template + prefix (a protocol
+ *          invariant the owner must uphold), an intent's Account address is IDENTICAL regardless of which
+ *          implementation version is active — see {accountAddress}. This is the whole point of the proxy.
+ *        - An intent is PINNED to its declared version: its hash commits `protocolVersion` (the first
+ *          `Intent` field), and every lifecycle call re-declares it, so the intent is always served by the
+ *          implementation it was created under, even after newer versions are registered or its own version
+ *          expires.
+ *
+ *      STORAGE. The implementations execute in THIS contract's storage (delegatecall). The only
+ *      implementation storage is a slot-0 mapping ({IntentSource.rewardStatuses}); to avoid any collision
+ *      the proxy keeps its version registry in ERC-7201 NAMESPACED storage and its owner IMMUTABLE (in
+ *      code, not storage), matching this codebase's immutable-trust-anchor ethos (it uses immutable
+ *      whitelists, not OpenZeppelin `Ownable`).
+ *
+ *      DISPATCH. Most Portal entry points take `protocolVersion` as an explicit LEADING scalar (route
+ *      stays opaque bytes at the source, so the version cannot be decoded from a nested struct on the
+ *      `fund`/`settle`/`refund` paths). For those the {fallback} reads the version straight from
+ *      `calldata[4:36]` and needs no per-function code. The exceptions get thin typed forwarders:
+ *        - entry points taking a full `Intent` (its `protocolVersion` field selects the version), and
+ *        - VERSION-AGNOSTIC helpers ({getRewardStatus}, {accountAddress}, {version}, {prove}) and the
+ *          ERC-7683 adapter surface ({open}/{openFor}/{resolve}/{resolveFor}/{fill}) — dispatched to the
+ *          LATEST registered implementation. These either only read shared proxy storage / derive an
+ *          address (identical across implementations that share the Account template), or carry the pinned
+ *          version inside their order/originData that the implementation itself validates and hashes with.
+ */
+contract PortalProxy is IPortalProxy {
+    /// @notice The protocol owner: may register versions and perform the expired-version deployer sweep.
+    /// @dev Immutable (set once at construction, never transferable) — matches the codebase's immutable
+    ///      trust anchors and, being in code rather than storage, cannot collide with an implementation's
+    ///      delegatecall storage writes.
+    address private immutable OWNER;
+
+    /// @custom:storage-location erc7201:eco.portal.proxy.registry
+    struct RegistryStorage {
+        mapping(uint32 => VersionInfo) versions;
+        uint32 latestVersion;
+    }
+
+    /// @dev ERC-7201 namespaced slot for {RegistryStorage}:
+    ///      keccak256(abi.encode(uint256(keccak256("eco.portal.proxy.registry")) - 1)) & ~0xff
+    bytes32 private constant REGISTRY_SLOT =
+        0x10a89caf7e3594b0f121a45225d831fd536e5f0685b5dcbe2b9da79a3ac6ab00;
+
+    /**
+     * @notice Sets the immutable protocol owner. Registers NO version — the implementation contracts do not
+     *         exist yet at proxy-construction time, so {registerVersion} is called afterwards by the deploy
+     *         script.
+     * @param initialOwner The protocol owner address.
+     */
+    constructor(address initialOwner) {
+        if (initialOwner == address(0)) {
+            revert ZeroImplementation();
+        }
+        OWNER = initialOwner;
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Registry (real proxy functions — NOT forwarded)
+    // ---------------------------------------------------------------------------------------------------
+
+    /// @inheritdoc IPortalProxy
+    function registerVersion(
+        uint32 version,
+        address implementation
+    ) external {
+        if (msg.sender != OWNER) {
+            revert NotOwner(msg.sender);
+        }
+        if (implementation == address(0)) {
+            revert ZeroImplementation();
+        }
+        RegistryStorage storage $ = _registry();
+        // WRITE-ONCE: a version's implementation binding is immutable once set. Repointing a version that
+        // live intents already reference would be a rug vector, so re-registration is rejected outright.
+        if ($.versions[version].implementation != address(0)) {
+            revert VersionAlreadyRegistered(version);
+        }
+        uint64 registeredAt = uint64(block.timestamp);
+        $.versions[version] = VersionInfo({
+            implementation: implementation,
+            registeredAt: registeredAt
+        });
+        if (version > $.latestVersion) {
+            $.latestVersion = version;
+        }
+        emit VersionRegistered(version, implementation, registeredAt);
+    }
+
+    /// @inheritdoc IPortalProxy
+    function versions(
+        uint32 version
+    ) external view returns (address implementation, uint64 registeredAt) {
+        VersionInfo storage info = _registry().versions[version];
+        return (info.implementation, info.registeredAt);
+    }
+
+    /// @inheritdoc IPortalProxy
+    function owner() external view returns (address) {
+        return OWNER;
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Forwarders for entry points carrying a full Intent (version = intent.protocolVersion)
+    // ---------------------------------------------------------------------------------------------------
+
+    function publish(Intent calldata intent) external {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function publishAndFund(
+        Intent calldata intent,
+        bool /* allowPartial */
+    ) external payable {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function publishAndFundFor(
+        Intent calldata intent,
+        bool /* allowPartial */,
+        address /* funder */,
+        address /* permitContract */
+    ) external payable {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function intentAccountAddress(Intent calldata intent) external {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function isIntentFunded(Intent calldata intent) external {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function getIntentHash(Intent calldata intent) external {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function executeAsOwner(
+        Intent calldata intent,
+        address /* runtime */,
+        bytes calldata /* payload */
+    ) external payable {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    function fulfillAndSettle(
+        Intent calldata intent,
+        uint256[] calldata /* providedAmounts */,
+        bytes32 /* claimant */
+    ) external payable {
+        _delegate(_implementation(intent.protocolVersion));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Forwarders for version-agnostic helpers + the ERC-7683 adapter surface (dispatched to LATEST)
+    // ---------------------------------------------------------------------------------------------------
+
+    function getRewardStatus(bytes32 /* intentHash */) external {
+        _delegate(_latestImplementation());
+    }
+
+    function accountAddress(
+        bytes32 /* intentHash */,
+        uint64 /* roleChainId */
+    ) external {
+        _delegate(_latestImplementation());
+    }
+
+    function version() external {
+        _delegate(_latestImplementation());
+    }
+
+    function prove(
+        address /* prover */,
+        uint64 /* sourceChainDomainID */,
+        bytes32[] calldata /* intentHashes */,
+        bytes calldata /* data */
+    ) external payable {
+        _delegate(_latestImplementation());
+    }
+
+    function open(OnchainCrossChainOrder calldata /* order */) external payable {
+        _delegate(_latestImplementation());
+    }
+
+    function openFor(
+        GaslessCrossChainOrder calldata /* order */,
+        bytes calldata /* signature */,
+        bytes calldata /* originFillerData */
+    ) external payable {
+        _delegate(_latestImplementation());
+    }
+
+    function resolve(OnchainCrossChainOrder calldata /* order */) external {
+        _delegate(_latestImplementation());
+    }
+
+    function resolveFor(
+        GaslessCrossChainOrder calldata /* order */,
+        bytes calldata /* originFillerData */
+    ) external {
+        _delegate(_latestImplementation());
+    }
+
+    function fill(
+        bytes32 /* orderId */,
+        bytes calldata /* originData */,
+        bytes calldata /* fillerData */
+    ) external payable {
+        _delegate(_latestImplementation());
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Generic dispatch for every entry point taking a leading `uint32 protocolVersion`
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * @notice Dispatches all entry points whose FIRST ABI argument is the `uint32 protocolVersion` scalar,
+     *         plus any version-agnostic no-argument view not given a dedicated forwarder.
+     * @dev For a function with a leading `uint32 protocolVersion` the version sits in the first ABI word
+     *      after the selector, at `calldata[4:36]` (publish/fund/settle/refund/recover/fulfill/
+     *      executeAsOwner/stream... decomposed forms) — read it and route to that implementation. A
+     *      selector-only call (`4 <= length < 36`, i.e. a no-argument function such as `domainSeparatorV4`)
+     *      carries no version and is version-agnostic, so it routes to the LATEST implementation. Fewer than
+     *      4 bytes (incl. a bare value transfer) has no selector and reverts.
+     */
+    fallback() external payable {
+        if (msg.data.length < 4) {
+            revert UnknownProtocolVersion(0);
+        }
+        if (msg.data.length < 36) {
+            // No-argument function (selector only): version-agnostic, serve from the latest implementation.
+            _delegate(_latestImplementation());
+        }
+        uint32 protocolVersion = uint32(uint256(bytes32(msg.data[4:36])));
+        _delegate(_implementation(protocolVersion));
+    }
+
+    // ---------------------------------------------------------------------------------------------------
+    // Internals
+    // ---------------------------------------------------------------------------------------------------
+
+    /**
+     * @notice Resolves the implementation for a version, reverting if it is not registered.
+     * @dev Unregistered -> {UnknownProtocolVersion}. An EXPIRED (but registered) version still resolves —
+     *      existing intents on a retired version must stay settleable/refundable/sweepable forever; only
+     *      {IIntentSource-publish} additionally rejects an expired version for NEW intents.
+     * @param protocolVersion The version to resolve.
+     * @return impl The implementation address.
+     */
+    function _implementation(
+        uint32 protocolVersion
+    ) internal view returns (address impl) {
+        impl = _registry().versions[protocolVersion].implementation;
+        if (impl == address(0)) {
+            revert UnknownProtocolVersion(protocolVersion);
+        }
+    }
+
+    /**
+     * @notice The latest registered implementation (for version-agnostic + ERC-7683 forwarders).
+     * @dev Reverts {UnknownProtocolVersion} until at least one version is registered.
+     * @return The latest implementation address.
+     */
+    function _latestImplementation() internal view returns (address) {
+        return _implementation(_registry().latestVersion);
+    }
+
+    /**
+     * @notice `delegatecall`s the current calldata to `impl` and bubbles the raw return/revert verbatim.
+     * @param impl The implementation to execute in this proxy's context.
+     */
+    function _delegate(address impl) internal {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let ok := delegatecall(gas(), impl, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch ok
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /// @notice Points a storage struct at the ERC-7201 namespaced registry slot.
+    function _registry() private pure returns (RegistryStorage storage $) {
+        assembly {
+            $.slot := REGISTRY_SLOT
+        }
+    }
+}

--- a/contracts/account/Account.sol
+++ b/contracts/account/Account.sol
@@ -48,11 +48,18 @@ contract Account is IAccount {
         0xacc20dacae6b4d5949ef091bdce937ee4ae97c3312ea3d3826cb7ff678dcaca3;
 
     /**
-     * @notice Creates a new account instance
-     * @dev Sets the deployer (IntentSource) as the authorized portal contract
+     * @notice Creates a new account implementation bound to its portal.
+     * @dev `_portal` is the address authorized to drive every clone of this implementation
+     *      (fund/withdraw/refund/recover/execute/hooks). Under the PR9 {PortalProxy}, the implementations
+     *      run via `delegatecall` FROM the proxy, so `address(this)` at every account call site is the
+     *      PROXY — hence `_portal` must be the PROXY address (not a Portal implementation). A SINGLE Account
+     *      implementation is shared by every registered Portal version so that each intent's per-intent
+     *      Account address is stable across implementation versions (the address derives from the proxy +
+     *      this shared implementation, never from the active version).
+     * @param _portal The authorized caller (the {PortalProxy}).
      */
-    constructor() {
-        portal = msg.sender;
+    constructor(address _portal) {
+        portal = _portal;
     }
 
     /**

--- a/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
@@ -225,6 +225,7 @@ contract DepositAddress_CCTPMint_Arc is BaseDepositAddress {
 
         // Combine into Intent. Published on this (source) chain; fulfilled on Arc.
         intent = Intent({
+            protocolVersion: 1, // pinned to protocol version 1 (registered on the PortalProxy at deploy)
             source: uint64(block.chainid),
             destination: arcChainId,
             route: route,
@@ -320,6 +321,7 @@ contract DepositAddress_CCTPMint_Arc is BaseDepositAddress {
 
         // Combine into Intent. CCTP burn is fulfilled locally on the source chain (source == dest).
         intent = Intent({
+            protocolVersion: 1, // pinned to protocol version 1 (registered on the PortalProxy at deploy)
             source: uint64(block.chainid),
             destination: destChain,
             route: route,

--- a/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
@@ -287,6 +287,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
 
         // Combine into Intent. Published on this (source) chain; fulfilled on the destination.
         intent = Intent({
+            protocolVersion: 1, // pinned to protocol version 1 (registered on the PortalProxy at deploy)
             source: uint64(block.chainid),
             destination: destinationChainId,
             route: route,
@@ -391,6 +392,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
 
         // Combine into Intent. CCTP burn is fulfilled locally on the source chain (source == dest).
         intent = Intent({
+            protocolVersion: 1, // pinned to protocol version 1 (registered on the PortalProxy at deploy)
             source: uint64(block.chainid),
             destination: destChain,
             route: route,

--- a/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
+++ b/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
@@ -120,6 +120,7 @@ contract DepositAddress_USDCTransfer_Solana is BaseDepositAddress {
         // Call Portal.publishAndFund. Published on this (source) chain; fulfilled on Solana.
         Portal portalContract = Portal(portal);
         (intentHash,) = portalContract.publishAndFund(
+            1, // protocolVersion: pinned to protocol version 1 (registered on the PortalProxy at deploy)
             uint64(block.chainid),
             destChain,
             routeBytes,

--- a/contracts/interfaces/IInbox.sol
+++ b/contracts/interfaces/IInbox.sol
@@ -147,6 +147,7 @@ interface IInbox {
      * @return The runtime's raw return data
      */
     function fulfill(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,
@@ -184,6 +185,7 @@ interface IInbox {
      *      the correct domain ID for the source chain.
      */
     function fulfillAndProve(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         Route memory route,
@@ -210,6 +212,7 @@ interface IInbox {
      * @return The runtime's raw return data
      */
     function executeAsOwner(
+        uint32 protocolVersion,
         uint64 source,
         Route memory route,
         bytes32 rewardHash,

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -210,6 +210,7 @@ interface IIntentSource {
 
     /**
      * @notice Computes the hash components of an intent
+     * @param protocolVersion Creator-declared Portal implementation version
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
@@ -219,6 +220,7 @@ interface IIntentSource {
      * @return rewardHash Hash of the reward specifications
      */
     function getIntentHash(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -239,6 +241,7 @@ interface IIntentSource {
 
     /**
      * @notice Computes the deterministic (source/escrow) account address for an intent
+     * @param protocolVersion Creator-declared Portal implementation version
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
@@ -246,6 +249,7 @@ interface IIntentSource {
      * @return Predicted account address (the source-side escrow account)
      */
     function intentAccountAddress(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -270,6 +274,7 @@ interface IIntentSource {
      * @return True if the intent is properly funded
      */
     function isIntentFunded(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -298,6 +303,7 @@ interface IIntentSource {
      * @return account Address of the created account
      */
     function publish(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -327,6 +333,7 @@ interface IIntentSource {
      * @return account Address of the created account
      */
     function publishAndFund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -344,6 +351,7 @@ interface IIntentSource {
      * @return intentHash The hash of the funded intent
      */
     function fund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -363,6 +371,7 @@ interface IIntentSource {
      * @return intentHash The hash of the funded intent
      */
     function fundFor(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -401,6 +410,7 @@ interface IIntentSource {
      * @return account Address of the created account
      */
     function publishAndFundFor(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes memory route,
@@ -422,6 +432,7 @@ interface IIntentSource {
      * @param fulfilled Per-leg delivered amounts committed in the fulfillment (paired prefix)
      */
     function settle(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -438,6 +449,7 @@ interface IIntentSource {
      * @param reward The reward specification
      */
     function refund(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -453,6 +465,7 @@ interface IIntentSource {
      * @param refundee Address to receive the refunded rewards
      */
     function refundTo(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -470,6 +483,7 @@ interface IIntentSource {
      * @param token The address of the token to recover
      */
     function recoverToken(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -513,6 +527,7 @@ interface IIntentSource {
      *        slice preimages (opaque to the Portal; decoded by the policy)
      */
     function settleStream(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -532,6 +547,7 @@ interface IIntentSource {
      * @param reward The reward specification (must name a {IStreamingPolicy} at `reward.prover`)
      */
     function closeStream(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,

--- a/contracts/interfaces/ILocalPolicy.sol
+++ b/contracts/interfaces/ILocalPolicy.sol
@@ -42,12 +42,14 @@ interface ILocalPolicy is IPolicy {
      * @notice Atomically withdraws, fulfills an intent, and pays claimant the fulfillment reward
      * @dev Claimant receives all reward tokens and native (minus amounts consumed by route execution).
      *      Intent hash is computed from route and reward, no need to pass it separately.
+     * @param protocolVersion Creator-declared Portal implementation version committed in the intent hash
      * @param route Route information for the intent
      * @param reward Reward details for the intent
      * @param claimant Address that receives the fulfillment reward (ERC20 tokens + native ETH)
      * @return results The runtime's raw return data from the fulfill execution
      */
     function flashFulfill(
+        uint32 protocolVersion,
         Route calldata route,
         Reward calldata reward,
         bytes32 claimant

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -160,12 +160,14 @@ interface IPolicy is ISemver {
      * @notice Challenge an intent proof if destination chain ID doesn't match
      * @dev Can be called by anyone to remove invalid proofs. Safety mechanism ensuring intents are only
      *      claimable when executed on their intended destination chains.
+     * @param protocolVersion Creator-declared Portal implementation version committed in the intent hash
      * @param source The origin chain ID committed in the intent hash (Model C)
      * @param destination The intended destination chain ID
      * @param routeHash The hash of the intent's route
      * @param rewardHash The hash of the reward specification
      */
     function challengeIntentProof(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,

--- a/contracts/interfaces/IPortalProxy.sol
+++ b/contracts/interfaces/IPortalProxy.sol
@@ -1,0 +1,145 @@
+/* -*- c-basic-offset: 4 -*- */
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+// Lifetime after which a registered protocol version is EXPIRED. A version is registered at `registeredAt`
+// and stays valid for creating NEW intents until `registeredAt + VERSION_EXPIRY`. After that:
+// {IIntentSource-publish} rejects new intents on the version (ProtocolVersionExpired), and the protocol
+// owner gains the narrowly-scoped deployer-sweep authority on the EXISTING executeAsOwner escrow/proof lock
+// (it can sweep an account whose intent is independently dead, never a live escrow). Settling / refunding /
+// cooking existing intents keeps working forever regardless of expiry (an expired version stays REGISTERED
+// — the registry is write-once, nothing is ever removed). A file-level constant (not a settable parameter),
+// matching this codebase's immutable-trust-anchor ethos.
+uint256 constant VERSION_EXPIRY = 365 days;
+
+/**
+ * @title IPortalProxy
+ * @notice Minimal interface the versioned Portal implementations use to read the {PortalProxy} registry
+ *         they run behind.
+ * @dev A Portal implementation only ever executes via `delegatecall` FROM the {PortalProxy}, so inside the
+ *      implementation `address(this)` IS the proxy. The implementation reads the version registry and the
+ *      protocol owner by calling these functions against `address(this)` (an external call that lands on
+ *      the proxy's own real functions, reading the proxy's namespaced storage / immutable owner) — used by
+ *      {IIntentSource-publish} to validate the creator-declared version and by both `executeAsOwner`s to
+ *      authorize the deployer sweep once a version is expired.
+ */
+/**
+ * @notice Reverts unless `protocolVersion` is registered on `proxy` and not past its {VERSION_EXPIRY}.
+ * @dev Shared by the source ({IntentSource}) and destination ({Inbox}) halves so a NEW intent can only be
+ *      created under a live version. `proxy` is `address(this)` inside an implementation running via
+ *      `delegatecall` from the {PortalProxy}. Unknown -> {IPortalProxy-UnknownProtocolVersion}; expired ->
+ *      {IPortalProxy-ProtocolVersionExpired}.
+ * @param proxy The {PortalProxy} holding the version registry (`address(this)` under delegatecall).
+ * @param protocolVersion The version to validate.
+ */
+function requireValidProtocolVersion(
+    address proxy,
+    uint32 protocolVersion
+) view {
+    (address implementation, uint64 registeredAt) = IPortalProxy(proxy)
+        .versions(protocolVersion);
+    if (implementation == address(0)) {
+        revert IPortalProxy.UnknownProtocolVersion(protocolVersion);
+    }
+    if (block.timestamp >= uint256(registeredAt) + VERSION_EXPIRY) {
+        revert IPortalProxy.ProtocolVersionExpired(protocolVersion);
+    }
+}
+
+/**
+ * @notice Whether `protocolVersion` is registered on `proxy` AND past its {VERSION_EXPIRY}.
+ * @dev Authorizes the protocol-owner deployer sweep on both `executeAsOwner` paths. An UNREGISTERED
+ *      version is NOT expired (returns false): the sweep is only ever an alternate authority on a real,
+ *      once-live version, never one that never existed.
+ * @param proxy The {PortalProxy} holding the version registry (`address(this)` under delegatecall).
+ * @param protocolVersion The version to check.
+ * @return True if the version is registered and its expiry has elapsed.
+ */
+function isProtocolVersionExpired(
+    address proxy,
+    uint32 protocolVersion
+) view returns (bool) {
+    (address implementation, uint64 registeredAt) = IPortalProxy(proxy)
+        .versions(protocolVersion);
+    if (implementation == address(0)) {
+        return false;
+    }
+    return block.timestamp >= uint256(registeredAt) + VERSION_EXPIRY;
+}
+
+interface IPortalProxy {
+    /**
+     * @notice A registered implementation for a protocol version and when it was registered.
+     * @param implementation The Portal implementation contract for this version (`address(0)` if the
+     *        version is unregistered).
+     * @param registeredAt The block timestamp the version was registered (0 if unregistered).
+     */
+    struct VersionInfo {
+        address implementation;
+        uint64 registeredAt;
+    }
+
+    /**
+     * @notice A version number has already been registered (registration is WRITE-ONCE).
+     * @param version The version that was already taken.
+     */
+    error VersionAlreadyRegistered(uint32 version);
+
+    /**
+     * @notice A version was registered with the zero implementation address.
+     */
+    error ZeroImplementation();
+
+    /**
+     * @notice A call named a protocol version that has never been registered.
+     * @param version The unregistered version.
+     */
+    error UnknownProtocolVersion(uint32 version);
+
+    /**
+     * @notice A new intent was published under a version that is past its {VERSION_EXPIRY}.
+     * @param version The expired version.
+     */
+    error ProtocolVersionExpired(uint32 version);
+
+    /**
+     * @notice The caller is not the protocol owner.
+     * @param caller The unauthorized caller.
+     */
+    error NotOwner(address caller);
+
+    /**
+     * @notice A new implementation version was registered.
+     * @param version The version number registered.
+     * @param implementation The implementation address bound to it.
+     * @param registeredAt The registration timestamp.
+     */
+    event VersionRegistered(
+        uint32 indexed version,
+        address indexed implementation,
+        uint64 registeredAt
+    );
+
+    /**
+     * @notice Registers an implementation for a protocol version (owner-only, write-once).
+     * @param version The version number to register.
+     * @param implementation The Portal implementation contract for this version.
+     */
+    function registerVersion(uint32 version, address implementation) external;
+
+    /**
+     * @notice The implementation + registration time for a protocol version.
+     * @param version The protocol version to look up.
+     * @return implementation The implementation address (`address(0)` if unregistered).
+     * @return registeredAt The registration timestamp (0 if unregistered).
+     */
+    function versions(
+        uint32 version
+    ) external view returns (address implementation, uint64 registeredAt);
+
+    /**
+     * @notice The protocol owner (may register versions and perform the expired-version deployer sweep).
+     * @return The owner address.
+     */
+    function owner() external view returns (address);
+}

--- a/contracts/prover/BasePolicy.sol
+++ b/contracts/prover/BasePolicy.sol
@@ -243,12 +243,14 @@ abstract contract BasePolicy is IPolicy, ERC165 {
      * @param rewardHash The hash of the reward specification
      */
     function challengeIntentProof(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
         bytes32 rewardHash
     ) external {
         bytes32 intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             destination,
             routeHash,

--- a/contracts/prover/LocalPolicy.sol
+++ b/contracts/prover/LocalPolicy.sol
@@ -148,6 +148,7 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
      * @notice Challenges an intent proof (not applicable for same-chain intents)
      */
     function challengeIntentProof(
+        uint32 /* protocolVersion */,
         uint64 /* source */,
         uint64 /* destination */,
         bytes32 /* routeHash */,
@@ -176,6 +177,7 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
      * @return results The runtime's raw return data from the fulfill execution
      */
     function flashFulfill(
+        uint32 protocolVersion,
         Route calldata route,
         Reward calldata reward,
         bytes32 claimant
@@ -188,6 +190,7 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
         bytes32 routeHash = keccak256(abi.encode(route));
         bytes32 rewardHash = keccak256(abi.encode(reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            protocolVersion,
             _CHAIN_ID,
             _CHAIN_ID,
             routeHash,
@@ -210,6 +213,7 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
         }
 
         results = _PORTAL.fulfill{value: msg.value}(
+            protocolVersion,
             _CHAIN_ID,
             _CHAIN_ID,
             route,
@@ -222,6 +226,7 @@ contract LocalPolicy is ILocalPolicy, Semver, ReentrancyGuard {
         // Settle: pays the claimant the owed reward from the account, sweeps residual to the keeper.
         // `providedAmounts` is the committed `fulfilled[]`, so the preimage matches the recorded fact.
         _PORTAL.settle(
+            protocolVersion,
             _CHAIN_ID,
             _CHAIN_ID,
             routeHash,

--- a/contracts/prover/ScheduledPolicy.sol
+++ b/contracts/prover/ScheduledPolicy.sol
@@ -121,12 +121,14 @@ abstract contract ScheduledPolicy is IPolicy, Whitelist, Semver, ERC165 {
      *      same-chain synthesized fact (destination == {CHAIN_ID}) is never challengeable.
      */
     function challengeIntentProof(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
         bytes32 rewardHash
     ) external {
         bytes32 intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             destination,
             routeHash,

--- a/contracts/prover/StreamingPolicy.sol
+++ b/contracts/prover/StreamingPolicy.sol
@@ -311,12 +311,14 @@ contract StreamingPolicy is IStreamingPolicy, Whitelist, Semver, ERC165 {
      *      other than the intent commits to, drop them all (they can never legitimately settle).
      */
     function challengeIntentProof(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
         bytes32 rewardHash
     ) external {
         bytes32 intentHash = IntentLib.hashIntent(
+            protocolVersion,
             source,
             destination,
             routeHash,

--- a/contracts/test/TestDestinationSettler.sol
+++ b/contracts/test/TestDestinationSettler.sol
@@ -12,6 +12,7 @@ contract TestDestinationSettler is DestinationSettler {
     }
 
     function fulfillAndProve(
+        uint32 _protocolVersion,
         uint64 _source,
         uint64 _destination,
         Route memory _route,
@@ -25,6 +26,7 @@ contract TestDestinationSettler is DestinationSettler {
         // Call the portal's fulfillAndProve function
         return
             PORTAL.fulfillAndProve{value: msg.value}(
+                _protocolVersion,
                 _source,
                 _destination,
                 _route,

--- a/contracts/test/TestDestinationSettlerComplete.sol
+++ b/contracts/test/TestDestinationSettlerComplete.sol
@@ -17,6 +17,7 @@ contract TestDestinationSettlerComplete is DestinationSettler {
     }
 
     function fulfillAndProve(
+        uint32 _protocolVersion,
         uint64 _source,
         uint64 _destination,
         Route memory _route,
@@ -44,6 +45,7 @@ contract TestDestinationSettlerComplete is DestinationSettler {
         // Call the portal's fulfillAndProve function
         return
             PORTAL.fulfillAndProve{value: msg.value}(
+                _protocolVersion,
                 _source,
                 _destination,
                 _route,

--- a/contracts/tron/AccountTron.sol
+++ b/contracts/tron/AccountTron.sol
@@ -14,6 +14,12 @@ import {TronTransfer} from "../libs/TronTransfer.sol";
  */
 contract AccountTron is Account {
     /**
+     * @notice Creates the Tron Account implementation bound to its portal.
+     * @param _portal The authorized caller (the {PortalProxy}).
+     */
+    constructor(address _portal) Account(_portal) {}
+
+    /**
      * @inheritdoc Account
      */
     function _transferToken(

--- a/contracts/tron/PortalTron.sol
+++ b/contracts/tron/PortalTron.sol
@@ -4,15 +4,22 @@ pragma solidity ^0.8.26;
 
 import {PortalCore} from "../PortalCore.sol";
 import {AccountDeployer} from "../account/AccountDeployer.sol";
-import {AccountTron} from "./AccountTron.sol";
 
 /**
  * @title PortalTron
- * @notice Portal variant for Tron chains. Combines IntentSource and Inbox functionality.
- * @dev Uses AccountTron clones (via the 0x41 CREATE2 prefix) to support non-standard ERC20
- *      tokens such as Tron USDT. Identical to {Portal} apart from the Account clone template and the
- *      CREATE2 prefix supplied to the shared {AccountDeployer}.
+ * @notice Portal IMPLEMENTATION variant for Tron chains. Combines IntentSource and Inbox functionality.
+ * @dev Uses an {AccountTron} clone template (via the 0x41 CREATE2 prefix) to support non-standard ERC20
+ *      tokens such as Tron USDT. Identical to {Portal} apart from the Account clone template (a shared
+ *      {AccountTron} implementation bound to the proxy, passed in) and the CREATE2 prefix supplied to the
+ *      shared {AccountDeployer}. Runs behind the permanent {PortalProxy} (PR9).
  */
 contract PortalTron is PortalCore {
-    constructor() AccountDeployer(address(new AccountTron()), bytes1(0x41)) {}
+    /**
+     * @notice Wires the shared AccountTron clone template.
+     * @param accountImplementation The shared {AccountTron} implementation (bound to the proxy) that
+     *        per-intent clones delegate to.
+     */
+    constructor(
+        address accountImplementation
+    ) AccountDeployer(accountImplementation, bytes1(0x41)) {}
 }

--- a/contracts/types/ERC7683.sol
+++ b/contracts/types/ERC7683.sol
@@ -109,6 +109,7 @@ struct FillInstruction {
  * @notice contains everything which, when combined with other aspects of GaslessCrossChainOrder
  * is sufficient to publish an intent via Eco Protocol
  * @dev the orderData field of GaslessCrossChainOrder should be decoded as OrderData
+ * @param protocolVersion creator-declared Portal implementation version committed in the intent hash
  * @param destination the destination chain ID for the intent
  * @param route the route data for execution on the destination chain
  * @param reward the reward structure containing keeper, prover, amounts, and deadline information
@@ -117,6 +118,7 @@ struct FillInstruction {
  * @param maxSpent the maximum outputs that the filler will send
  */
 struct OrderData {
+    uint32 protocolVersion;
     uint64 destination;
     bytes route;
     Reward reward;
@@ -127,5 +129,5 @@ struct OrderData {
 
 // EIP712 type hash (referenced struct types sorted alphabetically per EIP-712)
 bytes32 constant ORDER_DATA_TYPEHASH = keccak256(
-    "OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)"
+    "OrderData(uint32 protocolVersion,uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)"
 );

--- a/contracts/types/Intent.sol
+++ b/contracts/types/Intent.sol
@@ -142,13 +142,18 @@ struct Reward {
  * @dev Main structure used to process and execute cross-chain messages. Both `source` and `destination`
  *      are HASHED into the intent hash (Model C), so an A->B intent is distinct from an A'->B intent
  *      (kills cross-chain replay) and the two chain-parameterized Account addresses separate the escrow
- *      (source) from the execution leftovers (destination).
+ *      (source) from the execution leftovers (destination). `protocolVersion` is the FIRST field and is
+ *      also hashed in, so it selects which registered Portal implementation the {PortalProxy} dispatches
+ *      to and pins the intent to that implementation's code for its whole lifetime.
+ * @param protocolVersion Creator-declared Portal implementation version this intent targets. Committed in
+ *        the intent hash and validated at {IIntentSource-publish} (must be registered and not expired).
  * @param source Origin chain ID where the reward is escrowed and settled
  * @param destination Target chain ID where the intent should be executed
  * @param route Routing and execution instructions
  * @param reward Reward and validation parameters
  */
 struct Intent {
+    uint32 protocolVersion;
     uint64 source;
     uint64 destination;
     Route route;
@@ -219,10 +224,12 @@ library IntentLib {
     error RewardShorterThanMinTokens(uint256 rewardCount, uint256 minTokensCount);
 
     /**
-     * @notice Canonical intent hash from its chain ids and component hashes.
-     * @dev `keccak256(abi.encodePacked(source, destination, routeHash, rewardHash))`. Both chain ids are
-     *      committed so the hash (and thus both chain-parameterized Account addresses) separates by
-     *      direction.
+     * @notice Canonical intent hash from its protocol version, chain ids and component hashes.
+     * @dev `keccak256(abi.encodePacked(protocolVersion, source, destination, routeHash, rewardHash))`.
+     *      `protocolVersion` leads the preimage (it is the first `Intent` field) so it selects the Portal
+     *      implementation and pins the intent to it; both chain ids are committed so the hash (and thus both
+     *      chain-parameterized Account addresses) separates by direction.
+     * @param protocolVersion Creator-declared Portal implementation version.
      * @param source Origin chain ID (where the reward is escrowed/settled).
      * @param destination Destination chain ID (where the route executes).
      * @param routeHash Hash of the route component.
@@ -230,6 +237,7 @@ library IntentLib {
      * @return The intent hash.
      */
     function hashIntent(
+        uint32 protocolVersion,
         uint64 source,
         uint64 destination,
         bytes32 routeHash,
@@ -237,7 +245,13 @@ library IntentLib {
     ) internal pure returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(source, destination, routeHash, rewardHash)
+                abi.encodePacked(
+                    protocolVersion,
+                    source,
+                    destination,
+                    routeHash,
+                    rewardHash
+                )
             );
     }
 

--- a/docs/v3/09-protocol-versioning.md
+++ b/docs/v3/09-protocol-versioning.md
@@ -1,0 +1,190 @@
+# PR9 — Protocol Versioning (permanent PortalProxy + versioned implementations)
+
+## Goal
+
+Let the protocol ship new Portal behaviour **without ever changing the address that intents and
+per-intent Accounts are anchored to**, and give the protocol owner a narrowly-scoped way to sweep funds
+that get stuck under an old implementation once it is retired.
+
+Three moving parts:
+
+1. **`Intent.protocolVersion`** — a new creator-declared `uint32`, the FIRST field of `Intent`, hashed into
+   the intent hash. It selects which registered implementation serves the intent and pins the intent to that
+   implementation for its whole lifetime.
+2. **`PortalProxy`** — the new PERMANENT, stable-address contract. It holds a write-once
+   `version → implementation` registry and `delegatecall`s each call into the implementation for the call's
+   version. This is what everything (solvers, keepers, per-intent Accounts, downstream policies) trusts
+   forever.
+3. **Deployer sweep** — once an implementation version is `VERSION_EXPIRY` (365 days) old, the protocol owner
+   becomes an *alternate authority* on the EXISTING, already-hardened `executeAsOwner` escrow/proof lock — it
+   can sweep an account whose intent is independently dead, and nothing more.
+
+## The proxy / implementation split
+
+`Portal` and `PortalTron` used to be the directly-deployed contracts. They are now **implementation**
+contracts that only ever run via `delegatecall` from the `PortalProxy`. The deploy script deploys the proxy
+as the canonical "Portal" address (`cfg.salt`), deploys the implementation at a derived salt, and calls
+`registerVersion(1, implementation)`. Every downstream contract (policies, deposit factories) references the
+**proxy** address.
+
+### Why account addresses stay stable across implementation versions
+
+A per-intent Account is an ERC-1167 clone deployed with CREATE2. Its address is
+`keccak(0xff, deployer, salt, keccak(cloneCreationCode))` where:
+
+- `deployer` is `address(this)` **of the code doing the CREATE2** (see `Clones.predict`/`Clones.clone`).
+  Because `delegatecall` preserves `address(this)`, when the implementation runs behind the proxy
+  `address(this)` is the **proxy** — so every Account is deployed and predicted against the proxy's stable
+  address, forever, regardless of which implementation version handled the call.
+- `cloneCreationCode` embeds the **Account implementation** address (`ACCOUNT_IMPLEMENTATION`) and the
+  CREATE2 prefix. These are immutables of the Portal implementation. For the address to be identical across
+  Portal versions, **every version must be deployed with the SAME Account implementation + prefix**.
+
+To make this a structural guarantee rather than a deploy-time convention, the **Account implementation is a
+single shared contract**: it is deployed once (bound to the proxy — see below) and passed into every Portal
+version's constructor as the clone template. The deploy script does exactly this; a hypothetical version 2 is
+`new Portal(sameAccountImplementation)`, so it derives byte-identical account addresses.
+
+`test/core/ProtocolVersioning.t.sol::test_accountAddressStableAcrossImplementationVersions` proves it:
+registering a second implementation (built on the same shared Account implementation) and computing
+`accountAddress(intentHash, chainId)` before and after registration returns the identical address.
+
+### The `Account` must trust the PROXY, not an implementation
+
+`Account.onlyPortal` authorizes a single `portal` address. Since every account call originates from the
+implementation running *as the proxy* (`msg.sender` seen by the Account is the proxy), the Account's `portal`
+must be the **proxy**. The shared Account implementation is therefore constructed with the proxy address:
+`new Account(proxyAddress)`. This is why the Account implementation is deployed *after* the proxy (the proxy
+address does not depend on any implementation, only on the owner + salt, so there is no cycle).
+
+### Storage safety under delegatecall
+
+The implementation executes in the proxy's storage. To avoid any collision:
+
+- The implementation's only mutable storage is `IntentSource.rewardStatuses` (slot 0). This is *intended* to
+  live in proxy storage — the reward lifecycle is shared across versions.
+- The proxy keeps its **version registry** in ERC-7201 **namespaced** storage
+  (`eco.portal.proxy.registry`), a keccak-derived high slot that cannot collide with the implementation's
+  sequential slots.
+- The proxy's **owner is immutable** (in code, not storage), matching this codebase's immutable-trust-anchor
+  ethos (it uses immutable whitelists, not OpenZeppelin `Ownable`). No storage, no collision.
+- `OriginSettler.GASLESS_CROSSCHAIN_ORDER_TYPEHASH` was a mutable public state variable; it is now
+  `constant` so it lives in code and reads correctly under delegatecall (a storage state variable would read
+  the proxy's unwritten slot). OpenZeppelin `EIP712` uses immutables and rebuilds the domain separator when
+  `address(this) != cachedThis`, so the domain separator correctly reflects the proxy address.
+
+## Dispatch
+
+Most Portal entry points take `protocolVersion` as an explicit **leading `uint32` scalar** — this is forced
+by the design: the route stays opaque `bytes` at the source (cross-VM compatibility), so on the
+`fund`/`fundFor`/`settle`/`refund`/`recoverToken`/stream paths there is no decoded struct to read the version
+from. It is threaded exactly like `source`/`destination` already are. `IntentLib.hashIntent` gains a leading
+`protocolVersion`, and `intentHash = keccak256(abi.encodePacked(protocolVersion, source, destination,
+routeHash, rewardHash))`.
+
+The proxy dispatches as follows:
+
+- **`fallback()`** handles every entry point whose first ABI argument is `uint32 protocolVersion`: it reads
+  the version straight from `calldata[4:36]` and `delegatecall`s the resolved implementation. No per-function
+  code. A selector-only call (`4 <= len < 36`, a no-argument view like `domainSeparatorV4`) is
+  version-agnostic and routes to the latest implementation; `< 4` bytes reverts.
+- **Typed forwarders** exist only for the exceptions:
+  - Entry points taking a full `Intent` (`publish(Intent)`, `publishAndFund(Intent,bool)`,
+    `publishAndFundFor`, `intentAccountAddress(Intent)`, `isIntentFunded(Intent)`, `getIntentHash(Intent)`,
+    source-side `executeAsOwner(Intent,...)`, `fulfillAndSettle`) — the version is read from
+    `intent.protocolVersion` and the intent is served by that version's implementation (pinning).
+  - Version-agnostic helpers (`getRewardStatus`, `accountAddress`, `version`, `prove`) and the ERC-7683
+    adapter surface (`open`/`openFor`/`resolve`/`resolveFor`/`fill`) — routed to the **latest**
+    implementation. These either only read shared proxy storage / derive an address that is identical across
+    versions, or carry the pinned version inside their order/originData that the implementation validates and
+    hashes with.
+
+Each forwarder is a one-liner over an internal `_delegate(impl)` that copies calldata, `delegatecall`s, and
+bubbles the raw return/revert verbatim. Resolving an **unregistered** version reverts
+`UnknownProtocolVersion`; an **expired but registered** version still resolves (existing intents must stay
+settleable/refundable/sweepable forever — only `publish` additionally rejects an expired version for NEW
+intents).
+
+## The version registry
+
+`struct VersionInfo { address implementation; uint64 registeredAt; }`,
+`mapping(uint32 => VersionInfo)` in namespaced storage. `registerVersion(version, implementation)` is
+owner-only and **write-once**: re-registering a version reverts `VersionAlreadyRegistered`, and
+`implementation == address(0)` reverts `ZeroImplementation`. There is no removal and no re-pointing — a
+version's binding is immutable once set, matching the codebase's `Whitelist` immutability ethos (repointing a
+version that live intents reference would be a rug vector). A `latestVersion` counter tracks the highest
+registered version for the version-agnostic forwarders.
+
+## `publish` validation
+
+`publish` calls `requireValidProtocolVersion(address(this), protocolVersion)` (a free function reading the
+proxy registry via `address(this)` under delegatecall): it reverts `UnknownProtocolVersion` if the version is
+unregistered and `ProtocolVersionExpired` if `block.timestamp >= registeredAt + VERSION_EXPIRY`. A new intent
+can therefore never be created already-sweepable.
+
+## Deployer sweep — alternate authority on the existing lock
+
+The sweep is **not a new function and not a new check**. It is a second authorized caller on the EXISTING
+`executeAsOwner`, on both the source and destination sides.
+
+Source side (`IntentSource.executeAsOwner`, keyed by `intent.protocolVersion`):
+
+```solidity
+bool isKeeper = msg.sender == intent.reward.keeper;
+bool isDeployerSweep = msg.sender == IPortalProxy(address(this)).owner()
+    && isProtocolVersionExpired(address(this), intent.protocolVersion);
+if (!isKeeper && !isDeployerSweep) revert NotAccountOwner(msg.sender);
+// ... UNCHANGED AccountLocked escrow/proof lock runs identically below ...
+```
+
+Destination side (`Inbox.executeAsOwner`): the same OR-branch is added to the existing `route.keeper` check,
+and the existing **cross-chain-only** restriction (`SourceChainOwnerOnly` when `source == block.chainid`)
+still applies to BOTH authorities — the same-chain collapse safety reasoning is caller-independent (a
+same-chain intent's leftover retrieval must always go through the source-side, escrow-aware path).
+
+### Why this is the safe minimal design — a two-condition gate
+
+The deployer sweep is authorized only when **both**:
+
+1. the intent's protocol version is **expired** (`registeredAt + 365 days` has passed), AND
+2. the account is **independently dead** — which is exactly what the existing `AccountLocked` lock already
+   enforces: `executeAsOwner` reverts `AccountLocked` in any non-terminal status while the reward still has
+   live legs and is before its deadline, or while a valid destination proof exists (a solver may be owed).
+
+Condition (2) falls out **for free** from code that was written and hardened in an earlier PR (the PR3
+`executeAsOwner` critical fix), so the deployer path rides the SAME safety rail the keeper does. Expiry ALONE
+is never sufficient: after expiry the owner still cannot touch an account that has live reward legs before the
+deadline or a valid unsettled proof. No existing invariant (the lock, the cross-chain-only restriction) is
+weakened to make the deployer path work.
+
+`test/core/ProtocolVersioning.t.sol` proves, for both sides:
+(a) before expiry the owner cannot sweep (only the keeper can) — reverts `NotAccountOwner` /
+`NotAccountKeeper`;
+(b) after expiry the owner can sweep an independently-dead account (empty-reward, or past-deadline with no
+live legs and no proof);
+(c) after expiry the owner is STILL blocked by `AccountLocked` if the account has live reward legs before the
+deadline or a valid unsettled proof — expiry alone is never enough;
+(d) the destination-side deployer sweep is additionally rejected same-chain (`SourceChainOwnerOnly`), like the
+keeper.
+
+## Size budget
+
+`optimizer_runs` lowered from 1000 to 400 (foundry.toml + hardhat.config.ts in lockstep): the Portal
+implementation grew with the per-entry-point `protocolVersion` parameter, the `publish`/sweep version reads,
+and the deployer-sweep branch. At 400 runs the implementation is comfortably under the 24,576 B EIP-170 limit,
+and `PortalProxy` is a small (~3 KB) standalone contract with its own budget.
+
+## Deferred / out of scope
+
+- **Settable `VERSION_EXPIRY`.** It is a file-level `constant` (365 days), not an owner-settable parameter —
+  deliberately, matching the immutable-trust-anchor ethos. Making it settable would add a mutable trust knob;
+  bumping the constant in a new implementation version is the intended path if the horizon ever needs to
+  change.
+- **ERC-7683 order version pinning at the proxy.** The ERC-7683 adapter surface routes to the latest
+  implementation; the order's declared `protocolVersion` still travels in `OrderData` → `originData` and is
+  validated (`publish`) and hashed with by the implementation, so the created/filled intent is correctly
+  pinned in its hash. Pinning the *executing implementation* of `open`/`fill` to the order's declared version
+  (rather than latest) is a possible future refinement if implementation versions ever diverge in
+  open/publish behaviour.
+- **Owner transfer.** The proxy owner is immutable. Rotating the protocol owner would require a new proxy
+  (and is out of scope); it is intentionally not a mutable knob.

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = "out"
 fs_permissions = [{ access = "read-write", path = "./out"}]
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 1000
+optimizer_runs = 400
 via_ir = true
 retries = 2
 evm_version = "paris"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,8 +21,10 @@ const config: HardhatUserConfig = {
             enabled: true,
             // Kept in lockstep with foundry.toml `optimizer_runs`. PR6 lowered this from 20000 to 1000
             // so the Portal (which gained the streaming settle/close entry points) stays under the
-            // 24,576 B EIP-170 limit. See docs/v3/06-streaming-and-deposits.md ("Size budget").
-            runs: 1000,
+            // 24,576 B EIP-170 limit; PR9 lowered it again from 1000 to 400 (the Portal grew with the
+            // per-entry-point `protocolVersion` param + version validation + deployer-sweep branch).
+            // See docs/v3/09-protocol-versioning.md ("Size budget").
+            runs: 400,
           },
         },
       },

--- a/scripts/DeployV3.s.sol
+++ b/scripts/DeployV3.s.sol
@@ -15,6 +15,11 @@ import {AddressConverter} from "../contracts/libs/AddressConverter.sol";
 // Core (no ctor args => CREATE2, identical address on every chain)
 import {Portal} from "../contracts/Portal.sol";
 import {PortalTron} from "../contracts/tron/PortalTron.sol";
+import {PortalProxy} from "../contracts/PortalProxy.sol";
+// Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Script-derived
+// contracts.
+import {Account as EcoAccount} from "../contracts/account/Account.sol";
+import {AccountTron} from "../contracts/tron/AccountTron.sol";
 import {MulticallRuntime} from "../contracts/runtime/MulticallRuntime.sol";
 
 // Same-chain settlement (portal-only ctor)
@@ -116,7 +121,8 @@ contract DeployV3 is Script {
     }
 
     struct Deployment {
-        address portal;
+        address portal; // the permanent PortalProxy (what everything references as "the Portal")
+        address portalImplementation; // the versioned implementation registered as version 1
         address runtime;
         address localPolicy;
         address hyperPolicy;
@@ -156,15 +162,58 @@ contract DeployV3 is Script {
     function deploy(Config memory cfg) public returns (Deployment memory dep) {
         _ensureCreate3Deployer(cfg.isTron);
 
-        // 1. Core (CREATE2, no ctor args).
+        // 1. Core: a permanent PortalProxy in front of a versioned implementation (PR9).
+        //    - The PortalProxy is the PERMANENT, stable "Portal" address that every intent, account, and
+        //      downstream policy anchors to. Deployed at `cfg.salt` (the canonical address) with the
+        //      deployer as protocol owner. Deployed FIRST because both the shared Account implementation
+        //      (bound to the proxy as its authorized caller) and the Portal implementation reference it.
+        //    - The Account implementation is SHARED across all Portal versions and bound to the proxy, so
+        //      every version derives the same per-intent Account addresses (address-stability invariant).
+        //    - The Portal implementation (Portal / PortalTron) carries ALL the logic; it references the
+        //      shared Account implementation as its clone template. Deployed at a derived salt.
         dep.portal = _deployCreate2(
-            cfg.isTron
-                ? type(PortalTron).creationCode
-                : type(Portal).creationCode,
+            abi.encodePacked(
+                type(PortalProxy).creationCode,
+                abi.encode(cfg.deployer) // initialOwner = deployer (protocol owner)
+            ),
             cfg.salt,
             cfg.isTron
         );
-        console.log("Portal:", dep.portal);
+        console.log("PortalProxy (permanent Portal):", dep.portal);
+
+        address accountImplementation = _deployCreate2(
+            abi.encodePacked(
+                cfg.isTron
+                    ? type(AccountTron).creationCode
+                    : type(EcoAccount).creationCode,
+                abi.encode(dep.portal) // Account.portal = the proxy (its authorized caller)
+            ),
+            _contractSalt(cfg.salt, "ACCOUNT_IMPLEMENTATION"),
+            cfg.isTron
+        );
+        console.log("Account implementation (shared):", accountImplementation);
+
+        dep.portalImplementation = _deployCreate2(
+            abi.encodePacked(
+                cfg.isTron
+                    ? type(PortalTron).creationCode
+                    : type(Portal).creationCode,
+                abi.encode(accountImplementation) // shared Account clone template
+            ),
+            _contractSalt(cfg.salt, "PORTAL_IMPLEMENTATION_V1"),
+            cfg.isTron
+        );
+        console.log("Portal implementation (v1):", dep.portalImplementation);
+
+        // Bootstrap version 1 -> implementation (owner-only; broadcasting as the deployer/owner).
+        // Idempotent on re-run: re-registration would revert VersionAlreadyRegistered, so skip if set.
+        (address registered, ) = PortalProxy(payable(dep.portal)).versions(1);
+        if (registered == address(0)) {
+            PortalProxy(payable(dep.portal)).registerVersion(
+                1,
+                dep.portalImplementation
+            );
+        }
 
         dep.runtime = _deployCreate2(
             type(MulticallRuntime).creationCode,
@@ -471,6 +520,7 @@ contract DeployV3 is Script {
             return;
         }
         _writeLine(path, dep.portal, "Portal");
+        _writeLine(path, dep.portalImplementation, "PortalImplementation");
         _writeLine(path, dep.runtime, "MulticallRuntime");
         _writeLine(path, dep.localPolicy, "LocalPolicy");
         _writeLine(path, dep.hyperPolicy, "HyperPolicy");

--- a/scripts/semantic-release/sr-build-package.ts
+++ b/scripts/semantic-release/sr-build-package.ts
@@ -35,6 +35,7 @@ import { zeroAddress } from 'viem'
 // This is used for both CSV headers and TypeScript type definitions
 export const CONTRACT_TYPES = [
   'Portal',
+  'PortalImplementation',
   'MulticallRuntime',
   'LocalPolicy',
   'HyperPolicy',

--- a/scripts/semantic-release/tests/sr-build-package.spec.ts
+++ b/scripts/semantic-release/tests/sr-build-package.spec.ts
@@ -148,6 +148,8 @@ describe('Semantic Release Build Package', () => {
     it('should contain the expected contract types', () => {
       // Assert: the v3 contract set (Prover→Policy rename, full deployed set)
       expect(CONTRACT_TYPES).toContain('Portal')
+      // PR9: the permanent proxy is "Portal"; the versioned implementation address is also recorded.
+      expect(CONTRACT_TYPES).toContain('PortalImplementation')
       expect(CONTRACT_TYPES).toContain('MulticallRuntime')
       expect(CONTRACT_TYPES).toContain('HyperPolicy')
       expect(CONTRACT_TYPES).toContain('CCIPPolicy')
@@ -155,7 +157,7 @@ describe('Semantic Release Build Package', () => {
       expect(CONTRACT_TYPES).toContain('VestingPolicy')
       // No pre-rename names remain.
       expect(CONTRACT_TYPES).not.toContain('HyperProver')
-      expect(CONTRACT_TYPES.length).toBe(12)
+      expect(CONTRACT_TYPES.length).toBe(13)
     })
   })
 })

--- a/src/__tests__/hashing.test.ts
+++ b/src/__tests__/hashing.test.ts
@@ -6,6 +6,7 @@ import type { Intent } from '../types'
 // Solidity test (forge test --match-path test/v3/sdk/GoldenVector.t.sol -vv) — this asserts TS<->Solidity
 // byte-parity of the hashing scheme.
 const INTENT: Intent = {
+  protocolVersion: 1,
   source: 8453n,
   destination: 10n,
   route: {
@@ -44,7 +45,7 @@ const GOLDEN = {
   rewardHash:
     '0x5435b4137cc49f6627e966eddc3be93118edac8c4732fcff5ded126b22788b81',
   intentHash:
-    '0xa5fc9f392a4c4f858e79502faa282dc4cc364d9c034138d7a36c54a74caa6db7',
+    '0x911a9cd64402c234a708c7a849125ab713d2edb18d4e0c02a2aa00266e0632d8',
 }
 
 // Build abi.encode(Hook[2]) exactly as the Solidity fixture does.

--- a/src/hashing.ts
+++ b/src/hashing.ts
@@ -65,8 +65,9 @@ export function hashReward(reward: Reward): Hex {
   return keccak256(encodeAbiParameters([REWARD_ABI], [reward]))
 }
 
-/** `keccak256(abi.encodePacked(uint64 source, uint64 destination, bytes32 routeHash, bytes32 rewardHash))`. */
+/** `keccak256(abi.encodePacked(uint32 protocolVersion, uint64 source, uint64 destination, bytes32 routeHash, bytes32 rewardHash))`. */
 export function hashIntentComponents(
+  protocolVersion: number,
   source: bigint,
   destination: bigint,
   routeHash: Hex,
@@ -74,15 +75,16 @@ export function hashIntentComponents(
 ): Hex {
   return keccak256(
     encodePacked(
-      ['uint64', 'uint64', 'bytes32', 'bytes32'],
-      [source, destination, routeHash, rewardHash],
+      ['uint32', 'uint64', 'uint64', 'bytes32', 'bytes32'],
+      [protocolVersion, source, destination, routeHash, rewardHash],
     ),
   )
 }
 
-/** Full intent hash: hashes the route + reward, then combines with source/destination. */
+/** Full intent hash: hashes the route + reward, then combines with protocolVersion/source/destination. */
 export function hashIntent(intent: Intent): Hex {
   return hashIntentComponents(
+    intent.protocolVersion,
     intent.source,
     intent.destination,
     hashRoute(intent.route),

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface Reward {
 }
 
 export interface Intent {
+  protocolVersion: number // uint32 — creator-declared Portal implementation version (first hashed field)
   source: bigint
   destination: bigint
   route: Route

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -10,6 +10,10 @@ import {BadERC20} from "../contracts/test/BadERC20.sol";
 import {FakePermit} from "../contracts/test/FakePermit.sol";
 import {TestPolicy} from "../contracts/test/TestPolicy.sol";
 import {Portal} from "../contracts/Portal.sol";
+import {PortalProxy} from "../contracts/PortalProxy.sol";
+// Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Test-derived
+// contracts, so the contract type is imported under a distinct name.
+import {Account as EcoAccount} from "../contracts/account/Account.sol";
 import {Inbox} from "../contracts/Inbox.sol";
 import {IIntentSource} from "../contracts/interfaces/IIntentSource.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../contracts/types/Intent.sol";
@@ -23,6 +27,8 @@ contract BaseTest is Test {
     uint256 internal constant REWARD_NATIVE_ETH = 2 ether;
     uint256 internal constant EXPIRY_DURATION = 123;
     uint64 internal constant CHAIN_ID = 1;
+    // Protocol version the tests publish under (registered on the PortalProxy in setUp).
+    uint32 internal constant PROTOCOL_VERSION = 1;
 
     // Test addresses
     address internal keeper;
@@ -30,8 +36,13 @@ contract BaseTest is Test {
     address internal otherPerson;
     address internal deployer;
 
-    // Core contracts
+    // Core contracts. `portal` is the PortalProxy address cast to the Portal type, so every test call
+    // routes through the proxy (which delegatecalls the registered implementation) — exactly as in
+    // production. `portalImplementation` is the version-1 implementation behind it.
     Portal internal portal;
+    PortalProxy internal portalProxy;
+    address internal portalImplementation;
+    address internal accountImplementation; // shared Account clone template (bound to the proxy)
     IIntentSource internal intentSource; // Interface for Portal
     Inbox internal inbox; // Backward compatibility alias
     TestPolicy internal prover;
@@ -68,8 +79,18 @@ contract BaseTest is Test {
 
         vm.startPrank(deployer);
 
-        // Deploy core contracts
-        portal = new Portal();
+        // Deploy the versioned implementation behind a permanent PortalProxy, register it as version 1,
+        // and point `portal` at the PROXY so all tests exercise the proxy-mediated path (delegatecall into
+        // the implementation) — not the implementation directly. `deployer` is the proxy's protocol owner.
+        // The Account implementation is shared and bound to the PROXY (its authorized `portal`), so every
+        // registered Portal version derives the same per-intent Account addresses.
+        portalProxy = new PortalProxy(deployer);
+        EcoAccount accountImpl = new EcoAccount(address(portalProxy));
+        Portal implementation = new Portal(address(accountImpl));
+        portalProxy.registerVersion(PROTOCOL_VERSION, address(implementation));
+        accountImplementation = address(accountImpl);
+        portalImplementation = address(implementation);
+        portal = Portal(payable(address(portalProxy)));
         // Set backward compatibility aliases
         intentSource = IIntentSource(address(portal));
         inbox = Inbox(payable(address(portal)));
@@ -163,6 +184,7 @@ contract BaseTest is Test {
 
         // Setup intent (default is same-chain: source == destination == CHAIN_ID)
         intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: CHAIN_ID,
             destination: CHAIN_ID,
             route: route,
@@ -228,6 +250,7 @@ contract BaseTest is Test {
         bytes32 rewardHash = keccak256(abi.encode(_intent.reward));
         return
             IntentLib.hashIntent(
+                _intent.protocolVersion,
                 _intent.source,
                 _intent.destination,
                 routeHash,
@@ -266,6 +289,7 @@ contract BaseTest is Test {
         address claimantAddr
     ) internal {
         intentSource.settle(
+            PROTOCOL_VERSION,
             source,
             destination,
             routeHash,

--- a/test/DestinationSettler.spec.ts
+++ b/test/DestinationSettler.spec.ts
@@ -57,8 +57,20 @@ describe('Destination Settler Test', (): void => {
       await ethers.getContractFactory('TestMailbox')
     ).deploy(ethers.ZeroAddress)
     const [owner, keeper, solver, dstAddr] = await ethers.getSigners()
-    const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(owner.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
     const multicallRuntime = await (
       await ethers.getContractFactory('MulticallRuntime')
@@ -134,6 +146,7 @@ describe('Destination Settler Test', (): void => {
     }
     const _chainId = Number((await owner.provider.getNetwork()).chainId)
     const _intent: Intent = {
+      protocolVersion: 1,
       source: _chainId,
       destination: _chainId,
       route: _route,
@@ -173,6 +186,7 @@ describe('Destination Settler Test', (): void => {
       inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -204,6 +218,7 @@ describe('Destination Settler Test', (): void => {
       inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -94,7 +94,20 @@ describe('HyperPolicy Test', (): void => {
       await ethers.getContractFactory('TestMailbox')
     ).deploy(ethers.ZeroAddress) // No processor needed for these tests
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(owner.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const token = await (
@@ -308,6 +321,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent: Intent = {
+        protocolVersion: 1,
         source: currentChain, // Current chain (same-chain default)
         destination: currentChain, // Current chain
         route: {
@@ -363,6 +377,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -451,6 +466,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent: Intent = {
+        protocolVersion: 1,
         source: currentChain, // Current chain (same-chain default)
         destination: currentChain, // Current chain
         route: {
@@ -506,6 +522,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -577,6 +594,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent: Intent = {
+        protocolVersion: 1,
         source: currentChain, // Current chain (same-chain default)
         destination: currentChain, // Current chain
         route: {
@@ -632,6 +650,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -899,6 +918,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent: Intent = {
+        protocolVersion: 1,
         source: currentChain, // Current chain (same-chain default)
         destination: currentChain,
         route: {
@@ -985,6 +1005,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfillAndProve(
+          1,
           intent.source,
           intent.destination,
           route,
@@ -1045,6 +1066,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent: Intent = {
+        protocolVersion: 1,
         source: currentChain, // Current chain (same-chain default)
         destination: currentChain,
         route: {
@@ -1136,6 +1158,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfillAndProve(
+          1,
           intent.source,
           intent.destination,
           route,
@@ -1260,6 +1283,7 @@ describe('HyperPolicy Test', (): void => {
         (await hyperProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent0: Intent = {
+        protocolVersion: 1,
         source: destination, // Current chain (same-chain default)
         destination,
         route,
@@ -1287,6 +1311,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent0.source,
           intent0.destination,
           route,
@@ -1327,6 +1352,7 @@ describe('HyperPolicy Test', (): void => {
         hooks: '0x',
       }
       const intent1: Intent = {
+        protocolVersion: 1,
         source: destination, // Current chain (same-chain default)
         destination,
         route: route1,
@@ -1349,6 +1375,7 @@ describe('HyperPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent1.source,
           intent1.destination,
           route1,
@@ -1451,6 +1478,7 @@ describe('HyperPolicy Test', (): void => {
     beforeEach(async () => {
       // Create a standard intent for testing
       intent = {
+        protocolVersion: 1,
         source: 42161, // Fixed to match `destination` so it's inherited unchanged by every
         // spread-derived variant below (only `destination` varies across those tests).
         destination: 42161, // Arbitrum
@@ -1508,6 +1536,7 @@ describe('HyperPolicy Test', (): void => {
 
       await expect(
         prover.challengeIntentProof(
+          1,
           intent.source,
           intent.destination,
           routeHash,
@@ -1545,6 +1574,7 @@ describe('HyperPolicy Test', (): void => {
       const rewardHash = hashIntent(intent).rewardHash
 
       await prover.challengeIntentProof(
+        1,
         intent.source,
         intent.destination,
         routeHash,
@@ -1566,6 +1596,7 @@ describe('HyperPolicy Test', (): void => {
       // Challenge non-existent proof should be a no-op
       await expect(
         prover.challengeIntentProof(
+          1,
           intent.source,
           intent.destination,
           routeHash,
@@ -1595,6 +1626,7 @@ describe('HyperPolicy Test', (): void => {
 
       // First challenge
       await prover.challengeIntentProof(
+        1,
         intent.source,
         intent.destination,
         routeHash,
@@ -1608,6 +1640,7 @@ describe('HyperPolicy Test', (): void => {
       // Second challenge (should be no-op)
       await expect(
         prover.challengeIntentProof(
+          1,
           intent.source,
           intent.destination,
           routeHash,
@@ -1638,6 +1671,7 @@ describe('HyperPolicy Test', (): void => {
         prover
           .connect(solver)
           .challengeIntentProof(
+            1,
             intent.source,
             intent.destination,
             routeHash,
@@ -1667,6 +1701,7 @@ describe('HyperPolicy Test', (): void => {
       // Challenge with chain ID 0
       await expect(
         prover.challengeIntentProof(
+          1,
           edgeIntent.source,
           edgeIntent.destination,
           hashIntent(edgeIntent).routeHash,
@@ -1704,6 +1739,7 @@ describe('HyperPolicy Test', (): void => {
       // Challenge both proofs
       await expect(
         prover.challengeIntentProof(
+          1,
           intent1.source,
           intent1.destination,
           hashIntent(intent1).routeHash,
@@ -1715,6 +1751,7 @@ describe('HyperPolicy Test', (): void => {
 
       await expect(
         prover.challengeIntentProof(
+          1,
           intent2.source,
           intent2.destination,
           hashIntent(intent2).routeHash,

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -54,8 +54,20 @@ describe('Inbox Test', (): void => {
     dstAddr: SignerWithAddress
   }> {
     const [owner, solver, dstAddr] = await ethers.getSigners()
-    const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(owner.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
     const multicallRuntime = await (
       await ethers.getContractFactory('MulticallRuntime')
@@ -99,6 +111,7 @@ describe('Inbox Test', (): void => {
 
     // Create intent directly. `source` defaults to same-chain (== destination) for these tests.
     const intent: Intent = {
+      protocolVersion: 1,
       source: chainId,
       destination: chainId,
       route: {
@@ -165,6 +178,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(owner)
           .fulfill(
+            1,
             chainId,
             wrongDestination,
             route,
@@ -193,6 +207,7 @@ describe('Inbox Test', (): void => {
         ),
       }
       const { intentHash: tamperedHash } = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -206,6 +221,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -226,9 +242,23 @@ describe('Inbox Test', (): void => {
       )
     })
     it('should revert via InvalidPortal if all intent data was input correctly, but the intent used a different portal on creation', async () => {
-      const anotherPortal = await (
+      const anotherPortalProxy = await (
+        await ethers.getContractFactory('PortalProxy')
+      ).deploy(owner.address)
+      const anotherAccountImpl = await (
+        await ethers.getContractFactory('Account')
+      ).deploy(await anotherPortalProxy.getAddress())
+      const anotherPortalImpl = await (
         await ethers.getContractFactory('Portal')
-      ).deploy()
+      ).deploy(await anotherAccountImpl.getAddress())
+      await anotherPortalProxy.registerVersion(
+        1,
+        await anotherPortalImpl.getAddress(),
+      )
+      const anotherPortal = await ethers.getContractAt(
+        'Portal',
+        await anotherPortalProxy.getAddress(),
+      )
       const anotherInbox = await ethers.getContractAt(
         'Inbox',
         await anotherPortal.getAddress(),
@@ -240,6 +270,7 @@ describe('Inbox Test', (): void => {
       }
 
       const _intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -250,6 +281,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -268,6 +300,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -284,6 +317,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -310,6 +344,7 @@ describe('Inbox Test', (): void => {
       }
 
       const _intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -319,6 +354,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -344,6 +380,7 @@ describe('Inbox Test', (): void => {
         ]),
       }
       const intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -353,6 +390,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -381,6 +419,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -418,6 +457,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -432,6 +472,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -461,6 +502,7 @@ describe('Inbox Test', (): void => {
       }
 
       const intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -474,6 +516,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -492,6 +535,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -522,6 +566,7 @@ describe('Inbox Test', (): void => {
       }
 
       const intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -538,6 +583,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -581,6 +627,7 @@ describe('Inbox Test', (): void => {
       }
 
       const _intentHash = hashIntent({
+        protocolVersion: 1,
         source: chainId,
         destination: chainId,
         route: _route,
@@ -600,6 +647,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             _route,
@@ -636,6 +684,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfill(
+            1,
             chainId,
             chainId,
             route,
@@ -699,6 +748,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfillAndProve(
+            1,
             chainId,
             chainId,
             route,
@@ -738,6 +788,7 @@ describe('Inbox Test', (): void => {
         inbox
           .connect(solver)
           .fulfillAndProve(
+            1,
             chainId,
             chainId,
             route,

--- a/test/LayerZeroProver.spec.ts
+++ b/test/LayerZeroProver.spec.ts
@@ -90,7 +90,20 @@ describe('LayerZeroPolicy Test', (): void => {
       .getContractFactory('TestLayerZeroEndpoint')
       .then((factory) => factory.deploy())
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(owner.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const multicallRuntime = await (
@@ -360,6 +373,7 @@ describe('LayerZeroPolicy Test', (): void => {
       const calldata = await encodeTransfer(await claimant.getAddress(), amount)
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await layerZeroProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -414,6 +428,7 @@ describe('LayerZeroPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -484,6 +499,7 @@ describe('LayerZeroPolicy Test', (): void => {
       const calldata = await encodeTransfer(await claimant.getAddress(), amount)
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await layerZeroProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -538,6 +554,7 @@ describe('LayerZeroPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -720,6 +737,7 @@ describe('LayerZeroPolicy Test', (): void => {
       const routeTokens = [{ token: await token.getAddress(), amount: amount }]
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await layerZeroProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -800,6 +818,7 @@ describe('LayerZeroPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfillAndProve(
+          1,
           intent.source,
           intent.destination,
           route,
@@ -901,6 +920,7 @@ describe('LayerZeroPolicy Test', (): void => {
       )
       const source = destination
       const intent0: Intent = {
+        protocolVersion: 1,
         source,
         destination,
         route,
@@ -925,6 +945,7 @@ describe('LayerZeroPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent0.source,
           intent0.destination,
           route,
@@ -965,6 +986,7 @@ describe('LayerZeroPolicy Test', (): void => {
         hooks: '0x',
       }
       const intent1: Intent = {
+        protocolVersion: 1,
         source,
         destination,
         route: route1,
@@ -985,6 +1007,7 @@ describe('LayerZeroPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent1.source,
           intent1.destination,
           route1,
@@ -1065,6 +1088,7 @@ describe('LayerZeroPolicy Test', (): void => {
     beforeEach(async () => {
       // Create a standard intent for testing
       intent = {
+        protocolVersion: 1,
         source: 42161, // Arbitrum
         destination: 42161, // Arbitrum
         route: {
@@ -1121,6 +1145,7 @@ describe('LayerZeroPolicy Test', (): void => {
 
       await expect(
         prover.challengeIntentProof(
+          1,
           intent.source,
           intent.destination,
           routeHash,
@@ -1158,6 +1183,7 @@ describe('LayerZeroPolicy Test', (): void => {
       const rewardHash = hashIntent(intent).rewardHash
 
       await prover.challengeIntentProof(
+        1,
         intent.source,
         intent.destination,
         routeHash,
@@ -1179,6 +1205,7 @@ describe('LayerZeroPolicy Test', (): void => {
       // Challenge non-existent proof should be a no-op
       await expect(
         prover.challengeIntentProof(
+          1,
           intent.source,
           intent.destination,
           routeHash,

--- a/test/MetaProver.spec.ts
+++ b/test/MetaProver.spec.ts
@@ -132,7 +132,20 @@ describe('MetaPolicy Test', (): void => {
       await ethers.getContractFactory('TestMetaRouter')
     ).deploy(ethers.ZeroAddress)
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(owner.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const token = await (
@@ -371,6 +384,7 @@ describe('MetaPolicy Test', (): void => {
       const calldata = await encodeTransfer(await claimant.getAddress(), amount)
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await metaProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -425,6 +439,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -493,6 +508,7 @@ describe('MetaPolicy Test', (): void => {
       const calldata = await encodeTransfer(await claimant.getAddress(), amount)
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await metaProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -547,6 +563,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -602,6 +619,7 @@ describe('MetaPolicy Test', (): void => {
       const calldata = await encodeTransfer(await claimant.getAddress(), amount)
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await metaProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -656,6 +674,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent.source,
           intent.destination,
           intent.route,
@@ -878,6 +897,7 @@ describe('MetaPolicy Test', (): void => {
       const routeTokens = [{ token: await token.getAddress(), amount: amount }]
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await metaProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -952,6 +972,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfillAndProve(
+          1,
           intent.source,
           intent.destination,
           route,
@@ -1008,6 +1029,7 @@ describe('MetaPolicy Test', (): void => {
       const routeTokens = [{ token: await token.getAddress(), amount: amount }]
 
       const intent: Intent = {
+        protocolVersion: 1,
         source: Number(
           (await metaProver.runner?.provider?.getNetwork())?.chainId,
         ),
@@ -1088,6 +1110,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfillAndProve(
+          1,
           intent.source,
           intent.destination,
           route,
@@ -1212,6 +1235,7 @@ describe('MetaPolicy Test', (): void => {
         (await metaProver.runner?.provider?.getNetwork())?.chainId,
       )
       const intent0: Intent = {
+        protocolVersion: 1,
         source: destination,
         destination,
         route,
@@ -1236,6 +1260,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent0.source,
           intent0.destination,
           route,
@@ -1275,6 +1300,7 @@ describe('MetaPolicy Test', (): void => {
         hooks: '0x',
       }
       const intent1: Intent = {
+        protocolVersion: 1,
         source: destination,
         destination,
         route: route1,
@@ -1295,6 +1321,7 @@ describe('MetaPolicy Test', (): void => {
       await inbox
         .connect(solver)
         .fulfill(
+          1,
           intent1.source,
           intent1.destination,
           route1,

--- a/test/OriginSettler.spec.ts
+++ b/test/OriginSettler.spec.ts
@@ -68,7 +68,7 @@ describe('Origin Settler Test', (): void => {
   // Use the correct ORDER_DATA_TYPEHASH from the contract (v3 rate+flat Reward shape)
   const ORDER_DATA_TYPEHASH = ethers.keccak256(
     ethers.toUtf8Bytes(
-      'OrderData(uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)',
+      'OrderData(uint32 protocolVersion,uint64 destination,bytes route,Reward reward,bytes32 routePortal,uint64 routeDeadline,Output[] maxSpent)Output(bytes32 token,uint256 amount,bytes32 recipient,uint256 chainId)Reward(uint64 deadline,address keeper,address prover,RewardToken[] tokens,bytes hooks)RewardToken(address token,uint256 rate,uint256 flat)',
     ),
   )
 
@@ -84,8 +84,20 @@ describe('Origin Settler Test', (): void => {
   }> {
     const [keeper, owner, otherPerson] = await ethers.getSigners()
 
-    const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(keeper.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     // deploy prover
@@ -189,6 +201,7 @@ describe('Origin Settler Test', (): void => {
         hooks: '0x',
       }
       intent = {
+        protocolVersion: 1,
         source: sourceChainId,
         destination: chainId,
         route: route,
@@ -215,10 +228,11 @@ describe('Origin Settler Test', (): void => {
         orderDataType: ORDER_DATA_TYPEHASH,
         orderData: AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+            'tuple(uint32,uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
           ],
           [
             [
+              1, // protocolVersion
               chainId, // destination
               encodeRoute(route), // route bytes
               [
@@ -269,10 +283,11 @@ describe('Origin Settler Test', (): void => {
         orderDataType: ORDER_DATA_TYPEHASH,
         orderData: AbiCoder.defaultAbiCoder().encode(
           [
-            'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+            'tuple(uint32,uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
           ],
           [
             [
+              1, // protocolVersion
               chainId, // destination
               encodeRoute(route), // route bytes
               [
@@ -333,10 +348,11 @@ describe('Origin Settler Test', (): void => {
         orderDataHash: keccak256(
           AbiCoder.defaultAbiCoder().encode(
             [
-              'tuple(uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
+              'tuple(uint32,uint64,bytes,tuple(uint64,address,address,tuple(address,uint256,uint256)[],bytes),bytes32,uint64,tuple(bytes32,uint256,bytes32,uint256)[])',
             ],
             [
               [
+                1, // protocolVersion
                 chainId, // destination
                 encodeRoute(route), // route bytes
                 [
@@ -371,6 +387,7 @@ describe('Origin Settler Test', (): void => {
         const provider: Provider = originSettler.runner!.provider!
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,
@@ -407,6 +424,7 @@ describe('Origin Settler Test', (): void => {
           .to.emit(originSettler, 'Open')
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,
@@ -416,6 +434,7 @@ describe('Origin Settler Test', (): void => {
         expect(
           await provider.getBalance(
             await portal.intentAccountAddress({
+              protocolVersion: 1,
               source: sourceChainId,
               destination: chainId,
               route,
@@ -431,6 +450,7 @@ describe('Origin Settler Test', (): void => {
         const provider: Provider = originSettler.runner!.provider!
 
         const accountAddress = await portal.intentAccountAddress({
+          protocolVersion: 1,
           source: sourceChainId,
           destination: chainId,
           route,
@@ -449,6 +469,7 @@ describe('Origin Settler Test', (): void => {
 
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,
@@ -478,6 +499,7 @@ describe('Origin Settler Test', (): void => {
       })
       it('publishes without transferring if intent is already funded', async () => {
         const accountAddress = await portal.intentAccountAddress({
+          protocolVersion: 1,
           source: sourceChainId,
           destination: chainId,
           route,
@@ -492,6 +514,7 @@ describe('Origin Settler Test', (): void => {
 
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,
@@ -600,6 +623,7 @@ describe('Origin Settler Test', (): void => {
       it('creates via openFor', async () => {
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,
@@ -629,6 +653,7 @@ describe('Origin Settler Test', (): void => {
 
         expect(
           await portal.isIntentFunded({
+            protocolVersion: 1,
             source: sourceChainId,
             destination: chainId,
             route,

--- a/test/TokenSecurityTests.spec.ts
+++ b/test/TokenSecurityTests.spec.ts
@@ -31,8 +31,20 @@ describe('Token Security Tests', () => {
     const [keeper, claimant] = await ethers.getSigners()
 
     // Deploy Portal (which includes IntentSource and Inbox)
-    const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portalProxy = await (
+      await ethers.getContractFactory('PortalProxy')
+    ).deploy(keeper.address)
+    const accountImpl = await (
+      await ethers.getContractFactory('Account')
+    ).deploy(await portalProxy.getAddress())
+    const portalImpl = await (
+      await ethers.getContractFactory('Portal')
+    ).deploy(await accountImpl.getAddress())
+    await portalProxy.registerVersion(1, await portalImpl.getAddress())
+    const portal = await ethers.getContractAt(
+      'Portal',
+      await portalProxy.getAddress(),
+    )
     // Use the IIntentSource interface with the Portal implementation
     const intentSource = await ethers.getContractAt(
       'IIntentSource',
@@ -120,6 +132,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
+      protocolVersion: 1,
       source: chainId,
       destination: chainId + 1,
       route,
@@ -190,6 +203,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
+      protocolVersion: 1,
       source: chainId,
       destination: chainId + 1,
       route,
@@ -255,6 +269,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
+      protocolVersion: 1,
       source: chainId,
       destination: chainId + 1,
       route,
@@ -334,6 +349,7 @@ describe('Token Security Tests', () => {
     }
 
     const intent = {
+      protocolVersion: 1,
       source: chainId,
       destination: chainId + 1,
       route,

--- a/test/core/Account.t.sol
+++ b/test/core/Account.t.sol
@@ -91,7 +91,7 @@ contract AccountTest is Test {
         unauthorized = makeAddr("unauthorized");
 
         vm.prank(portal);
-        account = IAccount(address(new EcoAccount()).clone(bytes32(0)));
+        account = IAccount(address(new EcoAccount(portal)).clone(bytes32(0)));
 
         token = new TestERC20("Test Token", "TEST");
         mockPermit = new MockPermit();
@@ -1051,7 +1051,7 @@ contract AccountTest is Test {
         // vm.prank sets msg.sender for the constructor so portal is set correctly.
         vm.prank(portal);
         IAccount accountTron = IAccount(
-            address(new AccountTron()).clone(bytes32(uint256(1)))
+            address(new AccountTron(portal)).clone(bytes32(uint256(1)))
         );
 
         // Fund via transferFrom (returns true) — mirrors publishAndFund on-chain.

--- a/test/core/DualVaultRuntime.t.sol
+++ b/test/core/DualVaultRuntime.t.sol
@@ -242,6 +242,7 @@ contract DualVaultRuntimeTest is BaseTest {
 
         uint256 before = tokenC.balanceOf(keeper);
         intentSource.recoverToken(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -263,6 +264,7 @@ contract DualVaultRuntimeTest is BaseTest {
             )
         );
         intentSource.recoverToken(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),

--- a/test/core/DutchDecayPolicy.t.sol
+++ b/test/core/DutchDecayPolicy.t.sol
@@ -79,6 +79,7 @@ contract DutchDecayPolicyTest is BaseTest {
         });
 
         it = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: source,
             destination: destination,
             route: r,
@@ -102,6 +103,7 @@ contract DutchDecayPolicyTest is BaseTest {
         uint256[] memory provided = new uint256[](1);
         provided[0] = DELIVER;
         inbox.fulfill(
+            it.protocolVersion,
             it.source,
             it.destination,
             it.route,
@@ -117,6 +119,7 @@ contract DutchDecayPolicyTest is BaseTest {
         uint256[] memory f = new uint256[](1);
         f[0] = DELIVER;
         intentSource.settle(
+            it.protocolVersion,
             it.source,
             it.destination,
             routeHash,

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {BaseTest} from "../BaseTest.sol";
 import {IInbox} from "../../contracts/interfaces/IInbox.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
 import {TypeCasts} from "@hyperlane-xyz/core/contracts/libs/TypeCasts.sol";
@@ -46,7 +47,7 @@ contract InboxTest is BaseTest {
         vm.chainId(validChainId);
 
         // This should not revert
-        Portal newPortal = new Portal();
+        Portal newPortal = new Portal(address(new EcoAccount(address(this))));
         assertTrue(address(newPortal) != address(0));
     }
 
@@ -60,6 +61,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -69,6 +71,7 @@ contract InboxTest is BaseTest {
         // This should not revert
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -84,6 +87,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -92,6 +96,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -111,6 +116,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -120,6 +126,7 @@ contract InboxTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -135,6 +142,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -143,6 +151,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -162,6 +171,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -170,6 +180,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -195,6 +206,7 @@ contract InboxTest is BaseTest {
         calls[0] = Call({target: recipient, data: "", value: ethAmount});
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -223,6 +235,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -232,6 +245,7 @@ contract InboxTest is BaseTest {
         vm.prank(solver);
         vm.deal(solver, ethAmount);
         portal.fulfill{value: ethAmount}(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -256,6 +270,7 @@ contract InboxTest is BaseTest {
         calls[0] = Call({target: recipient, data: "", value: ethAmount});
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -279,6 +294,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -296,6 +312,7 @@ contract InboxTest is BaseTest {
             )
         );
         portal.fulfill{value: ethAmount / 2}(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -315,6 +332,7 @@ contract InboxTest is BaseTest {
             )
         );
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -337,6 +355,7 @@ contract InboxTest is BaseTest {
         calls[0] = Call({target: recipient, data: "", value: ethAmount});
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -360,6 +379,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -374,6 +394,7 @@ contract InboxTest is BaseTest {
         uint256 solverInitialBalance = solver.balance;
 
         portal.fulfill{value: ethAmount + extraFee}(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -400,6 +421,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -408,6 +430,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -426,6 +449,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -435,6 +459,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfillAndProve(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -481,6 +506,7 @@ contract InboxTest is BaseTest {
             bytes32 routeHash = keccak256(abi.encode(intent.route));
             bytes32 rewardHash = keccak256(abi.encode(intent.reward));
             bytes32 intentHash = IntentLib.hashIntent(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 routeHash,
@@ -491,6 +517,7 @@ contract InboxTest is BaseTest {
             // Fulfill each intent
             vm.prank(solver);
             portal.fulfill(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 intent.route,
@@ -516,6 +543,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -526,6 +554,7 @@ contract InboxTest is BaseTest {
         // First fulfillment should succeed
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -539,6 +568,7 @@ contract InboxTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -556,6 +586,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -565,6 +596,7 @@ contract InboxTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -580,6 +612,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -592,6 +625,7 @@ contract InboxTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -607,6 +641,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -616,6 +651,7 @@ contract InboxTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -656,6 +692,7 @@ contract InboxTest is BaseTest {
 
         return
             Intent({
+                protocolVersion: PROTOCOL_VERSION,
                 source: uint64(block.chainid),
                 destination: uint64(block.chainid),
                 route: Route({
@@ -726,6 +763,7 @@ contract InboxTest is BaseTest {
 
         return
             Intent({
+                protocolVersion: PROTOCOL_VERSION,
                 source: uint64(block.chainid),
                 destination: uint64(block.chainid),
                 route: Route({
@@ -753,6 +791,7 @@ contract InboxTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -760,6 +799,7 @@ contract InboxTest is BaseTest {
         );
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -811,6 +851,7 @@ contract InboxTest is BaseTest {
 
         return
             Intent({
+                protocolVersion: PROTOCOL_VERSION,
                 source: uint64(block.chainid),
                 destination: uint64(block.chainid),
                 route: Route({

--- a/test/core/InboxAdvanced.t.sol
+++ b/test/core/InboxAdvanced.t.sol
@@ -96,6 +96,7 @@ contract InboxAdvancedTest is BaseTest {
         });
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -119,6 +120,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -127,6 +129,7 @@ contract InboxAdvancedTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -156,6 +159,7 @@ contract InboxAdvancedTest is BaseTest {
         calls[0] = Call({target: address(tokenA), data: complexData, value: 0});
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -179,6 +183,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -187,6 +192,7 @@ contract InboxAdvancedTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -221,6 +227,7 @@ contract InboxAdvancedTest is BaseTest {
         calls[1] = Call({target: recipient2, data: "", value: ethAmount});
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -244,6 +251,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -255,6 +263,7 @@ contract InboxAdvancedTest is BaseTest {
         vm.prank(solver);
         vm.deal(solver, ethAmount);
         portal.fulfill{value: ethAmount}(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -289,6 +298,7 @@ contract InboxAdvancedTest is BaseTest {
         );
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             wrongDestination,
             intent.route,
@@ -303,6 +313,7 @@ contract InboxAdvancedTest is BaseTest {
         Intent memory intent = _createBasicIntent();
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -316,6 +327,7 @@ contract InboxAdvancedTest is BaseTest {
         Route memory mismatchedRoute = intent.route;
         mismatchedRoute.salt = keccak256("different");
         bytes32 mismatchedHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(mismatchedRoute)),
@@ -328,6 +340,7 @@ contract InboxAdvancedTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             mismatchedRoute,
@@ -352,6 +365,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -361,6 +375,7 @@ contract InboxAdvancedTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -376,6 +391,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -385,6 +401,7 @@ contract InboxAdvancedTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -402,6 +419,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -411,6 +429,7 @@ contract InboxAdvancedTest is BaseTest {
         vm.expectRevert();
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -470,6 +489,7 @@ contract InboxAdvancedTest is BaseTest {
         });
 
         Intent memory intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -493,6 +513,7 @@ contract InboxAdvancedTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -501,6 +522,7 @@ contract InboxAdvancedTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             intent.route,
@@ -533,6 +555,7 @@ contract InboxAdvancedTest is BaseTest {
             bytes32 routeHash = keccak256(abi.encode(intent.route));
             bytes32 rewardHash = keccak256(abi.encode(intent.reward));
             bytes32 intentHash = IntentLib.hashIntent(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 routeHash,
@@ -543,6 +566,7 @@ contract InboxAdvancedTest is BaseTest {
             // Fulfill each intent
             vm.prank(solver);
             portal.fulfill(
+                intent.protocolVersion,
                 intent.source,
                 intent.destination,
                 intent.route,
@@ -602,6 +626,7 @@ contract InboxAdvancedTest is BaseTest {
 
         return
             Intent({
+                protocolVersion: PROTOCOL_VERSION,
                 source: uint64(block.chainid),
                 destination: uint64(block.chainid),
                 route: Route({

--- a/test/core/MilestonePolicy.t.sol
+++ b/test/core/MilestonePolicy.t.sol
@@ -81,6 +81,7 @@ contract MilestonePolicyTest is BaseTest {
         });
 
         it = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: source,
             destination: destination,
             route: r,
@@ -104,6 +105,7 @@ contract MilestonePolicyTest is BaseTest {
         uint256[] memory provided = new uint256[](1);
         provided[0] = DELIVER;
         inbox.fulfill(
+            it.protocolVersion,
             it.source,
             it.destination,
             it.route,
@@ -123,6 +125,7 @@ contract MilestonePolicyTest is BaseTest {
 
     function _settle(Intent memory it, bytes32 routeHash) internal {
         intentSource.settleStream(
+            it.protocolVersion,
             it.source,
             it.destination,
             routeHash,

--- a/test/core/PolicyHooks.t.sol
+++ b/test/core/PolicyHooks.t.sol
@@ -64,6 +64,7 @@ contract PolicyHooksTest is BaseTest {
     function _settleDefault() internal {
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -75,6 +76,7 @@ contract PolicyHooksTest is BaseTest {
 
     function _refundDefault() internal {
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -282,6 +284,7 @@ contract PolicyHooksTest is BaseTest {
         _addProof(hashA, CHAIN_ID, claimant);
         vm.prank(otherPerson);
         intentSource.settle(
+            intentA.protocolVersion,
             intentA.source,
             intentA.destination,
             keccak256(abi.encode(intentA.route)),
@@ -296,6 +299,7 @@ contract PolicyHooksTest is BaseTest {
         bytes memory reenterCd = abi.encodeCall(
             IIntentSource.settle,
             (
+                intentA.protocolVersion,
                 intentA.source,
                 intentA.destination,
                 keccak256(abi.encode(intentA.route)),
@@ -320,6 +324,7 @@ contract PolicyHooksTest is BaseTest {
         emit IIntentSource.HookReverted(hashB, 0);
         vm.prank(otherPerson);
         intentSource.settle(
+            intentB.protocolVersion,
             intentB.source,
             intentB.destination,
             keccak256(abi.encode(intentB.route)),

--- a/test/core/ProtocolVersioning.t.sol
+++ b/test/core/ProtocolVersioning.t.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {BaseTest} from "../BaseTest.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {IInbox} from "../../contracts/interfaces/IInbox.sol";
+import {IPortalProxy, VERSION_EXPIRY} from "../../contracts/interfaces/IPortalProxy.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Portal} from "../../contracts/Portal.sol";
+import {Intent, Reward, RewardToken} from "../../contracts/types/Intent.sol";
+import {Call} from "../../contracts/interfaces/IRuntime.sol";
+
+/**
+ * @title ProtocolVersioningTest
+ * @notice PR9 coverage: the PortalProxy version registry (write-once, owner-only), version-pinned dispatch,
+ *         publish version validation, per-intent Account address stability across implementation versions,
+ *         and the expired-version deployer sweep (an alternate authority on the EXISTING, unchanged
+ *         executeAsOwner escrow/proof lock — never a way around it).
+ * @dev Runs with `block.chainid == CHAIN_ID`. `deployer` is the PortalProxy's protocol owner (BaseTest).
+ */
+contract ProtocolVersioningTest is BaseTest {
+    uint32 internal constant V2 = 2;
+
+    function setUp() public override {
+        vm.chainId(uint256(CHAIN_ID));
+        super.setUp();
+        _mintAndApprove(keeper, MINT_AMOUNT);
+        _fundUserNative(keeper, 10 ether);
+    }
+
+    // Empty program for owner-cook / sweep calls (MulticallRuntime decodes an empty Call[] as a no-op).
+    function _noop() internal pure returns (bytes memory) {
+        return abi.encode(new Call[](0));
+    }
+
+    // A copy of the default intent with no reward legs (a deposit/owner-cook intent — never locked).
+    function _emptyReward() internal view returns (Intent memory x) {
+        x = intent;
+        x.reward.tokens = new RewardToken[](0);
+    }
+
+    function _versionRegisteredAt(uint32 v) internal view returns (uint64 at) {
+        (, at) = portalProxy.versions(v);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Registry — write-once, owner-only
+    // -----------------------------------------------------------------------------------------------
+
+    function test_registerVersion_writeOnce_reverts() public {
+        vm.prank(deployer);
+        portalProxy.registerVersion(V2, portalImplementation);
+
+        vm.prank(deployer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPortalProxy.VersionAlreadyRegistered.selector,
+                V2
+            )
+        );
+        portalProxy.registerVersion(V2, portalImplementation);
+    }
+
+    function test_registerVersion_v1_alreadyRegistered_reverts() public {
+        vm.prank(deployer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPortalProxy.VersionAlreadyRegistered.selector,
+                PROTOCOL_VERSION
+            )
+        );
+        portalProxy.registerVersion(PROTOCOL_VERSION, portalImplementation);
+    }
+
+    function test_registerVersion_zeroImplementation_reverts() public {
+        vm.prank(deployer);
+        vm.expectRevert(IPortalProxy.ZeroImplementation.selector);
+        portalProxy.registerVersion(V2, address(0));
+    }
+
+    function test_registerVersion_onlyOwner_reverts() public {
+        vm.prank(otherPerson);
+        vm.expectRevert(
+            abi.encodeWithSelector(IPortalProxy.NotOwner.selector, otherPerson)
+        );
+        portalProxy.registerVersion(V2, portalImplementation);
+    }
+
+    function test_versions_getter() public view {
+        (address impl, uint64 at) = portalProxy.versions(PROTOCOL_VERSION);
+        assertEq(impl, portalImplementation);
+        assertGt(at, 0);
+
+        (address none, uint64 zero) = portalProxy.versions(99);
+        assertEq(none, address(0));
+        assertEq(zero, 0);
+    }
+
+    function test_owner_isImmutableDeployer() public view {
+        assertEq(portalProxy.owner(), deployer);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Dispatch + publish validation
+    // -----------------------------------------------------------------------------------------------
+
+    function test_dispatch_reachesImplementation() public {
+        vm.prank(keeper);
+        intentSource.publishAndFund(intent, false);
+        assertEq(
+            uint256(intentSource.getRewardStatus(_hashIntent(intent))),
+            uint256(IIntentSource.Status.Funded)
+        );
+    }
+
+    function test_publish_unregisteredVersion_reverts() public {
+        Intent memory x = intent;
+        x.protocolVersion = 99;
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPortalProxy.UnknownProtocolVersion.selector,
+                uint32(99)
+            )
+        );
+        intentSource.publishAndFund(x, false);
+    }
+
+    function test_publish_expiredVersion_reverts() public {
+        // Register a second version, warp exactly to its expiry, and try to publish a NEW intent on it.
+        vm.prank(deployer);
+        portalProxy.registerVersion(V2, portalImplementation);
+        uint64 at = _versionRegisteredAt(V2);
+        vm.warp(uint256(at) + VERSION_EXPIRY);
+
+        Intent memory x = intent;
+        x.protocolVersion = V2;
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IPortalProxy.ProtocolVersionExpired.selector,
+                V2
+            )
+        );
+        intentSource.publishAndFund(x, false);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Account-address stability across implementation versions
+    // -----------------------------------------------------------------------------------------------
+
+    /// @notice The per-intent Account address depends on the proxy (address(this) under delegatecall) and
+    ///         the SHARED Account implementation, NOT on which Portal version is active. Registering a
+    ///         DIFFERENT Portal implementation (built on the same shared Account implementation) as a newer
+    ///         version must not move any account address.
+    function test_accountAddressStableAcrossImplementationVersions() public {
+        Intent memory x = intent;
+        x.source = 10;
+        x.destination = 20;
+        bytes32 hash = _hashIntent(x);
+
+        address addrV1 = portal.accountAddress(hash, x.source);
+
+        // A genuinely different Portal implementation, sharing the same Account clone template.
+        Portal impl2 = new Portal(accountImplementation);
+        assertTrue(
+            address(impl2) != portalImplementation,
+            "impl2 must differ from v1"
+        );
+        vm.prank(deployer);
+        portalProxy.registerVersion(V2, address(impl2));
+
+        // accountAddress routes to the LATEST implementation (now v2); the address must be identical.
+        address addrV2 = portal.accountAddress(hash, x.source);
+        assertEq(
+            addrV1,
+            addrV2,
+            "account address must be stable across implementation versions"
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Deployer sweep — SOURCE side (alternate authority on the UNCHANGED escrow/proof lock)
+    // -----------------------------------------------------------------------------------------------
+
+    /// @notice (a) Before expiry the protocol owner is NOT an authority — only the keeper can cook.
+    function test_deployerSweep_source_beforeExpiry_reverts() public {
+        Intent memory x = _emptyReward(); // never locked, so only the auth gate matters here
+        vm.prank(deployer); // proxy owner, but v1 is not expired yet
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.NotAccountOwner.selector,
+                deployer
+            )
+        );
+        intentSource.executeAsOwner(x, address(multicallRuntime), _noop());
+    }
+
+    /// @notice (b) After expiry the owner CAN sweep an independently-dead (empty-reward) account.
+    function test_deployerSweep_source_afterExpiry_deadAccount_succeeds() public {
+        Intent memory x = _emptyReward();
+        address account = portal.accountAddress(_hashIntent(x), x.source);
+        tokenA.mint(account, 500); // a stray token to sweep out
+
+        uint64 at = _versionRegisteredAt(PROTOCOL_VERSION);
+        vm.warp(uint256(at) + VERSION_EXPIRY + 1);
+
+        Call[] memory sweep = new Call[](1);
+        sweep[0] = Call({
+            target: address(tokenA),
+            value: 0,
+            data: abi.encodeWithSignature(
+                "transfer(address,uint256)",
+                deployer,
+                uint256(500)
+            )
+        });
+
+        uint256 before = tokenA.balanceOf(deployer);
+        vm.prank(deployer);
+        intentSource.executeAsOwner(x, address(multicallRuntime), abi.encode(sweep));
+        assertEq(tokenA.balanceOf(deployer), before + 500);
+    }
+
+    /// @notice (c) After expiry the owner is STILL blocked by AccountLocked while the reward is LIVE (has
+    ///         legs and is before its deadline) — expiry alone is never sufficient.
+    function test_deployerSweep_source_afterExpiry_liveEscrow_stillLocked() public {
+        Intent memory x = intent;
+        // Reward deadline far beyond the version expiry so the reward is still live after we warp.
+        x.reward.deadline = uint64(block.timestamp + 800 days);
+        vm.prank(keeper);
+        intentSource.publishAndFund(x, false);
+
+        uint64 at = _versionRegisteredAt(PROTOCOL_VERSION);
+        vm.warp(uint256(at) + VERSION_EXPIRY + 1); // past version expiry, before reward deadline
+
+        vm.prank(deployer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.AccountLocked.selector,
+                _hashIntent(x)
+            )
+        );
+        intentSource.executeAsOwner(x, address(multicallRuntime), _noop());
+    }
+
+    /// @notice (c') After expiry the owner is STILL blocked by AccountLocked while a valid destination proof
+    ///         exists (a solver may be owed), even past the reward deadline.
+    function test_deployerSweep_source_afterExpiry_validProof_stillLocked() public {
+        vm.prank(keeper);
+        intentSource.publishAndFund(intent, false);
+        bytes32 hash = _hashIntent(intent);
+        _addProof(hash, CHAIN_ID, claimant);
+
+        uint64 at = _versionRegisteredAt(PROTOCOL_VERSION);
+        vm.warp(uint256(at) + VERSION_EXPIRY + 1);
+
+        vm.prank(deployer);
+        vm.expectRevert(
+            abi.encodeWithSelector(IIntentSource.AccountLocked.selector, hash)
+        );
+        intentSource.executeAsOwner(intent, address(multicallRuntime), _noop());
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Deployer sweep — DESTINATION side (cross-chain only, for the deployer too)
+    // -----------------------------------------------------------------------------------------------
+
+    function test_deployerSweep_dest_crossChain_beforeExpiry_reverts() public {
+        Intent memory x = intent;
+        x.source = 777; // cross-chain: this chain is purely the destination
+        x.destination = CHAIN_ID;
+        bytes32 rewardHash = keccak256(abi.encode(x.reward));
+
+        vm.prank(deployer); // owner, but not expired and not route.keeper
+        vm.expectRevert(
+            abi.encodeWithSelector(IInbox.NotAccountKeeper.selector, deployer)
+        );
+        portal.executeAsOwner(
+            x.protocolVersion,
+            x.source,
+            x.route,
+            rewardHash,
+            address(multicallRuntime),
+            _noop()
+        );
+    }
+
+    function test_deployerSweep_dest_crossChain_afterExpiry_succeeds() public {
+        Intent memory x = intent;
+        x.source = 777;
+        x.destination = CHAIN_ID;
+        bytes32 rewardHash = keccak256(abi.encode(x.reward));
+
+        uint64 at = _versionRegisteredAt(PROTOCOL_VERSION);
+        vm.warp(uint256(at) + VERSION_EXPIRY + 1);
+
+        vm.prank(deployer);
+        portal.executeAsOwner(
+            x.protocolVersion,
+            x.source,
+            x.route,
+            rewardHash,
+            address(multicallRuntime),
+            _noop()
+        );
+        address account = portal.accountAddress(_hashIntent(x), x.destination);
+        assertGt(account.code.length, 0, "dest account must be deployed");
+    }
+
+    /// @notice The cross-chain-only restriction applies to the deployer too: a same-chain dest sweep is
+    ///         rejected (leftover retrieval must go through the escrow-aware source path).
+    function test_deployerSweep_dest_sameChain_rejected() public {
+        Intent memory x = intent; // source == destination == CHAIN_ID
+        bytes32 rewardHash = keccak256(abi.encode(x.reward));
+
+        uint64 at = _versionRegisteredAt(PROTOCOL_VERSION);
+        vm.warp(uint256(at) + VERSION_EXPIRY + 1);
+
+        vm.prank(deployer);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IInbox.SourceChainOwnerOnly.selector,
+                x.source
+            )
+        );
+        portal.executeAsOwner(
+            x.protocolVersion,
+            x.source,
+            x.route,
+            rewardHash,
+            address(multicallRuntime),
+            _noop()
+        );
+    }
+}

--- a/test/core/RewardLegs.t.sol
+++ b/test/core/RewardLegs.t.sol
@@ -73,6 +73,7 @@ contract RewardLegsTest is BaseTest {
         });
 
         _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: r,
@@ -92,6 +93,7 @@ contract RewardLegsTest is BaseTest {
         vm.startPrank(solver);
         tokenA.approve(address(portal), provided);
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -167,6 +169,7 @@ contract RewardLegsTest is BaseTest {
         uint256 keeperBefore = tokenA.balanceOf(keeper);
 
         intentSource.settle(
+            _intent.protocolVersion,
             _intent.source,
             uint64(block.chainid),
             keccak256(abi.encode(_intent.route)),
@@ -199,6 +202,7 @@ contract RewardLegsTest is BaseTest {
         uint256 claimantBefore = tokenA.balanceOf(claimant);
 
         intentSource.settle(
+            _intent.protocolVersion,
             _intent.source,
             uint64(block.chainid),
             keccak256(abi.encode(_intent.route)),
@@ -278,6 +282,7 @@ contract RewardLegsTest is BaseTest {
             )
         );
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -301,6 +306,7 @@ contract RewardLegsTest is BaseTest {
         );
         vm.prank(solver);
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -338,6 +344,7 @@ contract RewardLegsTest is BaseTest {
             )
         );
         intentSource.settle(
+            _intent.protocolVersion,
             _intent.source,
             uint64(block.chainid),
             keccak256(abi.encode(_intent.route)),
@@ -361,6 +368,7 @@ contract RewardLegsTest is BaseTest {
             hooks: ""
         });
         Intent memory _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: route,
@@ -396,6 +404,7 @@ contract RewardLegsTest is BaseTest {
             hooks: ""
         });
         Intent memory _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: route,
@@ -441,6 +450,7 @@ contract RewardLegsTest is BaseTest {
             hooks: ""
         });
         Intent memory _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: r,
@@ -451,6 +461,7 @@ contract RewardLegsTest is BaseTest {
             abi.encodeWithSelector(IntentLib.MinTokensNotSorted.selector, hi, lo)
         );
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             r,
@@ -484,6 +495,7 @@ contract RewardLegsTest is BaseTest {
             hooks: ""
         });
         Intent memory _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: r,
@@ -498,6 +510,7 @@ contract RewardLegsTest is BaseTest {
             )
         );
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             r,

--- a/test/core/SameChainAndGates.t.sol
+++ b/test/core/SameChainAndGates.t.sol
@@ -81,6 +81,7 @@ contract SameChainAndGatesTest is BaseTest {
 
         return
             Intent({
+                protocolVersion: PROTOCOL_VERSION,
                 source: uint64(block.chainid),
                 destination: uint64(block.chainid),
                 route: Route({
@@ -134,6 +135,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -162,6 +164,7 @@ contract SameChainAndGatesTest is BaseTest {
 
         vm.prank(solver);
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -223,6 +226,7 @@ contract SameChainAndGatesTest is BaseTest {
         legs[0] = RewardToken({token: address(tokenA), rate: 0, flat: rewardFlat});
 
         Intent memory _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: uint64(block.chainid),
             destination: uint64(block.chainid),
             route: Route({
@@ -314,6 +318,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         intentSource.fund(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -347,6 +352,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         intentSource.settle(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -368,6 +374,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         intentSource.refund(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -387,6 +394,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         intentSource.recoverToken(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -432,6 +440,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         portal.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             wrongDestination,
             _intent.route,
@@ -464,6 +473,7 @@ contract SameChainAndGatesTest is BaseTest {
 
         vm.prank(keeper);
         portal.executeAsOwner(
+            _intent.protocolVersion,
             _intent.source,
             _intent.route,
             rewardHash,
@@ -493,6 +503,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         portal.executeAsOwner(
+            _intent.protocolVersion,
             _intent.source, // == block.chainid (same-chain)
             _intent.route,
             rewardHash,
@@ -513,6 +524,7 @@ contract SameChainAndGatesTest is BaseTest {
             )
         );
         portal.executeAsOwner(
+            _intent.protocolVersion,
             _intent.source,
             _intent.route,
             rewardHash,
@@ -551,6 +563,7 @@ contract SameChainAndGatesTest is BaseTest {
         vm.startPrank(attacker);
         vm.expectRevert(wrongSource);
         intentSource.settle(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -560,6 +573,7 @@ contract SameChainAndGatesTest is BaseTest {
         );
         vm.expectRevert(wrongSource);
         intentSource.refund(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -567,6 +581,7 @@ contract SameChainAndGatesTest is BaseTest {
         );
         vm.expectRevert(wrongSource);
         intentSource.recoverToken(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -591,6 +606,7 @@ contract SameChainAndGatesTest is BaseTest {
         vm.startPrank(attacker);
         vm.expectRevert(wrongSource);
         intentSource.fund(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,
@@ -599,6 +615,7 @@ contract SameChainAndGatesTest is BaseTest {
         );
         vm.expectRevert(wrongSource);
         intentSource.refund(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             routeHash,

--- a/test/core/Streaming.t.sol
+++ b/test/core/Streaming.t.sol
@@ -90,6 +90,7 @@ contract StreamingTest is BaseTest {
         });
 
         _intent = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: source,
             destination: destination,
             route: r,
@@ -119,6 +120,7 @@ contract StreamingTest is BaseTest {
         uint256[] memory provided = new uint256[](1);
         provided[0] = DELIVER;
         inbox.fulfill(
+            _intent.protocolVersion,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -177,6 +179,7 @@ contract StreamingTest is BaseTest {
         slices[1] = _slice(claimant2, DELIVER);
 
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             CHAIN_ID,
             routeHash,
@@ -235,6 +238,7 @@ contract StreamingTest is BaseTest {
 
         // Settle the batch: pays both claimants from the SOURCE account.
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -302,6 +306,7 @@ contract StreamingTest is BaseTest {
 
         // Settle it once; re-delivery afterwards stays deduped (batchSeen permanent) so nothing wedges.
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -343,6 +348,7 @@ contract StreamingTest is BaseTest {
 
         // Settle the SECOND batch first (content-addressed, no FIFO): removes b1 by value, b0 remains.
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -354,6 +360,7 @@ contract StreamingTest is BaseTest {
 
         // Then settle the first batch.
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -387,10 +394,11 @@ contract StreamingTest is BaseTest {
                 intentHash
             )
         );
-        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+        intentSource.closeStream(it.protocolVersion, CHAIN_ID, FOREIGN, routeHash, it.reward);
 
         // The batch is settled to the solver's claimant first.
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -402,7 +410,7 @@ contract StreamingTest is BaseTest {
         // Now the keeper can close and reclaim the remainder.
         uint256 keeperBefore = tokenA.balanceOf(keeper);
         vm.prank(keeper);
-        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+        intentSource.closeStream(it.protocolVersion, CHAIN_ID, FOREIGN, routeHash, it.reward);
         assertEq(
             tokenA.balanceOf(keeper),
             keeperBefore + (BUDGET - DELIVER),
@@ -424,7 +432,7 @@ contract StreamingTest is BaseTest {
                 otherPerson
             )
         );
-        intentSource.closeStream(CHAIN_ID, FOREIGN, routeHash, it.reward);
+        intentSource.closeStream(it.protocolVersion, CHAIN_ID, FOREIGN, routeHash, it.reward);
     }
 
     // ---------------------------------------------------------------------
@@ -454,6 +462,7 @@ contract StreamingTest is BaseTest {
             )
         );
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -466,6 +475,7 @@ contract StreamingTest is BaseTest {
         // Keeper tops up; the same batch now settles fully -> shortfall recovered, not forfeited.
         tokenA.mint(account, DELIVER);
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,
@@ -502,6 +512,7 @@ contract StreamingTest is BaseTest {
             )
         );
         intentSource.settleStream(
+            it.protocolVersion,
             CHAIN_ID,
             FOREIGN,
             routeHash,

--- a/test/core/VestingPolicy.t.sol
+++ b/test/core/VestingPolicy.t.sol
@@ -77,6 +77,7 @@ contract VestingPolicyTest is BaseTest {
         });
 
         it = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: source,
             destination: destination,
             route: r,
@@ -100,6 +101,7 @@ contract VestingPolicyTest is BaseTest {
         uint256[] memory provided = new uint256[](1);
         provided[0] = DELIVER;
         inbox.fulfill(
+            it.protocolVersion,
             it.source,
             it.destination,
             it.route,
@@ -119,6 +121,7 @@ contract VestingPolicyTest is BaseTest {
 
     function _settle(Intent memory it, bytes32 routeHash) internal {
         intentSource.settleStream(
+            it.protocolVersion,
             it.source,
             it.destination,
             routeHash,
@@ -216,6 +219,7 @@ contract VestingPolicyTest is BaseTest {
             )
         );
         intentSource.settle(
+            it.protocolVersion,
             CHAIN_ID,
             CHAIN_ID,
             routeHash,

--- a/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
@@ -7,6 +7,8 @@ import {DepositFactory_CCTPMint_Arc} from "../../contracts/deposit/DepositFactor
 import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddress_CCTPMint_Arc.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
 import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
@@ -39,7 +41,11 @@ contract DepositAddress_CCTPMint_ArcTest is Test {
 
     function setUp() public {
         token = new TestERC20("Test USDC", "USDC");
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         factory = new DepositFactory_CCTPMint_Arc(
             address(token),

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -7,6 +7,8 @@ import {DepositFactory_CCTPMint_GatewayERC20} from "../../contracts/deposit/Depo
 import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
 import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
@@ -39,7 +41,11 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
 
     function setUp() public {
         token = new TestERC20("Test USDC", "USDC");
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         factory = new DepositFactory_CCTPMint_GatewayERC20(
             address(token),

--- a/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
@@ -7,6 +7,8 @@ import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Reward, TokenAmount} from "../../contracts/types/Intent.sol";
 import {TestERC20} from "../../contracts/test/TestERC20.sol";
 
@@ -35,7 +37,11 @@ contract DepositAddressTest is Test {
         token = new TestERC20("Test Token", "TEST");
 
         // Deploy Portal
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         // Deploy factory
         factory = new DepositFactory_USDCTransfer_Solana(

--- a/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
@@ -7,6 +7,8 @@ import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddres
 import {BaseDepositFactory} from "../../contracts/deposit/BaseDepositFactory.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
 contract DepositFactory_CCTPMint_ArcTest is Test {
     DepositFactory_CCTPMint_Arc public factory;
@@ -30,7 +32,11 @@ contract DepositFactory_CCTPMint_ArcTest is Test {
     address constant DEPOSITOR_2 = address(0x4444);
 
     function setUp() public {
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         factory = new DepositFactory_CCTPMint_Arc(
             SOURCE_TOKEN,

--- a/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
@@ -7,6 +7,8 @@ import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/Depo
 import {BaseDepositFactory} from "../../contracts/deposit/BaseDepositFactory.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
 contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
     DepositFactory_CCTPMint_GatewayERC20 public factory;
@@ -31,7 +33,11 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
     address constant DEPOSITOR_2 = address(0x4444);
 
     function setUp() public {
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         factory = new DepositFactory_CCTPMint_GatewayERC20(
             SOURCE_TOKEN,

--- a/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
@@ -5,6 +5,8 @@ import {Test} from "forge-std/Test.sol";
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
 contract DepositFactoryTest is Test {
     DepositFactory_USDCTransfer_Solana public factory;
@@ -29,7 +31,11 @@ contract DepositFactoryTest is Test {
 
     function setUp() public {
         // Deploy Portal
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         // Deploy factory
         factory = new DepositFactory_USDCTransfer_Solana(

--- a/test/deposit/DepositIntegration_CCTPMint.t.sol
+++ b/test/deposit/DepositIntegration_CCTPMint.t.sol
@@ -6,6 +6,8 @@ import {Vm} from "forge-std/Vm.sol";
 import {DepositFactory_CCTPMint_Arc} from "../../contracts/deposit/DepositFactory_CCTPMint_Arc.sol";
 import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddress_CCTPMint_Arc.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {LocalPolicy} from "../../contracts/prover/LocalPolicy.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
@@ -81,7 +83,11 @@ contract DepositIntegration_CCTPMintTest is Test {
         token = new TestERC20("USD Coin", "USDC");
 
         // Deploy Portal
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         // Deploy LocalPolicy (for same-chain testing)
         prover = new LocalPolicy(address(portal));
@@ -478,7 +484,7 @@ contract DepositIntegration_CCTPMintTest is Test {
         // Intent 2's source is always `uint64(block.chainid)` (the depositor's source chain) per
         // DepositAddress_CCTPMint_Arc's _constructGatewayIntent; this test sets ARC_CHAIN_ID ==
         // block.chainid for local provability, so source == destination == localChainId here.
-        address account2 = portal.intentAccountAddress(localChainId, localChainId, abi.encode(route2), reward2);
+        address account2 = portal.intentAccountAddress(1, localChainId, localChainId, abi.encode(route2), reward2);
         assertTrue(account2 != address(0), "account2 address should be non-zero");
 
         // --- Simulate CCTP mint: fund account2 with native ETH (= native USDC on Arc) ---
@@ -495,6 +501,7 @@ contract DepositIntegration_CCTPMintTest is Test {
         vm.prank(solver);
         vm.recordLogs();
         arcProver.flashFulfill{value: nativeReward}(
+            1,
             route2,
             reward2,
             bytes32(uint256(uint160(solver)))

--- a/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
@@ -6,6 +6,8 @@ import {Vm} from "forge-std/Vm.sol";
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
 import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
 import {TestERC20} from "../../contracts/test/TestERC20.sol";
@@ -51,7 +53,11 @@ contract DepositIntegration_USDCTransfer_SolanaTest is Test {
         token = new TestERC20("Test Token", "TEST");
 
         // Deploy Portal
-        portal = new Portal();
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
 
         // Deploy prover
         prover = new TestPolicy(address(portal));

--- a/test/interfaces/OriginSettler.t.sol
+++ b/test/interfaces/OriginSettler.t.sol
@@ -5,6 +5,7 @@ import "../BaseTest.sol";
 import {IOriginSettler} from "../../contracts/interfaces/ERC7683/IOriginSettler.sol";
 import {OnchainCrossChainOrder, GaslessCrossChainOrder, ResolvedCrossChainOrder, Output, FillInstruction} from "../../contracts/types/ERC7683.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {OriginSettler} from "../../contracts/ERC7683/OriginSettler.sol";
 
 // Simple concrete implementation for testing
@@ -207,7 +208,11 @@ contract OriginSettlerTest is BaseTest {
 
         // The domain separator should be unique to this contract instance
         // Deploy another Portal and verify they have different domain separators
-        Portal portal2 = new Portal();
+        PortalProxy _proxy2 = new PortalProxy(address(this));
+        EcoAccount _acct2 = new EcoAccount(address(_proxy2));
+        Portal _impl2 = new Portal(address(_acct2));
+        _proxy2.registerVersion(1, address(_impl2));
+        Portal portal2 = Portal(payable(address(_proxy2)));
         bytes32 domainSeparator3 = portal2.domainSeparatorV4();
 
         // Domain separators should be different due to different contract addresses
@@ -247,7 +252,11 @@ contract OriginSettlerTest is BaseTest {
 
         // Deploy a new Portal on a different chain ID
         vm.chainId(999);
-        Portal portalDifferentChain = new Portal();
+        PortalProxy _proxyDiff = new PortalProxy(address(this));
+        EcoAccount _acctDiff = new EcoAccount(address(_proxyDiff));
+        Portal _implDiff = new Portal(address(_acctDiff));
+        _proxyDiff.registerVersion(1, address(_implDiff));
+        Portal portalDifferentChain = Portal(payable(address(_proxyDiff)));
         bytes32 domainSeparator2 = portalDifferentChain.domainSeparatorV4();
 
         // Domain separators should be different on different chains
@@ -255,7 +264,11 @@ contract OriginSettlerTest is BaseTest {
 
         // Deploy another Portal on the original chain
         vm.chainId(1);
-        Portal portalSameChain = new Portal();
+        PortalProxy _proxySame = new PortalProxy(address(this));
+        EcoAccount _acctSame = new EcoAccount(address(_proxySame));
+        Portal _implSame = new Portal(address(_acctSame));
+        _proxySame.registerVersion(1, address(_implSame));
+        Portal portalSameChain = Portal(payable(address(_proxySame)));
         bytes32 domainSeparator3 = portalSameChain.domainSeparatorV4();
 
         // Domain separator should be different from the first portal due to different addresses

--- a/test/libs/Clones.t.sol
+++ b/test/libs/Clones.t.sol
@@ -158,7 +158,7 @@ contract ClonesTest is BaseTest {
     }
 
     function testCloneWithAccountImplementation() public {
-        EcoAccount accountImpl = new EcoAccount();
+        EcoAccount accountImpl = new EcoAccount(address(this));
 
         address clone = Clones.clone(address(accountImpl), TEST_SALT);
         address predicted = Clones.predict(

--- a/test/prover/CCIPProver.t.sol
+++ b/test/prover/CCIPProver.t.sol
@@ -499,6 +499,7 @@ contract CCIPProverTest is BaseTest {
         // actually proven (block.chainid), so challenging with the intent's true fields should clear it.
         vm.prank(keeper);
         ccipProver.challengeIntentProof(
+            foreignIntent.protocolVersion,
             foreignIntent.source,
             foreignIntent.destination,
             keccak256(abi.encode(foreignIntent.route)),
@@ -536,7 +537,7 @@ contract CCIPProverTest is BaseTest {
         // Challenge with correct chain should do nothing
         vm.prank(keeper);
         ccipProver.challengeIntentProof(
-            localIntent.source, localIntent.destination, keccak256(abi.encode(localIntent.route)), keccak256(abi.encode(localIntent.reward))
+            localIntent.protocolVersion, localIntent.source, localIntent.destination, keccak256(abi.encode(localIntent.route)), keccak256(abi.encode(localIntent.reward))
         );
 
         // Verify proof is still there

--- a/test/prover/HyperProver.t.sol
+++ b/test/prover/HyperProver.t.sol
@@ -430,6 +430,7 @@ contract HyperProverTest is BaseTest {
         // actually proven (block.chainid), so challenging with the intent's true fields should clear it.
         vm.prank(keeper);
         hyperProver.challengeIntentProof(
+            foreignIntent.protocolVersion,
             foreignIntent.source,
             foreignIntent.destination,
             keccak256(abi.encode(foreignIntent.route)),
@@ -475,6 +476,7 @@ contract HyperProverTest is BaseTest {
         // Challenge with correct chain (destination matches proof) should do nothing
         vm.prank(keeper);
         hyperProver.challengeIntentProof(
+            localIntent.protocolVersion,
             localIntent.source,
             localIntent.destination,
             keccak256(abi.encode(localIntent.route)),

--- a/test/prover/LayerZeroProver.t.sol
+++ b/test/prover/LayerZeroProver.t.sol
@@ -452,6 +452,7 @@ contract LayerZeroProverTest is BaseTest {
         bytes32 routeHash = keccak256("route");
         bytes32 rewardHash = keccak256("reward");
         bytes32 intentHash = IntentLib.hashIntent(
+            PROTOCOL_VERSION,
             actualDestination,
             actualDestination,
             routeHash,
@@ -497,6 +498,7 @@ contract LayerZeroProverTest is BaseTest {
         emit IPolicy.IntentProofInvalidated(intentHash);
 
         lzProver.challengeIntentProof(
+            PROTOCOL_VERSION,
             actualDestination,
             actualDestination,
             routeHash,
@@ -521,6 +523,7 @@ contract LayerZeroProverTest is BaseTest {
         bytes32 routeHash = keccak256("route");
         bytes32 rewardHash = keccak256("reward");
         bytes32 intentHash = IntentLib.hashIntent(
+            PROTOCOL_VERSION,
             correctDestination,
             correctDestination,
             routeHash,
@@ -563,6 +566,7 @@ contract LayerZeroProverTest is BaseTest {
 
         // Challenge the proof with correct destination (should do nothing)
         lzProver.challengeIntentProof(
+            PROTOCOL_VERSION,
             correctDestination,
             correctDestination,
             routeHash,
@@ -587,6 +591,7 @@ contract LayerZeroProverTest is BaseTest {
         bytes32 routeHash = keccak256("route");
         bytes32 rewardHash = keccak256("reward");
         bytes32 intentHash = IntentLib.hashIntent(
+            PROTOCOL_VERSION,
             actualDestination,
             actualDestination,
             routeHash,
@@ -621,6 +626,7 @@ contract LayerZeroProverTest is BaseTest {
         emit IPolicy.IntentProofInvalidated(intentHash);
 
         lzProver.challengeIntentProof(
+            PROTOCOL_VERSION,
             actualDestination,
             actualDestination,
             routeHash,

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 import {LocalPolicy} from "../../contracts/prover/LocalPolicy.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {PortalProxy} from "../../contracts/PortalProxy.sol";
+import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {TestPolicy} from "../../contracts/test/TestPolicy.sol";
 import {TestERC20} from "../../contracts/test/TestERC20.sol";
 import {IPolicy} from "../../contracts/interfaces/IPolicy.sol";
@@ -44,8 +46,12 @@ contract LocalProverTest is Test {
         // Set CHAIN_ID to current chain
         CHAIN_ID = uint64(block.chainid);
 
-        // Deploy contracts
-        portal = new Portal();
+        // Deploy contracts (Portal behind a versioned PortalProxy, registered as version 1)
+        PortalProxy _proxy = new PortalProxy(address(this));
+        EcoAccount _acct = new EcoAccount(address(_proxy));
+        Portal _impl = new Portal(address(_acct));
+        _proxy.registerVersion(1, address(_impl));
+        portal = Portal(payable(address(_proxy)));
         localProver = new LocalPolicy(address(portal));
         secondaryProver = new TestPolicy(address(portal));
         token = new TestERC20("Test Token", "TEST");
@@ -108,6 +114,7 @@ contract LocalProverTest is Test {
 
         return
             Intent({
+                protocolVersion: 1,
                 source: CHAIN_ID,
                 destination: CHAIN_ID,
                 route: route,
@@ -157,6 +164,7 @@ contract LocalProverTest is Test {
         vm.startPrank(solver);
         vm.deal(solver, REWARD_AMOUNT);
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -205,7 +213,7 @@ contract LocalProverTest is Test {
     // A3. challengeIntentProof()
     function test_challengeIntentProof_IsNoOp() public {
         // Test: challengeIntentProof() is a no-op (doesn't revert)
-        localProver.challengeIntentProof(0, 0, bytes32(0), bytes32(0));
+        localProver.challengeIntentProof(1, 0, 0, bytes32(0), bytes32(0));
         // Should not revert
     }
 
@@ -229,7 +237,7 @@ contract LocalProverTest is Test {
 
         vm.prank(solver);
         vm.expectRevert(ILocalPolicy.InvalidClaimant.selector);
-        localProver.flashFulfill(_intent.route, _intent.reward, bytes32(0));
+        localProver.flashFulfill(1, _intent.route, _intent.reward, bytes32(0));
     }
 
     function test_flashFulfill_RevertsIfIntentAlreadyFulfilled() public {
@@ -245,6 +253,7 @@ contract LocalProverTest is Test {
         vm.startPrank(solver);
         vm.deal(solver, REWARD_AMOUNT);
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -257,6 +266,7 @@ contract LocalProverTest is Test {
         // Try flashFulfill
         vm.expectRevert();
         localProver.flashFulfill(
+            1,
             _intent.route,
             _intent.reward,
             bytes32(uint256(uint160(solver)))
@@ -279,6 +289,7 @@ contract LocalProverTest is Test {
         vm.prank(solver);
         vm.expectRevert();
         localProver.flashFulfill(
+            1,
             _intent.route,
             _intent.reward,
             bytes32(uint256(uint160(solver)))
@@ -304,6 +315,7 @@ contract LocalProverTest is Test {
         // Should succeed even though rejecter doesn't accept ETH transfers
         vm.prank(solver);
         localProver.flashFulfill(
+            1,
             _intent.route,
             _intent.reward,
             rejecterClaimant
@@ -353,6 +365,7 @@ contract LocalProverTest is Test {
         });
 
         Intent memory _intent = Intent({
+            protocolVersion: 1,
             source: CHAIN_ID,
             destination: CHAIN_ID,
             route: route,
@@ -370,7 +383,7 @@ contract LocalProverTest is Test {
         token.approve(address(localProver), TOKEN_AMOUNT);
 
         vm.prank(solver);
-        localProver.flashFulfill(_intent.route, _intent.reward, claimantBytes);
+        localProver.flashFulfill(1, _intent.route, _intent.reward, claimantBytes);
 
         // The route has no calls, so the provided TOKEN_AMOUNT is unconsumed and the Portal moves it to
         // the intent's Account (leftover stays with the intent); the executor ends drained. flashFulfill
@@ -425,6 +438,7 @@ contract LocalProverTest is Test {
         });
 
         Intent memory _intent = Intent({
+            protocolVersion: 1,
             source: CHAIN_ID,
             destination: CHAIN_ID,
             route: route,
@@ -445,7 +459,7 @@ contract LocalProverTest is Test {
 
         // FlashFulfill should succeed
         vm.prank(solver);
-        localProver.flashFulfill(_intent.route, _intent.reward, claimantBytes);
+        localProver.flashFulfill(1, _intent.route, _intent.reward, claimantBytes);
 
         // The route has no calls, so the provided token input is unconsumed and moved to the intent's
         // Account; settle then pays the claimant its flat token reward and sweeps the residual (the
@@ -498,6 +512,7 @@ contract LocalProverTest is Test {
         });
 
         Intent memory _intent = Intent({
+            protocolVersion: 1,
             source: CHAIN_ID,
             destination: CHAIN_ID,
             route: route,
@@ -518,7 +533,7 @@ contract LocalProverTest is Test {
 
         // FlashFulfill should succeed
         vm.prank(solver);
-        localProver.flashFulfill(_intent.route, _intent.reward, claimantBytes);
+        localProver.flashFulfill(1, _intent.route, _intent.reward, claimantBytes);
 
         // The route has no calls, so the provided route input (500) is unconsumed and moved to the
         // intent's Account; settle then pays the claimant its flat reward (1000) and sweeps the residual
@@ -556,6 +571,7 @@ contract LocalProverTest is Test {
             uint256(uint160(address(localProver)))
         );
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -577,6 +593,7 @@ contract LocalProverTest is Test {
         vm.startPrank(solver);
         vm.expectRevert(); // Portal reverts with IntentAlreadyFulfilled
         localProver.flashFulfill(
+            1,
             _intent.route,
             _intent.reward,
             bytes32(uint256(uint160(solver)))
@@ -590,6 +607,7 @@ contract LocalProverTest is Test {
         uint256 keeperBalanceBefore = keeper.balance;
         vm.prank(user);
         portal.refund(
+            1,
             _intent.source,
             _intent.destination,
             keccak256(abi.encode(_intent.route)),
@@ -619,6 +637,7 @@ contract LocalProverTest is Test {
         vm.deal(attacker, REWARD_AMOUNT);
         bytes32 nonEVMBytes32 = bytes32(uint256(type(uint256).max)); // All 1s
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -640,6 +659,7 @@ contract LocalProverTest is Test {
         vm.startPrank(solver);
         vm.expectRevert(); // Portal reverts with IntentAlreadyFulfilled
         localProver.flashFulfill(
+            1,
             _intent.route,
             _intent.reward,
             bytes32(uint256(uint160(solver)))
@@ -653,6 +673,7 @@ contract LocalProverTest is Test {
         uint256 keeperBalanceBefore = keeper.balance;
         vm.prank(user);
         portal.refund(
+            1,
             _intent.source,
             _intent.destination,
             keccak256(abi.encode(_intent.route)),
@@ -683,6 +704,7 @@ contract LocalProverTest is Test {
             uint256(uint160(address(localProver)))
         );
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -697,6 +719,7 @@ contract LocalProverTest is Test {
         vm.prank(user);
         vm.expectRevert(); // Portal reverts with InvalidStatusForRefund
         portal.refund(
+            1,
             _intent.source,
             _intent.destination,
             keccak256(abi.encode(_intent.route)),
@@ -722,6 +745,7 @@ contract LocalProverTest is Test {
             uint256(uint160(address(localProver)))
         );
         portal.fulfill{value: REWARD_AMOUNT}(
+            1,
             _intent.source,
             _intent.destination,
             _intent.route,
@@ -741,6 +765,7 @@ contract LocalProverTest is Test {
 
         vm.prank(user);
         portal.refund(
+            1,
             _intent.source,
             _intent.destination,
             keccak256(abi.encode(_intent.route)),
@@ -774,6 +799,7 @@ contract LocalProverTest is Test {
         vm.startPrank(attacker);
         vm.expectRevert(ILocalPolicy.InvalidClaimant.selector);
         localProver.flashFulfill(
+            1,
             intent.route,
             intent.reward,
             localProverAsClaimant // Should revert - LocalPolicy cannot be claimant
@@ -797,6 +823,7 @@ contract LocalProverTest is Test {
         vm.startPrank(solver);
         vm.expectRevert(ILocalPolicy.InvalidProver.selector);
         localProver.flashFulfill(
+            1,
             intent.route,
             intent.reward,
             claimantBytes // Should revert - intent uses secondaryProver, not localProver
@@ -851,6 +878,7 @@ contract LocalProverTest is Test {
         });
 
         Intent memory _intent = Intent({
+            protocolVersion: 1,
             source: CHAIN_ID,
             destination: CHAIN_ID,
             route: route,
@@ -875,7 +903,7 @@ contract LocalProverTest is Test {
                 address(token)
             )
         );
-        localProver.flashFulfill(_intent.route, _intent.reward, claimantBytes);
+        localProver.flashFulfill(1, _intent.route, _intent.reward, claimantBytes);
     }
 
     // ============ Helper Functions ============

--- a/test/prover/MetaProver.t.sol
+++ b/test/prover/MetaProver.t.sol
@@ -830,6 +830,7 @@ contract MetaProverTest is BaseTest {
         // Anyone can challenge
         vm.prank(otherPerson);
         metaProver.challengeIntentProof(
+            testIntent.protocolVersion,
             testIntent.source,
             testIntent.destination,
             routeHash,
@@ -884,6 +885,7 @@ contract MetaProverTest is BaseTest {
 
         vm.prank(otherPerson);
         metaProver.challengeIntentProof(
+            testIntent.protocolVersion,
             testIntent.source,
             testIntent.destination,
             routeHash,
@@ -936,6 +938,7 @@ contract MetaProverTest is BaseTest {
         // Challenge the proof
         vm.prank(otherPerson);
         metaProver.challengeIntentProof(
+            testIntent.protocolVersion,
             testIntent.source,
             testIntent.destination,
             routeHash,

--- a/test/prover/PolymerProver.t.sol
+++ b/test/prover/PolymerProver.t.sol
@@ -655,6 +655,7 @@ contract PolymerProverTest is BaseTest {
 
         // Challenge with different destination (intent.destination = 1 from BaseTest, proof.destination = 10)
         polymerProver.challengeIntentProof(
+            intent.protocolVersion,
             intent.source,
             intent.destination, // 1
             keccak256(abi.encode(intent.route)),
@@ -698,6 +699,7 @@ contract PolymerProverTest is BaseTest {
 
         // Challenge with correct destination should do nothing
         polymerProver.challengeIntentProof(
+            localIntent.protocolVersion,
             localIntent.source,
             localIntent.destination,
             keccak256(abi.encode(localIntent.route)),

--- a/test/security/TokenSecurity.t.sol
+++ b/test/security/TokenSecurity.t.sol
@@ -90,6 +90,7 @@ contract TokenSecurityTest is BaseTest {
         vm.prank(claimant);
         vm.expectRevert(BadERC20.TransferNotAllowed.selector);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -144,6 +145,7 @@ contract TokenSecurityTest is BaseTest {
         vm.prank(attacker);
         vm.expectRevert();
         portal.fulfill(
+            destIntent.protocolVersion,
             destIntent.source,
             destIntent.destination,
             destIntent.route,
@@ -183,6 +185,7 @@ contract TokenSecurityTest is BaseTest {
         // IntentWithdrawn should succeed and state should be updated
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -223,6 +226,7 @@ contract TokenSecurityTest is BaseTest {
         vm.expectRevert(); // Should revert because fake permit doesn't actually transfer
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -279,6 +283,7 @@ contract TokenSecurityTest is BaseTest {
 
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -385,6 +390,7 @@ contract TokenSecurityTest is BaseTest {
 
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -440,6 +446,7 @@ contract TokenSecurityTest is BaseTest {
 
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -493,6 +500,7 @@ contract TokenSecurityTest is BaseTest {
         vm.prank(keeper);
         vm.expectRevert();
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,

--- a/test/source/IntentSource.t.sol
+++ b/test/source/IntentSource.t.sol
@@ -103,6 +103,7 @@ contract IntentSourceTest is BaseTest {
         vm.expectRevert();
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -131,6 +132,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -156,6 +158,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -173,6 +176,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -184,6 +188,7 @@ contract IntentSourceTest is BaseTest {
         vm.expectRevert();
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -204,6 +209,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -218,6 +224,7 @@ contract IntentSourceTest is BaseTest {
         emit IIntentSource.IntentRefunded(intentHash, keeper);
         vm.prank(otherPerson);
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -238,6 +245,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -263,6 +271,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -292,6 +301,7 @@ contract IntentSourceTest is BaseTest {
         bytes32 routeHash = keccak256(abi.encode(evmIntent.route));
         vm.prank(otherPerson);
         prover.challengeIntentProof(
+            evmIntent.protocolVersion,
             evmIntent.source,
             evmIntent.destination,
             routeHash,
@@ -318,6 +328,7 @@ contract IntentSourceTest is BaseTest {
             )
         );
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -334,6 +345,7 @@ contract IntentSourceTest is BaseTest {
         vm.expectRevert();
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -363,6 +375,7 @@ contract IntentSourceTest is BaseTest {
         // batchWithdraw was removed in v3; settle each intent individually.
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -398,6 +411,7 @@ contract IntentSourceTest is BaseTest {
         // as the claimant, so the reward is paid to the keeper.
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -424,6 +438,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -453,6 +468,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -474,6 +490,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -504,6 +521,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -531,6 +549,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -685,6 +704,7 @@ contract IntentSourceTest is BaseTest {
         vm.prank(claimant);
         vm.expectRevert(BadERC20.TransferNotAllowed.selector);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -772,6 +792,7 @@ contract IntentSourceTest is BaseTest {
         vm.expectRevert();
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -838,6 +859,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -894,6 +916,7 @@ contract IntentSourceTest is BaseTest {
         // IntentWithdrawn should handle duplicates correctly
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -922,6 +945,7 @@ contract IntentSourceTest is BaseTest {
 
         // Intent 2: Funded but not proven (should be refunded after expiry)
         intents[1] = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: intent.source,
             destination: intent.destination,
             route: Route({
@@ -939,6 +963,7 @@ contract IntentSourceTest is BaseTest {
 
         // Intent 3: Proven but different claimant
         intents[2] = Intent({
+            protocolVersion: PROTOCOL_VERSION,
             source: intent.source,
             destination: intent.destination,
             route: Route({
@@ -968,6 +993,7 @@ contract IntentSourceTest is BaseTest {
         // Intent 1: Proven with claimant - should succeed
         vm.prank(claimant);
         intentSource.settle(
+            intents[0].protocolVersion,
             intents[0].source,
             intents[0].destination,
             keccak256(abi.encode(intents[0].route)),
@@ -979,6 +1005,7 @@ contract IntentSourceTest is BaseTest {
         // Intent 2: No proof, expired - should refund
         vm.prank(keeper);
         intentSource.refund(
+            intents[1].protocolVersion,
             intents[1].source,
             intents[1].destination,
             keccak256(abi.encode(intents[1].route)),
@@ -988,6 +1015,7 @@ contract IntentSourceTest is BaseTest {
         // Intent 3: Proven with keeper as claimant - should succeed
         vm.prank(keeper);
         intentSource.settle(
+            intents[2].protocolVersion,
             intents[2].source,
             intents[2].destination,
             keccak256(abi.encode(intents[2].route)),
@@ -1044,6 +1072,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.fundFor(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -1061,6 +1090,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(claimant);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,
@@ -1101,6 +1131,7 @@ contract IntentSourceTest is BaseTest {
 
         return
             EVMIntent({
+                protocolVersion: _evmIntent.protocolVersion,
                 source: _evmIntent.source,
                 destination: _evmIntent.destination,
                 route: EVMRoute({
@@ -1139,6 +1170,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.fund{value: 1 ether}(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1154,6 +1186,7 @@ contract IntentSourceTest is BaseTest {
         vm.warp(reward.deadline + 1);
         vm.prank(keeper);
         intentSource.refund(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1169,6 +1202,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.fund{value: 1 ether}(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1193,6 +1227,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(claimant);
         intentSource.settle(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1213,6 +1248,7 @@ contract IntentSourceTest is BaseTest {
         vm.warp(reward.deadline + 1);
         vm.prank(keeper);
         intentSource.refund(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1228,6 +1264,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(claimant);
         intentSource.settle(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1263,6 +1300,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(claimant);
         intentSource.settle(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1286,6 +1324,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.refund(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1322,6 +1361,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.refund(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1343,6 +1383,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1372,6 +1413,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1398,6 +1440,7 @@ contract IntentSourceTest is BaseTest {
             )
         );
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1421,6 +1464,7 @@ contract IntentSourceTest is BaseTest {
             )
         );
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1442,6 +1486,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1480,6 +1525,7 @@ contract IntentSourceTest is BaseTest {
             )
         );
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1496,6 +1542,7 @@ contract IntentSourceTest is BaseTest {
 
         vm.prank(otherPerson);
         intentSource.settle(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1512,6 +1559,7 @@ contract IntentSourceTest is BaseTest {
         emit IIntentSource.IntentRefunded(intentHash, refundee);
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1531,6 +1579,7 @@ contract IntentSourceTest is BaseTest {
         // First refund - gets original funds
         vm.prank(keeper);
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1560,6 +1609,7 @@ contract IntentSourceTest is BaseTest {
         // again to the keeper).
         vm.prank(keeper);
         intentSource.refund(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1584,6 +1634,7 @@ contract IntentSourceTest is BaseTest {
         // First refundTo - gets original funds
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1615,6 +1666,7 @@ contract IntentSourceTest is BaseTest {
         address refundee2 = makeAddr("refundee2");
         vm.prank(keeper);
         intentSource.refundTo(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             keccak256(abi.encode(intent.route)),
@@ -1659,6 +1711,7 @@ contract IntentSourceTest is BaseTest {
         vm.warp(reward.deadline + 1);
         vm.prank(keeper);
         intentSource.refund(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1687,6 +1740,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.recoverToken(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1709,6 +1763,7 @@ contract IntentSourceTest is BaseTest {
         );
         vm.prank(keeper);
         intentSource.recoverToken(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),
@@ -1741,6 +1796,7 @@ contract IntentSourceTest is BaseTest {
         // Settle the intent to the claimant
         vm.prank(claimant);
         intentSource.settle(
+            PROTOCOL_VERSION,
             CHAIN_ID,
             CHAIN_ID,
             keccak256(abi.encode(intent.route)),

--- a/test/v3/deploy/DeployV3.t.sol
+++ b/test/v3/deploy/DeployV3.t.sol
@@ -9,6 +9,9 @@ import {ICreate3Deployer} from "../../../contracts/tools/ICreate3Deployer.sol";
 import {AddressConverter} from "../../../contracts/libs/AddressConverter.sol";
 
 import {Portal} from "../../../contracts/Portal.sol";
+import {PortalProxy} from "../../../contracts/PortalProxy.sol";
+// Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Test contracts.
+import {Account as EcoAccount} from "../../../contracts/account/Account.sol";
 import {MulticallRuntime} from "../../../contracts/runtime/MulticallRuntime.sol";
 import {HyperPolicy} from "../../../contracts/prover/HyperPolicy.sol";
 import {VestingPolicy} from "../../../contracts/prover/VestingPolicy.sol";
@@ -136,10 +139,37 @@ contract DeployV3Test is Test {
     function test_b_create2AddressesReDerivable() public {
         DeployV3.Deployment memory dep = script.deploy(_cfg());
 
+        // The PERMANENT Portal is the PortalProxy, deployed at SALT with the deployer as owner.
         assertEq(
             dep.portal,
-            _predictCreate2(type(Portal).creationCode, SALT),
-            "portal CREATE2"
+            _predictCreate2(
+                abi.encodePacked(
+                    type(PortalProxy).creationCode,
+                    abi.encode(address(script)) // cfg.deployer = owner
+                ),
+                SALT
+            ),
+            "portal proxy CREATE2"
+        );
+        // The shared Account implementation is bound to the proxy and deployed at a derived salt.
+        address accountImpl = _predictCreate2(
+            abi.encodePacked(
+                type(EcoAccount).creationCode,
+                abi.encode(dep.portal)
+            ),
+            _contractSalt(SALT, "ACCOUNT_IMPLEMENTATION")
+        );
+        // The version-1 Portal implementation references the shared Account implementation.
+        assertEq(
+            dep.portalImplementation,
+            _predictCreate2(
+                abi.encodePacked(
+                    type(Portal).creationCode,
+                    abi.encode(accountImpl)
+                ),
+                _contractSalt(SALT, "PORTAL_IMPLEMENTATION_V1")
+            ),
+            "portal implementation CREATE2"
         );
         assertEq(
             dep.runtime,

--- a/test/v3/sdk/GoldenVector.t.sol
+++ b/test/v3/sdk/GoldenVector.t.sol
@@ -59,6 +59,7 @@ contract GoldenVectorTest is Test {
         });
 
         intent = Intent({
+            protocolVersion: 1,
             source: 8453,
             destination: 10,
             route: route,
@@ -71,6 +72,7 @@ contract GoldenVectorTest is Test {
         bytes32 routeHash = keccak256(abi.encode(intent.route));
         bytes32 rewardHash = keccak256(abi.encode(intent.reward));
         bytes32 intentHash = IntentLib.hashIntent(
+            intent.protocolVersion,
             intent.source,
             intent.destination,
             routeHash,

--- a/utils/intent.ts
+++ b/utils/intent.ts
@@ -52,6 +52,7 @@ export type Reward = {
 // v3 / Model C Intent: gained a `source` field (origin chain id), hashed FIRST (before `destination`)
 // into the intent hash.
 export type Intent = {
+  protocolVersion?: number | bigint
   source: number | bigint
   destination: number
   route: Route
@@ -125,6 +126,10 @@ export function encodeHooks(rewardHook: Hook, refundHook: Hook) {
 
 const IntentStruct = [
   {
+    name: 'protocolVersion',
+    type: 'uint32',
+  },
+  {
     name: 'source',
     type: 'uint64',
   },
@@ -172,22 +177,25 @@ export function encodeReward(reward: Reward) {
 
 /**
  * ABI-encodes the ERC-7683 `FillInstruction.originData` payload the same way
- * {OriginSettler-resolve} does: `abi.encode(source, routeBytes, reward)`, where `routeBytes` is the
- * ALREADY-ENCODED route (see {encodeRoute}) and `reward` is the full (unhashed) `Reward` struct.
+ * {OriginSettler-resolve} does: `abi.encode(protocolVersion, source, routeBytes, reward)`, where
+ * `routeBytes` is the ALREADY-ENCODED route (see {encodeRoute}) and `reward` is the full (unhashed)
+ * `Reward` struct.
  */
 export function encodeOriginData(
   source: number | bigint,
   routeBytes: string,
   reward: Reward,
+  protocolVersion: number | bigint = 1,
 ) {
   const abiCoder = AbiCoder.defaultAbiCoder()
   return abiCoder.encode(
     [
+      { name: 'protocolVersion', type: 'uint32' },
       { name: 'source', type: 'uint64' },
       { name: 'route', type: 'bytes' },
       { name: 'reward', type: 'tuple', components: RewardStruct },
     ],
-    [source, routeBytes, reward],
+    [protocolVersion, source, routeBytes, reward],
   )
 }
 
@@ -200,7 +208,7 @@ export function encodeIntent(intent: Intent) {
         components: IntentStruct,
       },
     ],
-    [intent],
+    [{ ...intent, protocolVersion: intent.protocolVersion ?? 1 }],
   )
 }
 
@@ -227,8 +235,14 @@ export function hashIntent(intent: Intent) {
 
   const intentHash = keccak256(
     solidityPacked(
-      ['uint64', 'uint64', 'bytes32', 'bytes32'],
-      [intent.source, intent.destination, routeHash, rewardHash],
+      ['uint32', 'uint64', 'uint64', 'bytes32', 'bytes32'],
+      [
+        intent.protocolVersion ?? 1,
+        intent.source,
+        intent.destination,
+        routeHash,
+        rewardHash,
+      ],
     ),
   )
 
@@ -265,5 +279,8 @@ export async function intentAccountAddress(
   intent: Intent,
 ) {
   const intentSource = await ethers.getContractAt('Portal', intentSourceAddress)
-  return intentSource.intentAccountAddress(intent)
+  return intentSource.intentAccountAddress({
+    ...intent,
+    protocolVersion: intent.protocolVersion ?? 1,
+  })
 }


### PR DESCRIPTION
## Summary
Stacked on PR8 (#403). The Portal becomes a permanent, stable-address delegatecall proxy in front of versioned implementations, so the protocol can ship new implementation code without ever changing the address intents and per-intent Accounts are anchored to.

- **`Intent.protocolVersion`** (uint32, new first field, creator-declared, hash-affecting): `intentHash = hashIntent(protocolVersion, source, destination, routeHash, rewardHash)`. Threaded as an explicit leading scalar through every entry point that only ever receives `reward`+`routeHash` (never the full route, which stays opaque bytes at the source for cross-VM compatibility) — the same pattern `source`/`destination` already use.
- **`PortalProxy`**: the new permanent externally-facing contract. Holds a write-once `version → (implementation, registeredAt)` registry (`registerVersion`, owner-only — re-registering an already-set version reverts `VersionAlreadyRegistered`, matching this codebase's immutable-trust-anchor convention). Dispatches every call via `delegatecall` into the implementation registered for that call's `protocolVersion` — for entry points carrying a leading `uint32 protocolVersion` scalar, a generic `fallback()` reads it directly from `calldata[4:36]` (sound because a leading value-type parameter always lands at that fixed offset in ABI encoding, regardless of what dynamic types follow it); entry points carrying a full `Intent` get thin typed forwarders reading `intent.protocolVersion`; version-agnostic helpers and the ERC-7683 adapter surface dispatch to the latest registered implementation.
- **Today's `Portal`/`PortalTron`** become versioned implementations. `publish()` validates the creator-declared version exists (`UnknownProtocolVersion`) and hasn't expired (`ProtocolVersionExpired`) — a new intent can never be created already-sweepable.
- **Account-address stability across versions**: `Account`'s `onlyPortal` now trusts the *proxy's* address (delegatecall means any call an implementation makes always arrives with `msg.sender == proxy`), and every registered `Portal` implementation shares one `Account` clone-template immutable, so an intent's Account address is identical no matter which implementation version is currently active. Proven by a test that registers a second, genuinely different `Portal` implementation and asserts the same intent hash resolves to the same Account address before and after.
- **Expired-version deployer sweep**: once an implementation is 365+ days old, the protocol owner becomes an *alternate authorized caller* on the existing `executeAsOwner` (both source and destination sides) — not a new check. The already-hardened escrow/proof lock (fixed in PR3, `test_executeAsOwner_lockedWhileInitial_hasLiveRewardLegs`) runs unchanged and identically for both the keeper and the deployer, so the deployer can never touch an account with live reward legs, an unsettled proof, or (on the destination side) a same-chain collapsed escrow — "gate on both an expired version and an independently-dead account" falls out for free from code that was already reviewed and tested, rather than a new bespoke check.

## Security note
This introduces a new admin privilege, so it received a direct, focused review beyond the standard gate-checking (not a full multi-agent sweep, given how much of the authorization logic is verbatim-reused from the already-hardened PR3 fix): the `executeAsOwner` lock body was read line-by-line on both the source and destination sides and confirmed byte-for-byte unchanged from PR3; the cross-chain-only restriction was confirmed to run unconditionally before either authorization branch, so it can't be bypassed by the deployer any more than by the keeper; and `isProtocolVersionExpired` was confirmed to fail closed (return `false`) for an unregistered version.

`optimizer_runs` is lowered from 1,000 to 400 to fit the new proxy/registry surface — a real but modest runtime-gas cost, not a safety concern; flagged for awareness.

## Test plan
- [x] `forge build` clean
- [x] `forge test`: 669 passed / 0 failed (17 new tests: write-once registry, account-address stability across a genuinely different implementation, `publish` rejecting unregistered/expired versions, and the full deployer-sweep matrix — blocked pre-expiry, allowed post-expiry only on an independently-dead account, still locked with live reward legs or an unsettled proof, cross-chain-only enforced for the deployer too)
- [x] `npx hardhat test`: 112 passing
- [x] `jest`: 46 passed
- [x] Portal/PortalTron (implementation): 23,469 B (1,107 B headroom); PortalProxy (new contract): 2,711 B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N25m45iFpZQEycqw7YFNsK