### PR TITLE
feat(v3): PR10 — split ERC-7683 adapter out of the lean Portal (delegatecall-direct)

### DIFF
--- a/contracts/ERC7683/ERC7683Implementation.sol
+++ b/contracts/ERC7683/ERC7683Implementation.sol
@@ -1,0 +1,248 @@
+/* -*- c-basic-offset: 4 -*- */
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+import {OriginSettler} from "./OriginSettler.sol";
+import {DestinationSettler} from "./DestinationSettler.sol";
+
+import {IInbox} from "../interfaces/IInbox.sol";
+import {IPortalProxy} from "../interfaces/IPortalProxy.sol";
+
+import {Route, Reward} from "../types/Intent.sol";
+
+/**
+ * @title IPortalPublishAndFund
+ * @notice The two decomposed source-side entry points the ERC-7683 adapter delegatecalls into the resolved
+ *         Portal implementation. Declared as a dedicated, NON-overloaded interface purely so
+ *         {abi.encodeCall} can reference each unambiguously — the public {IIntentSource} counterparts are
+ *         overloaded (a struct form + this decomposed form), and `abi.encodeCall`/`.selector` cannot pick
+ *         between overloads by name. The signatures (hence selectors) are byte-identical to
+ *         {IIntentSource.publishAndFund}/{IIntentSource.publishAndFundFor}'s decomposed overloads.
+ */
+interface IPortalPublishAndFund {
+    function publishAndFund(
+        uint32 protocolVersion,
+        uint64 source,
+        uint64 destination,
+        bytes memory route,
+        Reward memory reward,
+        bool allowPartial
+    ) external payable returns (bytes32 intentHash, address account);
+
+    function publishAndFundFor(
+        uint32 protocolVersion,
+        uint64 source,
+        uint64 destination,
+        bytes memory route,
+        Reward memory reward,
+        bool allowPartial,
+        address funder,
+        address permitContract
+    ) external payable returns (bytes32 intentHash, address account);
+}
+
+/**
+ * @title ERC7683Implementation
+ * @notice The Eco Protocol's ERC-7683 adapter, split OUT of the core Portal implementation so the Portal
+ *         reclaims the Settlers' bytecode (the ERC-7683 surface is lower-priority and can pay one extra
+ *         delegatecall hop).
+ * @dev Inherits ONLY the two ERC-7683 Settlers — NOT {IntentSource}, {Inbox}, {AccountDeployer} or
+ *      {Semver}. It duplicates NONE of the core intent logic. Its two abstract Settler hooks
+ *      ({OriginSettler-_publishAndFund}, {DestinationSettler-fulfillAndProve}) resolve the pinned Portal
+ *      implementation for the call's `protocolVersion` and `delegatecall` DIRECTLY into its real
+ *      `publishAndFund(For)` / `fulfillAndProve`.
+ *
+ *      EXECUTION CONTEXT. This contract is reached only via {PortalCore-fallback} — itself only reached via
+ *      `delegatecall` from the {PortalProxy}. So every call runs TWO delegatecalls deep in the proxy's
+ *      context: `address(this)` is the PROXY and `msg.sender` is the ORIGINAL caller. The final
+ *      `delegatecall` into the resolved Portal implementation is a THIRD hop that, being a delegatecall,
+ *      again preserves BOTH — which is the whole point:
+ *        - the Portal implementation reads/writes the proxy's storage (one consistent `rewardStatuses`
+ *          view, computed by the Portal's own bytecode — this adapter never touches it), and
+ *        - `msg.sender` is preserved. This matters CRITICALLY for the fulfill path: {Inbox._fulfill} pulls
+ *          the solver's ERC20 input with `safeTransferFrom(msg.sender, account, provided)` — HARDCODED to
+ *          `msg.sender`, no explicit-provider parameter. A plain external self-CALL back through the proxy
+ *          would reset `msg.sender` to the proxy (which holds no solver funds) and silently break every
+ *          `fill()`. A `delegatecall` never rebases `msg.sender`, so the solver's own tokens are pulled.
+ *
+ *      STORAGE. This contract declares no storage of its own; its only inherited storage is OZ {EIP712}'s
+ *      two fallback-string slots (unused at runtime for the short "EcoPortal"/"1" name, which live as
+ *      immutables in code). It never reads/writes `rewardStatuses` directly — that always happens inside
+ *      the delegatecalled Portal bytecode — so there is no cross-contract slot-alignment requirement with
+ *      the lean Portal (the failure mode of the earlier fat design).
+ */
+contract ERC7683Implementation is OriginSettler, DestinationSettler {
+    /**
+     * @notice Initializes the EIP-712 domain used by {OriginSettler}'s gasless-order signature check.
+     * @dev Required here because this contract no longer inherits {IntentSource} (which owns the EIP712
+     *      constructor call in the lean Portal). {OriginSettler} always inherits {EIP712}, so the 2-slot
+     *      layout is contributed identically regardless — and since both this contract and the lean Portal
+     *      are only ever reached via `delegatecall` against the PROXY, neither's constructor-time EIP712
+     *      writes are ever read at runtime: every call takes EIP712's `address(this) != cachedThis` rebuild
+     *      branch, which reconstructs the domain separator from the immutable (code) hashed name/version,
+     *      yielding an identical, correct separator. Same situation the lean Portal is already in (PR9);
+     *      just reached via a different base.
+     */
+    constructor() EIP712("EcoPortal", "1") {}
+
+    /**
+     * @notice {OriginSettler} hook: create + fund an intent by delegatecalling the resolved Portal
+     *         implementation's real `publishAndFund(For)`.
+     * @dev Resolves the implementation for `protocolVersion` (a harmless VIEW self-read of the proxy's
+     *      registry) then `delegatecall`s it, preserving `address(this)`=proxy and `msg.sender`. Chooses the
+     *      target to PRESERVE the funder-allowance semantics of the pre-split ERC-7683 path:
+     *        - `funder == msg.sender` (the {open} case, or a self-relayed {openFor}): route to the
+     *          `msg.sender` overload `publishAndFund`, which pulls each ERC20 leg via the PROXY's allowance
+     *          (`safeTransferFrom(funder, account)` executed by the Portal) — byte-for-byte the legacy
+     *          `open()` behaviour, so proxy approvals keep working unchanged.
+     *        - `funder != msg.sender` (a gasless {openFor} whose signed user is not the relayer): route to
+     *          `publishAndFundFor` with an empty permit. There is NO safe public way to pull from an
+     *          ARBITRARY funder via the proxy's allowance (that would let anyone drain any proxy approver),
+     *          so this path necessarily uses the per-intent Account's allowance instead — the signed user
+     *          must approve the (deterministic, pre-computable) intent Account. This is the one unavoidable
+     *          funder-allowance change introduced by the lean split, and only for cross-relayer openFor.
+     * @param protocolVersion Creator-declared Portal implementation version (selects the delegatecall target)
+     * @param source Origin chain ID (block.chainid at open time) committed in the intent hash
+     * @param destination Destination chain ID where the intent should be executed
+     * @param route Encoded route data (opaque bytes)
+     * @param reward The reward structure
+     * @param allowPartial Whether to accept partial funding
+     * @param funder The address providing the funding (`msg.sender` for open, `order.user` for openFor)
+     * @return intentHash Unique identifier of the created/existing intent
+     * @return account Address of the intent's source (escrow) Account
+     */
+    function _publishAndFund(
+        uint32 protocolVersion,
+        uint64 source,
+        uint64 destination,
+        bytes memory route,
+        Reward memory reward,
+        bool allowPartial,
+        address funder
+    ) internal override returns (bytes32 intentHash, address account) {
+        address implementation = _resolveImplementation(protocolVersion);
+
+        bytes memory callData;
+        if (funder == msg.sender) {
+            callData = abi.encodeCall(
+                IPortalPublishAndFund.publishAndFund,
+                (protocolVersion, source, destination, route, reward, allowPartial)
+            );
+        } else {
+            callData = abi.encodeCall(
+                IPortalPublishAndFund.publishAndFundFor,
+                (
+                    protocolVersion,
+                    source,
+                    destination,
+                    route,
+                    reward,
+                    allowPartial,
+                    funder,
+                    address(0)
+                )
+            );
+        }
+
+        bytes memory ret = _delegateToImplementation(implementation, callData);
+        (intentHash, account) = abi.decode(ret, (bytes32, address));
+    }
+
+    /**
+     * @notice {DestinationSettler} hook: fulfill + prove by delegatecalling the resolved Portal
+     *         implementation's real `fulfillAndProve`.
+     * @dev The `delegatecall` preserves `msg.sender` = the original solver, so {Inbox._fulfill}'s
+     *      `safeTransferFrom(msg.sender, account, provided)` pulls the SOLVER's own input (see the
+     *      contract-level note on why a plain self-CALL would be broken here). `msg.value` is likewise
+     *      preserved for the native input leg + the proof-message fee.
+     * @param protocolVersion Creator-declared Portal implementation version (selects the delegatecall target)
+     * @param source Origin chain ID committed in the intent hash
+     * @param destination Destination chain ID committed in the intent hash (must equal block.chainid)
+     * @param route The route of the intent
+     * @param reward The reward details (legs authenticated by the derived intent hash)
+     * @param claimant Cross-VM compatible claimant identifier
+     * @param providedAmounts Per-leg input the solver provides, index-aligned with `route.minTokens`
+     * @param prover Prover (policy) to record the fulfillment into
+     * @param sourceChainDomainID Bridge transport domain ID of the source chain
+     * @param data Additional data for message formatting
+     * @return The runtime's raw return data
+     */
+    function fulfillAndProve(
+        uint32 protocolVersion,
+        uint64 source,
+        uint64 destination,
+        Route memory route,
+        Reward memory reward,
+        bytes32 claimant,
+        uint256[] memory providedAmounts,
+        address prover,
+        uint64 sourceChainDomainID,
+        bytes memory data
+    ) public payable override(DestinationSettler) returns (bytes memory) {
+        address implementation = _resolveImplementation(protocolVersion);
+
+        bytes memory callData = abi.encodeCall(
+            IInbox.fulfillAndProve,
+            (
+                protocolVersion,
+                source,
+                destination,
+                route,
+                reward,
+                claimant,
+                providedAmounts,
+                prover,
+                sourceChainDomainID,
+                data
+            )
+        );
+
+        bytes memory ret = _delegateToImplementation(implementation, callData);
+        return abi.decode(ret, (bytes));
+    }
+
+    /**
+     * @notice Resolves the Portal implementation pinned to `protocolVersion` from the proxy registry.
+     * @dev `address(this)` IS the {PortalProxy} here (two delegatecalls deep), so this is a plain external
+     *      VIEW self-read of the proxy's own {IPortalProxy-versions} — it moves no funds, so the
+     *      msg.sender-reset concern that governs the WRITE paths does not apply to it.
+     * @param protocolVersion The creator-declared version to resolve.
+     * @return implementation The pinned Portal implementation address.
+     */
+    function _resolveImplementation(
+        uint32 protocolVersion
+    ) private view returns (address implementation) {
+        (implementation, ) = IPortalProxy(address(this)).versions(
+            protocolVersion
+        );
+        if (implementation == address(0)) {
+            revert IPortalProxy.UnknownProtocolVersion(protocolVersion);
+        }
+    }
+
+    /**
+     * @notice `delegatecall`s `implementation` with `callData`, bubbling the raw revert verbatim.
+     * @dev Mirrors {PortalProxy._delegate}'s intent (preserve identity, bubble raw revert) but targets a
+     *      DIFFERENT function selector than the enclosing call, so it forwards `callData` (not `msg.data`).
+     *      A `delegatecall` preserves `address(this)`=proxy and `msg.sender`=original caller, which is what
+     *      makes routing back into the core Portal logic correct where a plain self-CALL would not be. On
+     *      success the ABI-encoded return data is handed back for the caller to decode.
+     * @param implementation The resolved Portal implementation to execute in this (proxy) context.
+     * @param callData The encoded target call.
+     * @return The raw ABI-encoded return data.
+     */
+    function _delegateToImplementation(
+        address implementation,
+        bytes memory callData
+    ) private returns (bytes memory) {
+        (bool ok, bytes memory ret) = implementation.delegatecall(callData);
+        if (!ok) {
+            assembly ("memory-safe") {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+        return ret;
+    }
+}

--- a/contracts/ERC7683/OriginSettler.sol
+++ b/contracts/ERC7683/OriginSettler.sol
@@ -32,11 +32,12 @@ abstract contract OriginSettler is IOriginSettler, EIP712 {
             "GaslessCrossChainOrder(address originSettler,address user,uint256 nonce,uint256 originChainId,uint32 openDeadline,uint32 fillDeadline,bytes32 orderDataType,bytes32 orderDataHash)"
         );
 
-    /**
-     * @notice Initializes the Eco7683OriginSettler with EIP-712 domain
-     * @dev Sets up EIP-712 domain for signature verification with "EcoPortal" name and version "1"
-     */
-    constructor() EIP712("EcoPortal", "1") {}
+    // @dev No constructor here: {EIP712}'s domain args ("EcoPortal", "1") are supplied by the most-derived
+    //      concrete contract ({ERC7683Implementation}). Passing them here too would give {EIP712}'s base
+    //      constructor its arguments twice ("Base constructor arguments given twice"). {OriginSettler}
+    //      still inherits {EIP712} (so the 2-slot layout + immutables are contributed), just does not
+    //      initialize it — every runtime call takes EIP712's proxy-safe `address(this) != cachedThis`
+    //      rebuild branch anyway.
 
     /**
      * @notice Opens an Eco intent directly on chain via ERC-7683 interface

--- a/contracts/Inbox.sol
+++ b/contracts/Inbox.sol
@@ -13,7 +13,6 @@ import {Route, Reward} from "./types/Intent.sol";
 import {IntentLib} from "./types/Intent.sol";
 import {Refund} from "./libs/Refund.sol";
 
-import {DestinationSettler} from "./ERC7683/DestinationSettler.sol";
 import {AccountDeployer} from "./account/AccountDeployer.sol";
 
 /**
@@ -34,7 +33,7 @@ import {AccountDeployer} from "./account/AccountDeployer.sol";
  *      destination Account (leftover stays WITH THE INTENT for `route.keeper`). The Inbox commits
  *      `(intentHash, claimant, fulfilled[])` into a HASH-ONLY fact and records it into the named prover.
  */
-abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
+abstract contract Inbox is AccountDeployer, IInbox {
     using SafeERC20 for IERC20;
 
     /**
@@ -125,7 +124,7 @@ abstract contract Inbox is AccountDeployer, DestinationSettler, IInbox {
         address prover,
         uint64 sourceChainDomainID,
         bytes memory data
-    ) public payable override(DestinationSettler, IInbox) returns (bytes memory) {
+    ) public payable override(IInbox) returns (bytes memory) {
         (bytes memory result, , bytes32 intentHash) = _fulfill(
             protocolVersion,
             source,

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -17,7 +17,6 @@ import {Intent, Reward, RewardToken, IntentLib} from "./types/Intent.sol";
 import {AddressConverter} from "./libs/AddressConverter.sol";
 import {Refund} from "./libs/Refund.sol";
 
-import {OriginSettler} from "./ERC7683/OriginSettler.sol";
 import {AccountDeployer} from "./account/AccountDeployer.sol";
 
 /**
@@ -30,7 +29,7 @@ import {AccountDeployer} from "./account/AccountDeployer.sol";
  *      keeper. The source-side escrow Account is chain-parameterized by `intent.source` (Model C), so it
  *      is address-separated from the destination execution Account for a cross-chain intent.
  */
-abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource {
+abstract contract IntentSource is AccountDeployer, IIntentSource {
     using SafeERC20 for IERC20;
     using AddressConverter for address;
     using AddressConverter for bytes32;
@@ -955,7 +954,17 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
     }
 
     /**
-     * @notice Core OriginSettler implementation for atomic intent creation and funding
+     * @notice Core atomic intent creation + funding (proxy-allowance funding path)
+     * @dev The source-side funding primitive: `publish` + `_fundIntent`, where `_fundIntent` pulls each
+     *      ERC20 leg from `funder` via THIS contract's (the proxy's) allowance
+     *      (`safeTransferFrom(funder, account)` executed by the Portal). Callers must have established that
+     *      `funder` authorized this pull — either `funder == msg.sender` ({publishAndFund}) or a verified
+     *      signature (the ERC-7683 `openFor` path). It is intentionally NOT exposed as a public
+     *      arbitrary-`funder` entry point: that would let anyone drain any address that has approved the
+     *      proxy. The public arbitrary-`funder` path is {publishAndFundFor}, which pulls via the per-intent
+     *      Account's own allowance instead (safe because the funder must have approved that specific
+     *      Account). No longer overrides an abstract hook — the ERC-7683 Settlers now live in a separate
+     *      implementation (see {ERC7683Implementation}).
      * @param source Origin chain ID for the intent
      * @param destination Destination chain ID for the intent
      * @param route Encoded route data for the intent as bytes
@@ -973,7 +982,7 @@ abstract contract IntentSource is AccountDeployer, OriginSettler, IIntentSource 
         Reward memory reward,
         bool allowPartial,
         address funder
-    ) internal override returns (bytes32 intentHash, address account) {
+    ) internal returns (bytes32 intentHash, address account) {
         (intentHash, account) = publish(
             protocolVersion,
             source,

--- a/contracts/Portal.sol
+++ b/contracts/Portal.sol
@@ -18,11 +18,17 @@ import {AccountDeployer} from "./account/AccountDeployer.sol";
  */
 contract Portal is PortalCore {
     /**
-     * @notice Wires the shared Account clone template.
+     * @notice Wires the shared Account clone template and the ERC-7683 adapter implementation.
      * @param accountImplementation The shared {Account} implementation (bound to the proxy) that
      *        per-intent clones delegate to.
+     * @param erc7683Implementation The {ERC7683Implementation} the lean Portal delegates its ERC-7683
+     *        surface to via {PortalCore-fallback}.
      */
     constructor(
-        address accountImplementation
-    ) AccountDeployer(accountImplementation, bytes1(0xff)) {}
+        address accountImplementation,
+        address erc7683Implementation
+    )
+        AccountDeployer(accountImplementation, bytes1(0xff))
+        PortalCore(erc7683Implementation)
+    {}
 }

--- a/contracts/PortalCore.sol
+++ b/contracts/PortalCore.sol
@@ -22,6 +22,56 @@ import {Refund} from "./libs/Refund.sol";
  */
 abstract contract PortalCore is IntentSource, Inbox, Semver {
     /**
+     * @notice The ERC-7683 adapter implementation this Portal falls back to.
+     * @dev Immutable, set at construction (2nd ctor arg alongside the Account clone template). The
+     *      ERC-7683 entry points ({open}/{openFor}/{resolve}/{resolveFor}/{fill}, plus the EIP-712
+     *      helpers {domainSeparatorV4}/{GASLESS_CROSSCHAIN_ORDER_TYPEHASH}) are NO LONGER real functions on
+     *      this lean Portal implementation — they live on {ERC7683Implementation}. A call for one of those
+     *      selectors misses Solidity's generated dispatcher and hits {fallback}, which `delegatecall`s it
+     *      here. Because this Portal is itself only ever reached via `delegatecall` from the {PortalProxy},
+     *      this is a SECOND nested delegatecall: `address(this)` stays the proxy and `msg.sender` stays the
+     *      original caller through both hops, so the adapter operates on the proxy's storage and identity.
+     *      This is the deliberate extra hop the ERC-7683 (lower-priority) path pays so the core Portal
+     *      reclaims the Settlers' bytecode.
+     */
+    address private immutable ERC7683_IMPLEMENTATION;
+
+    /**
+     * @notice Wires the ERC-7683 adapter implementation.
+     * @param erc7683Implementation The {ERC7683Implementation} this Portal delegates the ERC-7683 surface
+     *        to via {fallback}. A SINGLE shared instance serves every Portal version (it holds no
+     *        version-specific or account-derivation state — it resolves + delegatecalls the pinned
+     *        implementation for each call).
+     */
+    constructor(address erc7683Implementation) {
+        ERC7683_IMPLEMENTATION = erc7683Implementation;
+    }
+
+    /**
+     * @notice Delegates any selector this lean Portal does not implement to the ERC-7683 adapter.
+     * @dev Only the detached ERC-7683 surface reaches here (every real Portal function is matched by
+     *      Solidity's own dispatcher first). Mirrors {PortalProxy._delegate}: copy calldata, `delegatecall`
+     *      the adapter, bubble the raw return/revert verbatim. `assembly ("memory-safe")` is REQUIRED — the
+     *      via-IR pipeline otherwise drops the memory guard for this function and the inherited {_fulfill}'s
+     *      stack allocation overflows (stack-too-deep) at compile time.
+     */
+    fallback() external payable {
+        address impl = ERC7683_IMPLEMENTATION;
+        assembly ("memory-safe") {
+            calldatacopy(0, 0, calldatasize())
+            let ok := delegatecall(gas(), impl, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch ok
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /**
      * @notice Atomically fulfills and settles a SAME-CHAIN intent in one transaction
      * @dev See {IPortal-fulfillAndSettle}. Requires `intent.source == intent.destination ==
      *      block.chainid`. Because source == destination the escrow Account and the execution Account are

--- a/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_Arc.sol
@@ -116,7 +116,7 @@ contract DepositAddress_CCTPMint_Arc is BaseDepositAddress {
         );
 
         // Publish Intent 2 and get its account address
-        Portal portalContract = Portal(portalAddress);
+        Portal portalContract = Portal(payable(portalAddress));
         (, address account2) = portalContract.publish(intent2);
 
         // ---- Step 2: Construct, fund, and publish Intent 1 (CCTP burn on source chain) ----

--- a/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol
@@ -112,7 +112,7 @@ contract DepositAddress_CCTPMint_GatewayERC20 is BaseDepositAddress {
         // ---- Step 1: Construct and publish Intent 2 (Gateway deposit on destination) ----
         // Hoisted into a helper so `_executeIntent` keeps its local-variable count below the
         // 16-stack-slot Yul limit imposed by the 12-field config + fee locals.
-        Portal portalContract = Portal(portalAddress);
+        Portal portalContract = Portal(payable(portalAddress));
         address account2 = _publishGatewayIntent(
             portalContract,
             destinationChainId,

--- a/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
+++ b/contracts/deposit/DepositAddress_USDCTransfer_Solana.sol
@@ -118,7 +118,7 @@ contract DepositAddress_USDCTransfer_Solana is BaseDepositAddress {
         IERC20(sourceToken).approve(portal, amount);
 
         // Call Portal.publishAndFund. Published on this (source) chain; fulfilled on Solana.
-        Portal portalContract = Portal(portal);
+        Portal portalContract = Portal(payable(portal));
         (intentHash,) = portalContract.publishAndFund(
             1, // protocolVersion: pinned to protocol version 1 (registered on the PortalProxy at deploy)
             uint64(block.chainid),

--- a/contracts/tron/PortalTron.sol
+++ b/contracts/tron/PortalTron.sol
@@ -15,11 +15,18 @@ import {AccountDeployer} from "../account/AccountDeployer.sol";
  */
 contract PortalTron is PortalCore {
     /**
-     * @notice Wires the shared AccountTron clone template.
+     * @notice Wires the shared AccountTron clone template and the ERC-7683 adapter implementation.
      * @param accountImplementation The shared {AccountTron} implementation (bound to the proxy) that
      *        per-intent clones delegate to.
+     * @param erc7683Implementation The {ERC7683Implementation} the lean Portal delegates its ERC-7683
+     *        surface to via {PortalCore-fallback} (a SINGLE shared adapter serves both EVM and TRON — it
+     *        holds no account-derivation state, so it needs no TRON-specific variant).
      */
     constructor(
-        address accountImplementation
-    ) AccountDeployer(accountImplementation, bytes1(0x41)) {}
+        address accountImplementation,
+        address erc7683Implementation
+    )
+        AccountDeployer(accountImplementation, bytes1(0x41))
+        PortalCore(erc7683Implementation)
+    {}
 }

--- a/docs/v3/10-erc7683-adapter-split.md
+++ b/docs/v3/10-erc7683-adapter-split.md
@@ -1,0 +1,175 @@
+# PR10 — ERC-7683 adapter split (lean, delegatecall-direct)
+
+**Branch:** `v3/10-erc7683-adapter-split` (base `v3/09-protocol-versioning`)
+
+## Goal
+
+Reclaim Portal bytecode headroom by moving the ERC-7683 surface
+(`open`/`openFor`/`resolve`/`resolveFor`/`fill`, plus the EIP-712 helpers) OUT of the core Portal
+implementation into a separate contract that the Portal falls back to. PR9 had eroded `optimizer_runs`
+all the way to **400** (main uses 1,000,000) because the combined Portal was bytecode-bound. Splitting the
+Settlers off restores **`optimizer_runs = 1,000,000`**.
+
+## Why the first attempt was rejected (and the real bug it hid)
+
+The first attempt made `ERC7683Implementation` inherit `IntentSource + Inbox + OriginSettler +
+DestinationSettler + Semver` — i.e. it re-embedded ALL of IntentSource+Inbox's logic a SECOND time just to
+satisfy the Settlers' abstract hooks. Result: `ERC7683Implementation` weighed **23,892 B** and became the
+new binding contract at only 684 B headroom — *worse* than the problem it set out to solve, and it capped
+`optimizer_runs` at 1000.
+
+The naive fix ("just have the adapter call the proxy's own public interface") is not merely wasteful — for
+the fulfill path it is **a real funds bug**. `Inbox._fulfill` pulls the solver's ERC20 input with:
+
+```solidity
+IERC20(token).safeTransferFrom(msg.sender, account, provided); // contracts/Inbox.sol:361
+```
+
+`msg.sender` is **hardcoded** — there is no explicit-provider parameter (unlike `funder` on the publish
+path). A plain external self-`CALL` from the adapter back into the proxy resets `msg.sender` to the proxy's
+own address, so the re-entered `_fulfill` would try to pull the solver's tokens **from the proxy** (which
+holds none) — silently breaking every ERC-7683 `fill()`. (Verified by reading `Inbox.sol` directly.)
+
+## The corrected design
+
+`ERC7683Implementation` (`contracts/ERC7683/ERC7683Implementation.sol`) inherits **ONLY**
+`OriginSettler, DestinationSettler` — NOT `IntentSource`, NOT `Inbox`, NOT `AccountDeployer`, NOT `Semver`.
+It carries essentially zero business logic. Its two abstract Settler hooks resolve the pinned Portal
+implementation for the call's `protocolVersion` and **`delegatecall` DIRECTLY into it**:
+
+1. `_resolveImplementation(pv)` — a harmless VIEW self-read `IPortalProxy(address(this)).versions(pv)`.
+   `address(this)` IS the proxy here (the adapter is reached two delegatecalls deep from the original
+   external call), so this reads the proxy's own registry. Reverts `UnknownProtocolVersion` if unset.
+2. `delegatecall` that resolved implementation, invoking its REAL `publishAndFund(For)` / `fulfillAndProve`.
+   A `delegatecall` (unlike a plain `CALL`) **never rebases `msg.sender` or `address(this)`** — both are
+   preserved from the enclosing frame — so the core Portal logic runs against the proxy's storage with the
+   ORIGINAL caller as `msg.sender`. This is exactly what makes it correct where a self-CALL is broken.
+
+### Call path
+
+```
+open/openFor/resolve/resolveFor/fill  (external)
+   -> PortalProxy forwarder            (delegatecall #1: address(this)=proxy, msg.sender=caller)
+   -> Portal (lean impl)               [selector not found]
+   -> PortalCore.fallback()            (delegatecall #2: still proxy + caller)
+   -> ERC7683Implementation.<fn>
+        -> _resolveImplementation(pv)  (view self-read of the proxy registry)
+        -> delegatecall pinned impl    (delegatecall #3: STILL proxy + caller)
+           -> Portal.publishAndFund(For) / Inbox.fulfillAndProve  (writes proxy storage, pulls from caller)
+```
+
+`PortalProxy` needed **no changes** — its existing `open/openFor/resolve/resolveFor/fill` forwarders already
+dispatch to `_latestImplementation()` (the lean Portal), whose new `fallback` relays onward.
+
+### Detaching the Settlers
+
+- `IntentSource is AccountDeployer, IIntentSource` (was `..., OriginSettler, ...`). Its `_publishAndFund`
+  is now a plain internal helper (no `override`) — nothing abstract requires the override relationship.
+- `Inbox is AccountDeployer, IInbox` (was `..., DestinationSettler, ...`). `fulfillAndProve` stays a real,
+  directly-callable function (`override(IInbox)`).
+- `PortalCore` gains an immutable `ERC7683_IMPLEMENTATION` (2nd ctor arg after `accountImplementation`) and
+  a `fallback() external payable` that delegatecalls it. The fallback uses `assembly ("memory-safe")` —
+  REQUIRED, or via-IR drops the memory guard and the inherited `_fulfill` overflows the stack at compile.
+- `OriginSettler`'s constructor drops its `EIP712("EcoPortal","1")` args (else "base constructor arguments
+  given twice" once `ERC7683Implementation` supplies them). `ERC7683Implementation` has the sole
+  `constructor() EIP712("EcoPortal", "1") {}`.
+
+### `abi.encodeCall` overload bridging
+
+`IIntentSource.publishAndFund`/`publishAndFundFor` are overloaded (struct + decomposed forms), and
+`abi.encodeCall`/`.selector` cannot pick between overloads by name. A tiny dedicated NON-overloaded
+interface `IPortalPublishAndFund` (declared in the adapter file, byte-identical decomposed signatures →
+identical selectors) lets `abi.encodeCall` reference each unambiguously. `IInbox.fulfillAndProve` is not
+overloaded, so `abi.encodeCall(IInbox.fulfillAndProve, (...))` is used directly.
+
+## Funding path — one deliberate behaviour change (needs sign-off)
+
+The pre-split `open`/`openFor` funded through `IntentSource._publishAndFund` -> `_fundIntent`, which pulls
+each ERC20 leg via **the PROXY's allowance** (`safeTransferFrom(funder, account)` executed by the Portal).
+There is **no public function** that pulls from an ARBITRARY funder via proxy allowance — and there must not
+be, because that would let anyone drain any address that has approved the proxy. That path is only safe when
+`funder == msg.sender` or the funder is signature-authenticated (openFor). The only public arbitrary-funder
+entry point, `publishAndFundFor`, deliberately pulls via **the per-intent Account's allowance** instead
+(safe: the funder must have approved that specific Account).
+
+So the adapter's `_publishAndFund` branches on `funder == msg.sender`:
+
+- **`open` (funder == msg.sender)** -> delegatecall `publishAndFund` (proxy-allowance). **Behaviour is
+  preserved byte-for-byte** — existing "approve the proxy, then open" integrations and tests are unchanged.
+- **`openFor` with a distinct signed user (funder != msg.sender)** -> delegatecall `publishAndFundFor`
+  (account-allowance, empty permit). This is the ONE unavoidable change: the signed user must approve the
+  (deterministic, pre-computable via `intentAccountAddress`) intent Account rather than the proxy. It cannot
+  be avoided in any lean design without re-introducing the unauthenticated theft vector or re-inheriting
+  IntentSource.
+
+Only `test/OriginSettler.spec.ts`'s `openFor` test needed updating (approve the Account); every `open` test
+is unchanged. **If a uniform account-allowance policy is preferred instead** (route BOTH paths through
+`publishAndFundFor`), drop the `funder == msg.sender` branch and update the `open` tests too — a small delta.
+
+## Storage-layout re-verification
+
+`forge inspect ... storage-layout` (run on all four contracts):
+
+| Contract | `rewardStatuses` slot | EIP712 fallback slots |
+|---|---|---|
+| `Portal` | 0 | — (EIP712 detached from the lean Portal) |
+| `PortalTron` | 0 | — |
+| `ERC7683Implementation` | *(not declared)* | `_nameFallback`=0, `_versionFallback`=1 |
+
+Why the risk that sank the first attempt **dissolves** here:
+
+- In the first attempt BOTH Portal and the adapter declared `rewardStatuses`, so their slots had to match
+  exactly (which forced EIP712 to sit at identical positions in both) — a fragile cross-contract invariant.
+- In this design **only the Portal declares `rewardStatuses`** (the adapter never inherits IntentSource).
+  All `rewardStatuses` reads/writes execute inside the Portal's own bytecode (via the final delegatecall),
+  which computes its own consistent slot 0. The adapter never touches `rewardStatuses`.
+- The adapter's only own slots (0/1) are OZ EIP712's fallback strings, which are **never read or written at
+  runtime**: "EcoPortal"/"1" are short-string immutables in code, and `_buildDomainSeparator` reads the
+  immutable hashes, not storage. So the adapter's bytecode never writes proxy slot 0/1 — it cannot corrupt
+  Portal's `rewardStatuses`. (Same proxy-safe EIP712 mechanism PR9 already relied on.)
+
+Proven at runtime too — see the cross-boundary tests below (state written via one path, read via the other).
+
+## TRON variant — not needed
+
+The lean `ERC7683Implementation` has **no** account-derivation logic: no `AccountDeployer`, no CREATE2, no
+0x41-vs-0xff prefix, no Account cloning, no `_transferToken`. Those are the only TRON-specific concerns, and
+they all live in `PortalTron`/`AccountTron` (which the adapter reaches via the version-resolved delegatecall,
+unchanged). So **one** `ERC7683Implementation` serves BOTH the EVM `Portal` and the TRON `PortalTron` — no
+`ERC7683ImplementationTron`. The deploy script wires the same adapter into both Portal ctors.
+
+## Sizes and optimizer_runs
+
+`optimizer_runs = 1,000,000` (foundry.toml + hardhat.config.ts in lockstep) — restored from PR9's 400.
+
+| Contract | runtime (B) | headroom to 24,576 |
+|---|---|---|
+| `Portal` | 23,564 | 1,012 |
+| `PortalTron` | 23,564 | 1,012 |
+| `ERC7683Implementation` | 10,105 | 14,471 |
+| `PortalProxy` | 3,723 | 20,853 |
+
+The lean adapter is 10,105 B (vs the rejected attempt's 23,892 B). Portal dropped from PR9's 23,469 B to
+18,000 B *at 400 runs*; the reclaimed ~5.5 KB is what lets 1,000,000 runs fit (23,564 B). Headroom is 1,012 B
+— comparable to PR9's own 1,107 B, and it is the highest standard optimizer value. A lower value buys more
+margin if desired, but 1,000,000 is the highest that fits all contracts.
+
+## Gates
+
+- `forge build` — 0 errors.
+- `forge test` — **673 passed / 0 failed** (669 baseline + 4 new).
+- `npx hardhat test` — **112 passed**.
+- `node_modules/.bin/jest` — **46 passed**.
+
+## Tests (`test/core/ERC7683AdapterSplit.t.sol`)
+
+1. `test_open2hop_write_coreRead_funded` — `open()` (2-hop) funds; core `getRewardStatus` (1-hop) reads
+   `Funded` and the escrow lands at the core-derived Account. (7683 write → core read.)
+2. `test_coreWrite_open2hop_readsTerminalStatus` — core `publishAndFund`+`refund` (1-hop) → `Refunded`;
+   a subsequent `open()` (2-hop) reverts `IntentAlreadyExists`. (core write → 7683 read.)
+3. `test_open2hop_fund_coreSettle_roundtrip` — `open()` funds (2-hop), core `settle` (1-hop) pays the
+   claimant out of that escrow and marks `Withdrawn`. (full round trip over one shared storage/escrow.)
+4. `test_fill2hop_pullsSolverOwnTokens_notProxy` — **the msg.sender-preservation proof**: a distinct solver
+   with its own balance + a proxy approval calls `fill()` through the 2-hop path; its OWN tokens are pulled
+   (balance drops by the input), the proxy's balance stays 0, and the call does not revert. This is the test
+   a plain self-CALL design would have failed.

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ out = "out"
 fs_permissions = [{ access = "read-write", path = "./out"}]
 libs = ["lib"]
 optimizer = true
-optimizer_runs = 400
+optimizer_runs = 1000000
 via_ir = true
 retries = 2
 evm_version = "paris"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,11 +19,13 @@ const config: HardhatUserConfig = {
           viaIR: true,
           optimizer: {
             enabled: true,
-            // Kept in lockstep with foundry.toml `optimizer_runs`. PR6 lowered this from 20000 to 1000
-            // so the Portal (which gained the streaming settle/close entry points) stays under the
-            // 24,576 B EIP-170 limit; PR9 lowered it again from 1000 to 400 (the Portal grew with the
-            // per-entry-point `protocolVersion` param + version validation + deployer-sweep branch).
-            // See docs/v3/09-protocol-versioning.md ("Size budget").
+            // Kept in lockstep with foundry.toml `optimizer_runs`. This had been ratcheted DOWN as the
+            // combined Portal grew (PR6: 20000 -> 1000 for the streaming settle/close entry points;
+            // PR9: 1000 -> 400 for the per-entry-point `protocolVersion` param + version validation +
+            // deployer-sweep branch). PR10 RESTORED it to 1,000,000: splitting the ERC-7683 Settlers out
+            // into ERC7683Implementation reclaimed ~5.5 KB of Portal bytecode, so all contracts once again
+            // fit under the 24,576 B EIP-170 limit at the maximum standard setting (Portal 23,564 B).
+            // See docs/v3/10-erc7683-adapter-split.md ("Sizes and optimizer_runs").
             runs: 1000000,
           },
         },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,7 +24,7 @@ const config: HardhatUserConfig = {
             // 24,576 B EIP-170 limit; PR9 lowered it again from 1000 to 400 (the Portal grew with the
             // per-entry-point `protocolVersion` param + version validation + deployer-sweep branch).
             // See docs/v3/09-protocol-versioning.md ("Size budget").
-            runs: 400,
+            runs: 1000000,
           },
         },
       },

--- a/scripts/DeployV3.s.sol
+++ b/scripts/DeployV3.s.sol
@@ -16,6 +16,7 @@ import {AddressConverter} from "../contracts/libs/AddressConverter.sol";
 import {Portal} from "../contracts/Portal.sol";
 import {PortalTron} from "../contracts/tron/PortalTron.sol";
 import {PortalProxy} from "../contracts/PortalProxy.sol";
+import {ERC7683Implementation} from "../contracts/ERC7683/ERC7683Implementation.sol";
 // Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Script-derived
 // contracts.
 import {Account as EcoAccount} from "../contracts/account/Account.sol";
@@ -123,6 +124,7 @@ contract DeployV3 is Script {
     struct Deployment {
         address portal; // the permanent PortalProxy (what everything references as "the Portal")
         address portalImplementation; // the versioned implementation registered as version 1
+        address erc7683Implementation; // the ERC-7683 adapter the Portal falls back to (PR10)
         address runtime;
         address localPolicy;
         address hyperPolicy;
@@ -193,12 +195,26 @@ contract DeployV3 is Script {
         );
         console.log("Account implementation (shared):", accountImplementation);
 
+        // ERC-7683 adapter (PR10): the open/openFor/resolve/resolveFor/fill surface lives OUTSIDE the lean
+        // Portal implementation, which delegatecalls it via {PortalCore-fallback}. It takes NO constructor
+        // args (it holds no version/account state — it resolves + delegatecalls the pinned implementation
+        // per call), and a SINGLE instance serves BOTH the EVM and TRON Portal (no TRON-specific variant).
+        dep.erc7683Implementation = _deployCreate2(
+            type(ERC7683Implementation).creationCode,
+            _contractSalt(cfg.salt, "ERC7683_IMPLEMENTATION"),
+            cfg.isTron
+        );
+        console.log("ERC7683 implementation:", dep.erc7683Implementation);
+
         dep.portalImplementation = _deployCreate2(
             abi.encodePacked(
                 cfg.isTron
                     ? type(PortalTron).creationCode
                     : type(Portal).creationCode,
-                abi.encode(accountImplementation) // shared Account clone template
+                abi.encode(
+                    accountImplementation, // shared Account clone template
+                    dep.erc7683Implementation // ERC-7683 adapter for the fallback
+                )
             ),
             _contractSalt(cfg.salt, "PORTAL_IMPLEMENTATION_V1"),
             cfg.isTron
@@ -521,6 +537,7 @@ contract DeployV3 is Script {
         }
         _writeLine(path, dep.portal, "Portal");
         _writeLine(path, dep.portalImplementation, "PortalImplementation");
+        _writeLine(path, dep.erc7683Implementation, "ERC7683Implementation");
         _writeLine(path, dep.runtime, "MulticallRuntime");
         _writeLine(path, dep.localPolicy, "LocalPolicy");
         _writeLine(path, dep.hyperPolicy, "HyperPolicy");

--- a/scripts/semantic-release/sr-build-package.ts
+++ b/scripts/semantic-release/sr-build-package.ts
@@ -36,6 +36,7 @@ import { zeroAddress } from 'viem'
 export const CONTRACT_TYPES = [
   'Portal',
   'PortalImplementation',
+  'ERC7683Implementation',
   'MulticallRuntime',
   'LocalPolicy',
   'HyperPolicy',

--- a/scripts/semantic-release/tests/sr-build-package.spec.ts
+++ b/scripts/semantic-release/tests/sr-build-package.spec.ts
@@ -150,6 +150,8 @@ describe('Semantic Release Build Package', () => {
       expect(CONTRACT_TYPES).toContain('Portal')
       // PR9: the permanent proxy is "Portal"; the versioned implementation address is also recorded.
       expect(CONTRACT_TYPES).toContain('PortalImplementation')
+      // PR10: the ERC-7683 adapter the Portal falls back to is also recorded.
+      expect(CONTRACT_TYPES).toContain('ERC7683Implementation')
       expect(CONTRACT_TYPES).toContain('MulticallRuntime')
       expect(CONTRACT_TYPES).toContain('HyperPolicy')
       expect(CONTRACT_TYPES).toContain('CCIPPolicy')
@@ -157,7 +159,7 @@ describe('Semantic Release Build Package', () => {
       expect(CONTRACT_TYPES).toContain('VestingPolicy')
       // No pre-rename names remain.
       expect(CONTRACT_TYPES).not.toContain('HyperProver')
-      expect(CONTRACT_TYPES.length).toBe(13)
+      expect(CONTRACT_TYPES.length).toBe(14)
     })
   })
 })

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -11,6 +11,7 @@ import {FakePermit} from "../contracts/test/FakePermit.sol";
 import {TestPolicy} from "../contracts/test/TestPolicy.sol";
 import {Portal} from "../contracts/Portal.sol";
 import {PortalProxy} from "../contracts/PortalProxy.sol";
+import {ERC7683Implementation} from "../contracts/ERC7683/ERC7683Implementation.sol";
 // Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Test-derived
 // contracts, so the contract type is imported under a distinct name.
 import {Account as EcoAccount} from "../contracts/account/Account.sol";
@@ -43,6 +44,7 @@ contract BaseTest is Test {
     PortalProxy internal portalProxy;
     address internal portalImplementation;
     address internal accountImplementation; // shared Account clone template (bound to the proxy)
+    address internal erc7683Implementation; // ERC-7683 adapter the Portal falls back to (PR10)
     IIntentSource internal intentSource; // Interface for Portal
     Inbox internal inbox; // Backward compatibility alias
     TestPolicy internal prover;
@@ -86,7 +88,11 @@ contract BaseTest is Test {
         // registered Portal version derives the same per-intent Account addresses.
         portalProxy = new PortalProxy(deployer);
         EcoAccount accountImpl = new EcoAccount(address(portalProxy));
-        Portal implementation = new Portal(address(accountImpl));
+        erc7683Implementation = address(new ERC7683Implementation());
+        Portal implementation = new Portal(
+            address(accountImpl),
+            erc7683Implementation
+        );
         portalProxy.registerVersion(PROTOCOL_VERSION, address(implementation));
         accountImplementation = address(accountImpl);
         portalImplementation = address(implementation);

--- a/test/DestinationSettler.spec.ts
+++ b/test/DestinationSettler.spec.ts
@@ -63,9 +63,12 @@ describe('Destination Settler Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -100,9 +100,12 @@ describe('HyperPolicy Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -60,9 +60,12 @@ describe('Inbox Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',
@@ -248,9 +251,15 @@ describe('Inbox Test', (): void => {
       const anotherAccountImpl = await (
         await ethers.getContractFactory('Account')
       ).deploy(await anotherPortalProxy.getAddress())
+      const anotherErc7683Impl = await (
+        await ethers.getContractFactory('ERC7683Implementation')
+      ).deploy()
       const anotherPortalImpl = await (
         await ethers.getContractFactory('Portal')
-      ).deploy(await anotherAccountImpl.getAddress())
+      ).deploy(
+        await anotherAccountImpl.getAddress(),
+        await anotherErc7683Impl.getAddress(),
+      )
       await anotherPortalProxy.registerVersion(
         1,
         await anotherPortalImpl.getAddress(),

--- a/test/LayerZeroProver.spec.ts
+++ b/test/LayerZeroProver.spec.ts
@@ -96,9 +96,12 @@ describe('LayerZeroPolicy Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',

--- a/test/MetaProver.spec.ts
+++ b/test/MetaProver.spec.ts
@@ -138,9 +138,12 @@ describe('MetaPolicy Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',

--- a/test/OriginSettler.spec.ts
+++ b/test/OriginSettler.spec.ts
@@ -90,9 +90,12 @@ describe('Origin Settler Test', (): void => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',
@@ -110,8 +113,13 @@ describe('Origin Settler Test', (): void => {
       await ethers.getContractFactory('MulticallRuntime')
     ).deploy()
 
-    // Use portal as the originSettler since OriginSettler is now abstract
-    const originSettler = portal
+    // The ERC-7683 surface (open/openFor/resolve/resolveFor/eip712Domain) is no longer on the lean Portal
+    // ABI — it lives on the ERC7683Implementation adapter the Portal falls back to. Bind `originSettler` to
+    // that ABI AT THE PROXY ADDRESS so calls route proxy -> Portal -> (fallback) -> adapter (2 hops).
+    const originSettler = await ethers.getContractAt(
+      'ERC7683Implementation',
+      await portalProxy.getAddress(),
+    )
 
     // deploy ERC20 test
     const erc20Factory = await ethers.getContractFactory('TestERC20')
@@ -631,15 +639,23 @@ describe('Origin Settler Test', (): void => {
           }),
         ).to.be.false
 
-        // Ensure keeper has enough tokens and approvals for gasless order
+        // Ensure keeper has enough tokens and approvals for gasless order.
+        // openFor is relayed by a DIFFERENT address (otherPerson) than the signed user (keeper), so the
+        // ERC-7683 adapter funds via the per-intent Account's allowance (the only way to safely pull from
+        // an arbitrary funder — a proxy-allowance arbitrary-funder pull would be an unauthenticated theft
+        // vector). So the signed user approves the (deterministic) intent Account, not the proxy. openFor
+        // derives source == block.chainid == sourceChainId, destination == chainId (cross-chain).
         await tokenA.connect(keeper).mint(keeper.address, mintAmount)
         await tokenB.connect(keeper).mint(keeper.address, mintAmount * 2n)
-        await tokenA
-          .connect(keeper)
-          .approve(await originSettler.getAddress(), mintAmount)
-        await tokenB
-          .connect(keeper)
-          .approve(await originSettler.getAddress(), mintAmount * 2n)
+        const openForAccount = await portal.intentAccountAddress({
+          protocolVersion: 1,
+          source: sourceChainId,
+          destination: chainId,
+          route,
+          reward,
+        })
+        await tokenA.connect(keeper).approve(openForAccount, mintAmount)
+        await tokenB.connect(keeper).approve(openForAccount, mintAmount * 2n)
 
         await expect(
           originSettler

--- a/test/TokenSecurityTests.spec.ts
+++ b/test/TokenSecurityTests.spec.ts
@@ -37,9 +37,12 @@ describe('Token Security Tests', () => {
     const accountImpl = await (
       await ethers.getContractFactory('Account')
     ).deploy(await portalProxy.getAddress())
+    const erc7683Impl = await (
+      await ethers.getContractFactory('ERC7683Implementation')
+    ).deploy()
     const portalImpl = await (
       await ethers.getContractFactory('Portal')
-    ).deploy(await accountImpl.getAddress())
+    ).deploy(await accountImpl.getAddress(), await erc7683Impl.getAddress())
     await portalProxy.registerVersion(1, await portalImpl.getAddress())
     const portal = await ethers.getContractAt(
       'Portal',

--- a/test/core/ERC7683AdapterSplit.t.sol
+++ b/test/core/ERC7683AdapterSplit.t.sol
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "../BaseTest.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
+import {IDestinationSettler} from "../../contracts/interfaces/ERC7683/IDestinationSettler.sol";
+import {OnchainCrossChainOrder, OrderData, Output, ORDER_DATA_TYPEHASH} from "../../contracts/types/ERC7683.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+
+/**
+ * @title ERC7683AdapterSplitTest
+ * @notice Proves the PR10 split is behaviourally transparent: the ERC-7683 surface, now reached via the
+ *         TWO-hop path (proxy -> lean Portal -> {PortalCore-fallback} -> {ERC7683Implementation} ->
+ *         delegatecall the pinned implementation), shares ONE consistent view of the proxy's storage and
+ *         escrow with the direct one-hop core path — AND that `msg.sender` is preserved end-to-end so a
+ *         solver's OWN tokens are pulled on the fill path (the bug the naive self-CALL design would have
+ *         introduced).
+ * @dev The default {BaseTest} intent is same-chain (source == destination == CHAIN_ID), so `open()` (which
+ *      commits source == block.chainid) and the direct core calls derive the SAME intent hash.
+ */
+contract ERC7683AdapterSplitTest is BaseTest {
+    function setUp() public override {
+        super.setUp();
+        _mintAndApprove(keeper, MINT_AMOUNT); // keeper approves the PROXY (default core funding path)
+    }
+
+    /// @dev Builds the ERC-7683 on-chain order that maps to the default same-chain intent.
+    function _order() internal view returns (OnchainCrossChainOrder memory) {
+        OrderData memory od = OrderData({
+            protocolVersion: PROTOCOL_VERSION,
+            destination: CHAIN_ID,
+            route: abi.encode(route),
+            reward: reward,
+            routePortal: bytes32(uint256(uint160(address(portal)))),
+            routeDeadline: uint64(expiry),
+            maxSpent: new Output[](0)
+        });
+        return
+            OnchainCrossChainOrder({
+                fillDeadline: uint32(expiry),
+                orderDataType: ORDER_DATA_TYPEHASH,
+                orderData: abi.encode(od)
+            });
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Cross-boundary storage/escrow sharing
+    // -----------------------------------------------------------------------------------------------
+
+    /// @notice ERC-7683 `open()` (2-hop) WRITES funded state that the direct core `getRewardStatus`/escrow
+    ///         (1-hop) READS — proving both paths see the same proxy storage + the same per-intent Account.
+    function test_open2hop_write_coreRead_funded() public {
+        bytes32 intentHash = _hashIntent(intent);
+        address account = intentSource.intentAccountAddress(intent);
+
+        assertTrue(
+            intentSource.getRewardStatus(intentHash) ==
+                IIntentSource.Status.Initial
+        );
+
+        vm.prank(keeper);
+        ERC7683Implementation(address(portal)).open(_order());
+
+        // Core (1-hop) read sees what the 7683 (2-hop) path wrote.
+        assertTrue(
+            intentSource.getRewardStatus(intentHash) ==
+                IIntentSource.Status.Funded
+        );
+        // Escrow landed at the SAME core-derived Account.
+        assertEq(tokenA.balanceOf(account), MINT_AMOUNT);
+        assertEq(tokenB.balanceOf(account), MINT_AMOUNT * 2);
+    }
+
+    /// @notice The direct core path (1-hop) WRITES terminal (Refunded) state that the ERC-7683 `open()`
+    ///         (2-hop) READS — a second open reverts {IntentAlreadyExists}, proving the shared view.
+    function test_coreWrite_open2hop_readsTerminalStatus() public {
+        _publishAndFund(intent, false); // core, 1-hop -> Funded
+        bytes32 intentHash = _hashIntent(intent);
+
+        _timeTravel(expiry + 1); // past the reward deadline so the refund is allowed
+        intentSource.refund(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            CHAIN_ID,
+            keccak256(abi.encode(route)),
+            reward
+        );
+        assertTrue(
+            intentSource.getRewardStatus(intentHash) ==
+                IIntentSource.Status.Refunded
+        );
+
+        // The 2-hop open reads the same Refunded status and refuses to re-create the intent.
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.IntentAlreadyExists.selector,
+                intentHash
+            )
+        );
+        ERC7683Implementation(address(portal)).open(_order());
+    }
+
+    /// @notice Full round trip: fund via ERC-7683 `open()` (2-hop), settle via the direct core path
+    ///         (1-hop). The core settle pays the claimant out of the escrow the 7683 path funded.
+    function test_open2hop_fund_coreSettle_roundtrip() public {
+        bytes32 intentHash = _hashIntent(intent);
+
+        vm.prank(keeper);
+        ERC7683Implementation(address(portal)).open(_order()); // 2-hop fund
+
+        _addProof(intentHash, CHAIN_ID, claimant); // record a proven same-chain fulfillment
+
+        uint256 claimantBefore = tokenA.balanceOf(claimant);
+        _settle(CHAIN_ID, CHAIN_ID, keccak256(abi.encode(route)), reward, claimant); // 1-hop settle
+
+        assertTrue(
+            intentSource.getRewardStatus(intentHash) ==
+                IIntentSource.Status.Withdrawn
+        );
+        assertEq(tokenA.balanceOf(claimant), claimantBefore + MINT_AMOUNT);
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // msg.sender preservation on the fill path (the reason a plain self-CALL would be WRONG)
+    // -----------------------------------------------------------------------------------------------
+
+    /// @notice A distinct solver that calls `fill()` through the 2-hop ERC-7683 path has ITS OWN tokens
+    ///         pulled (via {Inbox._fulfill}'s `safeTransferFrom(msg.sender, ...)`), NOT the proxy's.
+    /// @dev If the adapter used a plain self-CALL (resetting `msg.sender` to the proxy) instead of a
+    ///      `delegatecall`, the ERC20 pull would target the proxy — which holds no balance and grants no
+    ///      allowance — and revert. This test proves the delegatecall preserves `msg.sender`: the solver's
+    ///      balance drops, the proxy's stays zero, and the call does NOT revert.
+    function test_fill2hop_pullsSolverOwnTokens_notProxy() public {
+        address solver = makeAddr("erc7683Solver");
+
+        // The solver has its own input and approves the PROXY (the transferFrom is executed by the Portal,
+        // i.e. address(this) == proxy, so the allowance is granted to the proxy). The proxy itself holds
+        // NOTHING and grants NOTHING — if the pull were wrongly targeted at the proxy it would revert.
+        vm.startPrank(solver);
+        tokenA.mint(solver, MINT_AMOUNT);
+        tokenA.approve(address(portal), MINT_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(tokenA.balanceOf(address(portal)), 0, "proxy holds no input");
+
+        bytes memory originData = abi.encode(
+            PROTOCOL_VERSION,
+            CHAIN_ID, // source (same-chain default)
+            abi.encode(route),
+            reward
+        );
+        bytes memory fillerData = abi.encode(
+            address(prover),
+            CHAIN_ID, // sourceChainDomainID (unused by TestPolicy)
+            bytes32(uint256(uint160(solver))), // claimant
+            _defaultFulfilled(), // providedAmounts == [MINT_AMOUNT]
+            bytes("") // prover data
+        );
+
+        uint256 solverBefore = tokenA.balanceOf(solver);
+        uint256 keeperBefore = tokenA.balanceOf(keeper);
+
+        // fill() through the proxy: proxy -> Portal -> fallback -> ERC7683Implementation.fill ->
+        // fulfillAndProve override -> delegatecall Inbox.fulfillAndProve. msg.sender stays `solver`.
+        vm.prank(solver);
+        ERC7683Implementation(address(portal)).fill(
+            keccak256("orderId"),
+            originData,
+            fillerData
+        );
+
+        // The solver's OWN tokens were pulled (not the proxy's, which never held or approved anything).
+        assertEq(
+            tokenA.balanceOf(solver),
+            solverBefore - MINT_AMOUNT,
+            "solver's own input was pulled"
+        );
+        assertEq(
+            tokenA.balanceOf(address(portal)),
+            0,
+            "proxy never held solver input"
+        );
+        // The keeper-committed runtime ran in the Account and delivered the input to the keeper.
+        assertEq(
+            tokenA.balanceOf(keeper),
+            keeperBefore + MINT_AMOUNT,
+            "runtime executed inside the Account"
+        );
+    }
+}

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {BaseTest} from "../BaseTest.sol";
 import {IInbox} from "../../contracts/interfaces/IInbox.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
@@ -47,7 +48,7 @@ contract InboxTest is BaseTest {
         vm.chainId(validChainId);
 
         // This should not revert
-        Portal newPortal = new Portal(address(new EcoAccount(address(this))));
+        Portal newPortal = new Portal(address(new EcoAccount(address(this))), address(new ERC7683Implementation()));
         assertTrue(address(newPortal) != address(0));
     }
 

--- a/test/core/ProtocolVersioning.t.sol
+++ b/test/core/ProtocolVersioning.t.sol
@@ -7,6 +7,7 @@ import {IInbox} from "../../contracts/interfaces/IInbox.sol";
 import {IPortalProxy, VERSION_EXPIRY} from "../../contracts/interfaces/IPortalProxy.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {Intent, Reward, RewardToken} from "../../contracts/types/Intent.sol";
 import {Call} from "../../contracts/interfaces/IRuntime.sol";
 
@@ -162,7 +163,7 @@ contract ProtocolVersioningTest is BaseTest {
         address addrV1 = portal.accountAddress(hash, x.source);
 
         // A genuinely different Portal implementation, sharing the same Account clone template.
-        Portal impl2 = new Portal(accountImplementation);
+        Portal impl2 = new Portal(accountImplementation, address(new ERC7683Implementation()));
         assertTrue(
             address(impl2) != portalImplementation,
             "impl2 must differ from v1"

--- a/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
@@ -7,6 +7,7 @@ import {DepositFactory_CCTPMint_Arc} from "../../contracts/deposit/DepositFactor
 import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddress_CCTPMint_Arc.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
@@ -43,7 +44,7 @@ contract DepositAddress_CCTPMint_ArcTest is Test {
         token = new TestERC20("Test USDC", "USDC");
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -7,6 +7,7 @@ import {DepositFactory_CCTPMint_GatewayERC20} from "../../contracts/deposit/Depo
 import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/DepositAddress_CCTPMint_GatewayERC20.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Intent, Route, Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
@@ -43,7 +44,7 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
         token = new TestERC20("Test USDC", "USDC");
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
@@ -7,6 +7,7 @@ import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Reward, TokenAmount} from "../../contracts/types/Intent.sol";
@@ -39,7 +40,7 @@ contract DepositAddressTest is Test {
         // Deploy Portal
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
@@ -7,6 +7,7 @@ import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddres
 import {BaseDepositFactory} from "../../contracts/deposit/BaseDepositFactory.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
@@ -34,7 +35,7 @@ contract DepositFactory_CCTPMint_ArcTest is Test {
     function setUp() public {
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
@@ -7,6 +7,7 @@ import {DepositAddress_CCTPMint_GatewayERC20} from "../../contracts/deposit/Depo
 import {BaseDepositFactory} from "../../contracts/deposit/BaseDepositFactory.sol";
 import {BaseDepositAddress} from "../../contracts/deposit/BaseDepositAddress.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
@@ -35,7 +36,7 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
     function setUp() public {
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 
@@ -33,7 +34,7 @@ contract DepositFactoryTest is Test {
         // Deploy Portal
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositIntegration_CCTPMint.t.sol
+++ b/test/deposit/DepositIntegration_CCTPMint.t.sol
@@ -6,6 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DepositFactory_CCTPMint_Arc} from "../../contracts/deposit/DepositFactory_CCTPMint_Arc.sol";
 import {DepositAddress_CCTPMint_Arc} from "../../contracts/deposit/DepositAddress_CCTPMint_Arc.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {LocalPolicy} from "../../contracts/prover/LocalPolicy.sol";
@@ -85,7 +86,7 @@ contract DepositIntegration_CCTPMintTest is Test {
         // Deploy Portal
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
@@ -6,6 +6,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {DepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/DepositFactory_USDCTransfer_Solana.sol";
 import {DepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/DepositAddress_USDCTransfer_Solana.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {Reward, RewardToken, TokenAmount} from "../../contracts/types/Intent.sol";
@@ -55,7 +56,7 @@ contract DepositIntegration_USDCTransfer_SolanaTest is Test {
         // Deploy Portal
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
 

--- a/test/interfaces/OriginSettler.t.sol
+++ b/test/interfaces/OriginSettler.t.sol
@@ -5,6 +5,7 @@ import "../BaseTest.sol";
 import {IOriginSettler} from "../../contracts/interfaces/ERC7683/IOriginSettler.sol";
 import {OnchainCrossChainOrder, GaslessCrossChainOrder, ResolvedCrossChainOrder, Output, FillInstruction} from "../../contracts/types/ERC7683.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {OriginSettler} from "../../contracts/ERC7683/OriginSettler.sol";
 
@@ -196,24 +197,24 @@ contract OriginSettlerTest is BaseTest {
 
     function testDomainSeparatorV4() public {
         // Test that the Portal's domainSeparatorV4 returns the correct EIP-712 domain separator
-        bytes32 domainSeparator = portal.domainSeparatorV4();
+        bytes32 domainSeparator = ERC7683Implementation(address(portal)).domainSeparatorV4();
 
         // Verify domain separator is not zero (basic sanity check)
         assertNotEq(domainSeparator, bytes32(0));
 
         // The domain separator should be deterministic for the same contract
         // Call it again to ensure consistency
-        bytes32 domainSeparator2 = portal.domainSeparatorV4();
+        bytes32 domainSeparator2 = ERC7683Implementation(address(portal)).domainSeparatorV4();
         assertEq(domainSeparator, domainSeparator2);
 
         // The domain separator should be unique to this contract instance
         // Deploy another Portal and verify they have different domain separators
         PortalProxy _proxy2 = new PortalProxy(address(this));
         EcoAccount _acct2 = new EcoAccount(address(_proxy2));
-        Portal _impl2 = new Portal(address(_acct2));
+        Portal _impl2 = new Portal(address(_acct2), address(new ERC7683Implementation()));
         _proxy2.registerVersion(1, address(_impl2));
         Portal portal2 = Portal(payable(address(_proxy2)));
-        bytes32 domainSeparator3 = portal2.domainSeparatorV4();
+        bytes32 domainSeparator3 = ERC7683Implementation(address(portal2)).domainSeparatorV4();
 
         // Domain separators should be different due to different contract addresses
         assertNotEq(domainSeparator, domainSeparator3);
@@ -221,7 +222,7 @@ contract OriginSettlerTest is BaseTest {
 
     function testDomainSeparatorV4Structure() public view {
         // Test that the domain separator follows EIP-712 structure
-        bytes32 domainSeparator = portal.domainSeparatorV4();
+        bytes32 domainSeparator = ERC7683Implementation(address(portal)).domainSeparatorV4();
 
         // Calculate expected domain separator manually
         bytes32 typeHash = keccak256(
@@ -248,16 +249,16 @@ contract OriginSettlerTest is BaseTest {
 
     function testDomainSeparatorV4ChainDependency() public {
         // Test that domain separator is dependent on chain ID by deploying on different chains
-        bytes32 domainSeparator1 = portal.domainSeparatorV4();
+        bytes32 domainSeparator1 = ERC7683Implementation(address(portal)).domainSeparatorV4();
 
         // Deploy a new Portal on a different chain ID
         vm.chainId(999);
         PortalProxy _proxyDiff = new PortalProxy(address(this));
         EcoAccount _acctDiff = new EcoAccount(address(_proxyDiff));
-        Portal _implDiff = new Portal(address(_acctDiff));
+        Portal _implDiff = new Portal(address(_acctDiff), address(new ERC7683Implementation()));
         _proxyDiff.registerVersion(1, address(_implDiff));
         Portal portalDifferentChain = Portal(payable(address(_proxyDiff)));
-        bytes32 domainSeparator2 = portalDifferentChain.domainSeparatorV4();
+        bytes32 domainSeparator2 = ERC7683Implementation(address(portalDifferentChain)).domainSeparatorV4();
 
         // Domain separators should be different on different chains
         assertNotEq(domainSeparator1, domainSeparator2);
@@ -266,10 +267,10 @@ contract OriginSettlerTest is BaseTest {
         vm.chainId(1);
         PortalProxy _proxySame = new PortalProxy(address(this));
         EcoAccount _acctSame = new EcoAccount(address(_proxySame));
-        Portal _implSame = new Portal(address(_acctSame));
+        Portal _implSame = new Portal(address(_acctSame), address(new ERC7683Implementation()));
         _proxySame.registerVersion(1, address(_implSame));
         Portal portalSameChain = Portal(payable(address(_proxySame)));
-        bytes32 domainSeparator3 = portalSameChain.domainSeparatorV4();
+        bytes32 domainSeparator3 = ERC7683Implementation(address(portalSameChain)).domainSeparatorV4();
 
         // Domain separator should be different from the first portal due to different addresses
         // but should follow the same calculation pattern for the same chain

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {Test} from "forge-std/Test.sol";
 import {LocalPolicy} from "../../contracts/prover/LocalPolicy.sol";
 import {Portal} from "../../contracts/Portal.sol";
+import {ERC7683Implementation} from "../../contracts/ERC7683/ERC7683Implementation.sol";
 import {PortalProxy} from "../../contracts/PortalProxy.sol";
 import {Account as EcoAccount} from "../../contracts/account/Account.sol";
 import {TestPolicy} from "../../contracts/test/TestPolicy.sol";
@@ -49,7 +50,7 @@ contract LocalProverTest is Test {
         // Deploy contracts (Portal behind a versioned PortalProxy, registered as version 1)
         PortalProxy _proxy = new PortalProxy(address(this));
         EcoAccount _acct = new EcoAccount(address(_proxy));
-        Portal _impl = new Portal(address(_acct));
+        Portal _impl = new Portal(address(_acct), address(new ERC7683Implementation()));
         _proxy.registerVersion(1, address(_impl));
         portal = Portal(payable(address(_proxy)));
         localProver = new LocalPolicy(address(portal));

--- a/test/v3/deploy/DeployV3.t.sol
+++ b/test/v3/deploy/DeployV3.t.sol
@@ -10,6 +10,7 @@ import {AddressConverter} from "../../../contracts/libs/AddressConverter.sol";
 
 import {Portal} from "../../../contracts/Portal.sol";
 import {PortalProxy} from "../../../contracts/PortalProxy.sol";
+import {ERC7683Implementation} from "../../../contracts/ERC7683/ERC7683Implementation.sol";
 // Aliased: forge-std's StdCheats defines a `struct Account` that shadows this import in Test contracts.
 import {Account as EcoAccount} from "../../../contracts/account/Account.sol";
 import {MulticallRuntime} from "../../../contracts/runtime/MulticallRuntime.sol";
@@ -159,13 +160,24 @@ contract DeployV3Test is Test {
             ),
             _contractSalt(SALT, "ACCOUNT_IMPLEMENTATION")
         );
-        // The version-1 Portal implementation references the shared Account implementation.
+        // The ERC-7683 adapter (PR10) is deployed at a derived salt with no constructor args.
+        address erc7683Impl = _predictCreate2(
+            type(ERC7683Implementation).creationCode,
+            _contractSalt(SALT, "ERC7683_IMPLEMENTATION")
+        );
+        assertEq(
+            dep.erc7683Implementation,
+            erc7683Impl,
+            "erc7683 implementation CREATE2"
+        );
+        // The version-1 Portal implementation references the shared Account implementation AND the ERC-7683
+        // adapter (its fallback target).
         assertEq(
             dep.portalImplementation,
             _predictCreate2(
                 abi.encodePacked(
                     type(Portal).creationCode,
-                    abi.encode(accountImpl)
+                    abi.encode(accountImpl, erc7683Impl)
                 ),
                 _contractSalt(SALT, "PORTAL_IMPLEMENTATION_V1")
             ),


### PR DESCRIPTION
## Summary

Splits the ERC-7683 surface (`open`/`openFor`/`resolve`/`resolveFor`/`fill` + EIP-712 helpers) out of the combined Portal implementation into a separate `ERC7683Implementation` contract that the Portal falls back to via `delegatecall`. PR9's protocol-versioning proxy had eroded `optimizer_runs` to 400 (main uses 1,000,000) because the combined Portal was bytecode-bound; this restores **`optimizer_runs = 1,000,000`**.

Stacked on #404 (v3/09-protocol-versioning).

## Design

- `ERC7683Implementation` inherits **only** `OriginSettler, DestinationSettler` — not `IntentSource`/`Inbox`/`AccountDeployer`/`Semver`. It carries no business logic of its own.
- Its two abstract Settler hooks (`_publishAndFund`, `fulfillAndProve`) resolve the pinned Portal implementation for the call's `protocolVersion` via a harmless view self-read of the proxy's own registry (`IPortalProxy(address(this)).versions(pv)`), then `delegatecall` **directly** into it.
- `delegatecall` (never a plain `CALL`) is load-bearing: `Inbox._fulfill` pulls the solver's ERC20 input with `safeTransferFrom(msg.sender, account, provided)` — hardcoded to `msg.sender`, no explicit-provider param. A plain self-call would reset `msg.sender` to the proxy and silently break every `fill()`. This was caught by direct code review before implementation, not after.
- `abi.encodeCall` can't reference the overloaded `IIntentSource.publishAndFund`/`publishAndFundFor` by name, so a small dedicated non-overloaded interface (`IPortalPublishAndFund`, byte-identical decomposed signatures → identical selectors) bridges the call.
- One deliberate, unavoidable behavior change: `open()` keeps delegatecalling `publishAndFund` (proxy-allowance, byte-for-byte unchanged). A gasless `openFor` relayed by someone other than the signed user now goes through `publishAndFundFor` (account-allowance) instead — there is no safe way to pull from an arbitrary funder via the proxy's allowance. Only `openFor`'s approval target changes (signed user approves the deterministic intent Account instead of the proxy); `open()` is untouched.
- No TRON-specific variant needed — the adapter has no account-derivation logic, so one `ERC7683Implementation` serves both `Portal` and `PortalTron`.

Full design writeup, including why an earlier (rejected) attempt that re-inherited `IntentSource`+`Inbox` into the adapter was wasteful and worse for size: `docs/v3/10-erc7683-adapter-split.md`.

## Sizes

| Contract | runtime (B) | headroom to 24,576 |
|---|---|---|
| `Portal` | 23,564 | 1,012 |
| `PortalTron` | 23,564 | 1,012 |
| `ERC7683Implementation` | 10,105 | 14,471 |
| `PortalProxy` | 3,723 | 20,853 |

## Test plan

- [x] `forge test` — 673 passed / 0 failed (669 baseline + 4 new)
- [x] `npx hardhat test` — 112 passed
- [x] `node_modules/.bin/jest` — 46 passed
- [x] `forge inspect <contract> storage-layout` re-verified by hand for `Portal`, `PortalTron`, `ERC7683Implementation`, `PortalProxy`
- [x] New `test/core/ERC7683AdapterSplit.t.sol`: 3 cross-boundary storage/escrow-sharing tests (2-hop write / 1-hop read and vice versa, full round trip) + `test_fill2hop_pullsSolverOwnTokens_notProxy`, which proves a distinct solver's own tokens are pulled through the 2-hop `fill()` path (not the proxy's) — the exact property a plain self-call design would have violated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4pnnevHt2zFJwDqPyJreT