### PR TITLE
v3 PR12 — standing deposit-address streaming (deposit-template migration)

### DIFF
--- a/contracts/deposit/StandingDepositAddress.sol
+++ b/contracts/deposit/StandingDepositAddress.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {IIntentSource} from "../interfaces/IIntentSource.sol";
+
+/**
+ * @title StandingDepositAddress
+ * @notice Thin base for the STANDING (streaming/flash) deposit-address templates: ONE standing intent per
+ *         deposit address, drawn down per deposit rather than a FRESH one-shot intent per deposit.
+ * @dev A deliberately separate base from {BaseDepositAddress} (which the three immutable one-shot templates
+ *      inherit and which is NOT modified here — deposit clones are immutable CREATE2, so migration ships
+ *      NEW templates). It captures ONLY the cross-family common surface: init, the direct-transfer top-up
+ *      (`sweep`/`fundPool`), the pool-account view, the salt-epoch scheme, and the keeper `reopen`.
+ *
+ *      TOP-UP MECHANIC: once the standing intent is `Funded`, {IIntentSource-fund} is a silent no-op
+ *      (`onlyFundable`), so a per-deposit top-up MUST be a DIRECT TRANSFER into the escrow pool Account.
+ *      Users send tokens to this stable clone (their CEX-withdrawal address); `sweep`/`fundPool` moves the
+ *      clone's whole balance into the CURRENT-epoch pool Account. Draw-down is solver/operator-driven off
+ *      this contract (the flash policy's `flashSlice` / the streaming policy's settle path).
+ *
+ *      SALT-EPOCH: the standing intent's route salt is `keccak256(abi.encode(address(this), epoch))`
+ *      (deterministic — no `block.timestamp`, so the hash and pool address are stable and collision-free).
+ *      Because {IIntentSource-closeStream} is terminal (`Refunded`) and a `Refunded` hash can never be
+ *      re-published, a keeper `reopen` (bump `epoch`) is the only restart path.
+ */
+abstract contract StandingDepositAddress is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ============ Storage ============
+
+    /// @notice User's destination address on the target chain (bytes32 for cross-VM compatibility).
+    bytes32 public destinationAddress;
+
+    /// @notice Depositor on the source chain: the keeper (refunds via closeStream, reopen authority).
+    address public depositor;
+
+    /// @notice Initialization flag.
+    bool public initialized;
+
+    /// @notice Current salt epoch. Bumped by {reopen} after the prior epoch's streams are terminal.
+    uint256 public epoch;
+
+    // ============ Errors ============
+
+    error AlreadyInitialized();
+    error NotInitialized();
+    error OnlyFactory();
+    error InvalidDestinationAddress();
+    error InvalidDepositor();
+    error InvalidFunder();
+    error NotKeeper();
+    /// @notice `reopen` attempted while a current-epoch (source-chain) intent is not yet `Refunded`.
+    error EpochNotClosed(bytes32 intentHash);
+
+    // ============ Init ============
+
+    /**
+     * @notice Initialize the deposit address (called once by the factory after CREATE2 deployment).
+     * @param _destinationAddress User's destination address (bytes32 for cross-VM compatibility).
+     * @param _depositor Keeper/refund recipient on the source chain.
+     */
+    function initialize(
+        bytes32 _destinationAddress,
+        address _depositor
+    ) external {
+        if (initialized) revert AlreadyInitialized();
+        if (msg.sender != _factory()) revert OnlyFactory();
+        if (_destinationAddress == bytes32(0)) {
+            revert InvalidDestinationAddress();
+        }
+        if (_depositor == address(0)) revert InvalidDepositor();
+
+        destinationAddress = _destinationAddress;
+        depositor = _depositor;
+        initialized = true;
+    }
+
+    // ============ Top-up (direct transfer) ============
+
+    /**
+     * @notice Permissionless top-up: move the clone's ENTIRE source-token balance into the current-epoch
+     *         pool Account by direct transfer (the only working top-up for a `Funded` standing intent).
+     */
+    function sweep() external nonReentrant {
+        _sweep();
+    }
+
+    /// @notice Alias of {sweep} (funding vocabulary).
+    function fundPool() external nonReentrant {
+        _sweep();
+    }
+
+    /**
+     * @notice Top-up funded via ERC-20 approval: pull `min(allowance, balance)` from `funder` into the
+     *         clone, then sweep the whole balance into the pool Account (preserves the one-shot templates'
+     *         `createIntentWithApproval` semantics).
+     * @param funder Address that approved this contract to spend its tokens.
+     */
+    function fundPoolWithApproval(address funder) external nonReentrant {
+        if (!initialized) revert NotInitialized();
+        if (funder == address(0)) revert InvalidFunder();
+
+        address token = _sourceToken();
+        uint256 allowance = IERC20(token).allowance(funder, address(this));
+        uint256 balance = IERC20(token).balanceOf(funder);
+        uint256 amount = allowance < balance ? allowance : balance;
+        if (amount > 0) {
+            IERC20(token).safeTransferFrom(funder, address(this), amount);
+        }
+        _sweep();
+    }
+
+    /// @notice The current-epoch pool Account that deposits are swept into (the source escrow Account).
+    function poolAccount() external view returns (address) {
+        return _depositPoolAccount();
+    }
+
+    // ============ Epoch lifecycle ============
+
+    /**
+     * @notice Rotate to a fresh epoch after the current epoch's (source-chain) standing intents are
+     *         terminal, then re-open the streams under the new salt.
+     * @dev Keeper-only (`depositor`). Requires every hash returned by {_currentEpochIntentHashes} — the
+     *      intents whose escrow is reclaimable ON THIS chain — to be `Refunded` (i.e. the keeper has run
+     *      the source-side {IIntentSource-closeStream}). Cross-chain legs (e.g. a destination-chain pool)
+     *      are reclaimed separately on their own chain and are NOT gated here (their status is not readable
+     *      on this chain — see the template docs).
+     */
+    function reopen() external nonReentrant {
+        if (!initialized) revert NotInitialized();
+        if (msg.sender != depositor) revert NotKeeper();
+
+        IIntentSource src = IIntentSource(_portalAddress());
+        bytes32[] memory hashes = _currentEpochIntentHashes();
+        for (uint256 i; i < hashes.length; ++i) {
+            if (src.getRewardStatus(hashes[i]) != IIntentSource.Status.Refunded) {
+                revert EpochNotClosed(hashes[i]);
+            }
+        }
+
+        unchecked {
+            epoch += 1;
+        }
+        _open();
+    }
+
+    // ============ Internal ============
+
+    /// @notice Uniform deterministic salt for the current epoch's route(s).
+    function _saltForEpoch() internal view returns (bytes32) {
+        return keccak256(abi.encode(address(this), epoch));
+    }
+
+    function _sweep() internal {
+        if (!initialized) revert NotInitialized();
+        address token = _sourceToken();
+        uint256 bal = IERC20(token).balanceOf(address(this));
+        if (bal > 0) {
+            IERC20(token).safeTransfer(_depositPoolAccount(), bal);
+        }
+    }
+
+    // ---- Family hooks ----------------------------------------------------
+
+    /// @notice Factory that deployed this clone (init authority).
+    function _factory() internal view virtual returns (address);
+
+    /// @notice The Portal (PortalProxy) this family's intents anchor to.
+    function _portalAddress() internal view virtual returns (address);
+
+    /// @notice The source token users deposit (swept into the pool).
+    function _sourceToken() internal view virtual returns (address);
+
+    /// @notice The current-epoch pool Account deposits are swept into.
+    function _depositPoolAccount() internal view virtual returns (address);
+
+    /// @notice The current-epoch intent hashes whose escrow is reclaimable on THIS chain (gate for reopen).
+    function _currentEpochIntentHashes()
+        internal
+        view
+        virtual
+        returns (bytes32[] memory);
+
+    /// @notice (Re)publish/fund the current-epoch standing intent(s). Idempotent.
+    function _open() internal virtual;
+}

--- a/contracts/deposit/StandingDepositAddress_CCTPMint.sol
+++ b/contracts/deposit/StandingDepositAddress_CCTPMint.sol
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {StandingDepositAddress} from "./StandingDepositAddress.sol";
+import {IIntentSource} from "../interfaces/IIntentSource.sol";
+import {Intent, Route, Reward, RewardToken, TokenAmount, IntentLib} from "../types/Intent.sol";
+
+/**
+ * @title IStandingCCTPFactory
+ * @notice Config surface both CCTP standing factories (Arc + GatewayERC20) expose to the shared template.
+ * @dev Read as individual immutable getters (avoids a 16-field `getConfiguration` tuple / stack-too-deep).
+ */
+interface IStandingCCTPFactory {
+    function SOURCE_TOKEN() external view returns (address);
+
+    function PORTAL_ADDRESS() external view returns (address);
+
+    function PROTOCOL_VERSION() external view returns (uint32);
+
+    function STREAMING_FLASH_POLICY() external view returns (address);
+
+    function CCTP_BURN_RUNTIME() external view returns (address);
+
+    function GATEWAY_DEPOSIT_RUNTIME() external view returns (address);
+
+    function DESTINATION_CHAIN_ID() external view returns (uint64);
+
+    function DESTINATION_DOMAIN() external view returns (uint32);
+
+    function CCTP_TOKEN_MESSENGER() external view returns (address);
+
+    function DEST_USDC() external view returns (address);
+
+    function GATEWAY_ADDRESS() external view returns (address);
+
+    function RATE_1() external view returns (uint256);
+
+    function RATE_2() external view returns (uint256);
+
+    function MIN_SLICE_1() external view returns (uint256);
+
+    function MIN_SLICE_2() external view returns (uint256);
+
+    function MAX_FEE_BPS() external view returns (uint256);
+}
+
+/**
+ * @title StandingDepositAddress_CCTPMint
+ * @notice STANDING two-pool deposit template for CCTP + Gateway deposits, shared by BOTH the Arc and the
+ *         GatewayERC20 families (the only differences are factory config: token addresses, chain ids, and
+ *         the reward-leg rates).
+ * @dev Migrates the one-shot "publish+fund a FRESH intent per deposit" model onto TWO STANDING
+ *      {StreamingFlashPolicy} pools:
+ *
+ *        INTENT 1 (CCTP burn) — a same-chain pool on the SOURCE chain (`source == destination ==
+ *        block.chainid`). Its runtime is {CCTPBurnRuntime}; the payload commits `bytes32(account2)` as the
+ *        CCTP `mintRecipient`. Rate-only reward leg on the source USDC => `publishAndFund` marks it
+ *        `Funded` with ZERO token pull. Deposits are swept into its escrow Account and drawn down by
+ *        solver-driven `flashSlice` in DIRECT mode (reward token == input token == USDC, zero solver
+ *        capital); the slice is burned via CCTP to `account2` and the margin (the rate spread, if any) is
+ *        the solver/protocol fee.
+ *
+ *        INTENT 2 (Gateway deposit) — a same-chain pool on the DESTINATION chain (`source == destination ==
+ *        DESTINATION_CHAIN_ID`). This is the FIX for the one-shot templates' latent bug, which committed
+ *        `source = block.chainid` while the CCTP mint (its escrow) lands on the destination — every
+ *        source-side settle op is `onlySourceChain(source)` and could never run where the mint is (masked
+ *        in tests only by forcing the two chain ids equal). Its runtime is {GatewayDepositRuntime}; the
+ *        rate is `WAD` (the user receives the full CCTP net). The source clone `publish`es it (ungated) for
+ *        discovery and to pin `account2`; it is actually driven by `flashSlice` on the destination chain.
+ *
+ *      account2 is STABLE (its hash has no timestamp), so intent 1 can bake a fixed `mintRecipient` with no
+ *      circularity. Fees are ONLY the reward-leg rate spread (`rate >= WAD`), never a payload fee — payloads
+ *      commit CONFIG ONLY. The keeper exit is {IIntentSource-closeStream} per pool; deadlines are
+ *      `type(uint64).max` so the permissionless post-deadline refund can never terminate a pool.
+ *
+ *      CROSS-CHAIN CAVEAT: intent 2's escrow (the CCTP mint) lives on the destination chain, so its
+ *      `closeStream`, its status, and its dust-reclaim are all destination-chain keeper actions. {reopen}'s
+ *      gate therefore only checks intent 1 (the source pool) — intent 2's destination-side `Refunded`
+ *      status is not readable here. Rotate epochs only after in-flight CCTP has drained (a late mint under
+ *      a rotated-away epoch lands at a now-terminal account2, recoverable only via destination
+ *      `recoverToken`).
+ */
+contract StandingDepositAddress_CCTPMint is StandingDepositAddress {
+    // ============ Immutables ============
+
+    IStandingCCTPFactory internal immutable FACTORY;
+
+    // ============ Storage ============
+
+    /// @notice Whether the streams for a given epoch have been published/funded (idempotency hint).
+    mapping(uint256 => bool) public opened;
+
+    // ============ Constructor ============
+
+    constructor() {
+        FACTORY = IStandingCCTPFactory(msg.sender);
+    }
+
+    // ============ External ============
+
+    /**
+     * @notice Publish + fund both standing pools for the current epoch (permissionless, idempotent).
+     * @return account1 The source CCTP-burn pool Account (deposits are swept here).
+     * @return account2 The destination Gateway-deposit pool Account (the CCTP mint recipient).
+     */
+    function openStreams()
+        external
+        nonReentrant
+        returns (address account1, address account2)
+    {
+        return _openStreamsInternal();
+    }
+
+    /// @notice The two standing intents for the current epoch (so a keeper can call closeStream/reopen).
+    function getStandingIntents()
+        external
+        view
+        returns (Intent memory intent1, Intent memory intent2)
+    {
+        address account2;
+        (, account2, intent1, intent2) = _accounts();
+    }
+
+    /// @notice The two pool Accounts for the current epoch: (source burn pool, destination gateway pool).
+    function getAccounts()
+        external
+        view
+        returns (address account1, address account2)
+    {
+        (account1, account2, , ) = _accounts();
+    }
+
+    // ============ Internal: base hooks ============
+
+    function _factory() internal view override returns (address) {
+        return address(FACTORY);
+    }
+
+    function _portalAddress() internal view override returns (address) {
+        return FACTORY.PORTAL_ADDRESS();
+    }
+
+    function _sourceToken() internal view override returns (address) {
+        return FACTORY.SOURCE_TOKEN();
+    }
+
+    function _depositPoolAccount() internal view override returns (address) {
+        (address account1, , , ) = _accounts();
+        return account1;
+    }
+
+    /// @dev Only intent 1 (the SOURCE pool) is gated on reopen — intent 2's escrow/status live on the
+    ///      destination chain and are reclaimed/closed there (see the contract-level caveat).
+    function _currentEpochIntentHashes()
+        internal
+        view
+        override
+        returns (bytes32[] memory hashes)
+    {
+        (, , Intent memory i1, ) = _accounts();
+        hashes = new bytes32[](1);
+        hashes[0] = _intentHash(i1);
+    }
+
+    function _open() internal override {
+        _openStreamsInternal();
+    }
+
+    // ============ Internal: build + publish ============
+
+    function _openStreamsInternal()
+        internal
+        returns (address account1, address account2)
+    {
+        if (!initialized) revert NotInitialized();
+
+        Intent memory i1;
+        Intent memory i2;
+        (account1, account2, i1, i2) = _accounts();
+
+        if (!opened[epoch]) {
+            IIntentSource portal = IIntentSource(FACTORY.PORTAL_ADDRESS());
+
+            // Intent 2 (destination pool): publish only (ungated). Its escrow is the CCTP mint delivered
+            // by direct transfer, never a Portal pull, so it is NOT funded here.
+            portal.publish(
+                i2.protocolVersion,
+                i2.source,
+                i2.destination,
+                abi.encode(i2.route),
+                i2.reward
+            );
+
+            // Intent 1 (source pool): publish + fund. Rate-only leg => escrow target 0 => Funded, zero pull.
+            portal.publishAndFund(
+                i1.protocolVersion,
+                i1.source,
+                i1.destination,
+                abi.encode(i1.route),
+                i1.reward,
+                false
+            );
+
+            opened[epoch] = true;
+        }
+    }
+
+    /// @notice Build both intents and resolve both pool Accounts for the current epoch.
+    function _accounts()
+        internal
+        view
+        returns (
+            address account1,
+            address account2,
+            Intent memory intent1,
+            Intent memory intent2
+        )
+    {
+        IIntentSource portal = IIntentSource(FACTORY.PORTAL_ADDRESS());
+
+        intent2 = _buildIntent2();
+        account2 = portal.intentAccountAddress(
+            intent2.protocolVersion,
+            intent2.source,
+            intent2.destination,
+            abi.encode(intent2.route),
+            intent2.reward
+        );
+
+        intent1 = _buildIntent1(account2);
+        account1 = portal.intentAccountAddress(
+            intent1.protocolVersion,
+            intent1.source,
+            intent1.destination,
+            abi.encode(intent1.route),
+            intent1.reward
+        );
+    }
+
+    /// @notice Intent 2: the destination-chain Gateway-deposit pool (same-chain on DESTINATION_CHAIN_ID).
+    function _buildIntent2() internal view returns (Intent memory intent) {
+        address destUsdc = FACTORY.DEST_USDC();
+        uint64 destChain = FACTORY.DESTINATION_CHAIN_ID();
+
+        TokenAmount[] memory mo = new TokenAmount[](1);
+        mo[0] = TokenAmount({token: destUsdc, amount: FACTORY.MIN_SLICE_2()});
+
+        Route memory route = Route({
+            salt: _saltForEpoch(),
+            deadline: type(uint64).max,
+            portal: FACTORY.PORTAL_ADDRESS(),
+            keeper: depositor,
+            runtime: FACTORY.GATEWAY_DEPOSIT_RUNTIME(),
+            // CONFIG ONLY: (token, gateway, user recipient). No amount (read live by the runtime).
+            payload: abi.encode(
+                destUsdc,
+                FACTORY.GATEWAY_ADDRESS(),
+                address(uint160(uint256(destinationAddress)))
+            ),
+            minTokens: mo
+        });
+
+        RewardToken[] memory rw = new RewardToken[](1);
+        rw[0] = RewardToken({token: destUsdc, rate: FACTORY.RATE_2(), flat: 0});
+
+        Reward memory reward = Reward({
+            deadline: type(uint64).max,
+            keeper: depositor,
+            prover: FACTORY.STREAMING_FLASH_POLICY(),
+            tokens: rw,
+            hooks: ""
+        });
+
+        intent = Intent({
+            protocolVersion: FACTORY.PROTOCOL_VERSION(),
+            source: destChain,
+            destination: destChain,
+            route: route,
+            reward: reward
+        });
+    }
+
+    /// @notice Intent 1: the source-chain CCTP-burn pool (same-chain on block.chainid).
+    function _buildIntent1(
+        address account2
+    ) internal view returns (Intent memory intent) {
+        address sourceToken = FACTORY.SOURCE_TOKEN();
+        uint64 srcChain = uint64(block.chainid);
+
+        TokenAmount[] memory mo = new TokenAmount[](1);
+        mo[0] = TokenAmount({token: sourceToken, amount: FACTORY.MIN_SLICE_1()});
+
+        Route memory route = Route({
+            salt: _saltForEpoch(),
+            deadline: type(uint64).max,
+            portal: FACTORY.PORTAL_ADDRESS(),
+            keeper: depositor,
+            runtime: FACTORY.CCTP_BURN_RUNTIME(),
+            // CONFIG ONLY: (token, messenger, destinationDomain, mintRecipient=account2, maxFeeBps).
+            payload: abi.encode(
+                sourceToken,
+                FACTORY.CCTP_TOKEN_MESSENGER(),
+                FACTORY.DESTINATION_DOMAIN(),
+                bytes32(uint256(uint160(account2))),
+                FACTORY.MAX_FEE_BPS()
+            ),
+            minTokens: mo
+        });
+
+        RewardToken[] memory rw = new RewardToken[](1);
+        rw[0] = RewardToken({token: sourceToken, rate: FACTORY.RATE_1(), flat: 0});
+
+        Reward memory reward = Reward({
+            deadline: type(uint64).max,
+            keeper: depositor,
+            prover: FACTORY.STREAMING_FLASH_POLICY(),
+            tokens: rw,
+            hooks: ""
+        });
+
+        intent = Intent({
+            protocolVersion: FACTORY.PROTOCOL_VERSION(),
+            source: srcChain,
+            destination: srcChain,
+            route: route,
+            reward: reward
+        });
+    }
+
+    function _intentHash(
+        Intent memory intent
+    ) internal pure returns (bytes32) {
+        return
+            IntentLib.hashIntent(
+                intent.protocolVersion,
+                intent.source,
+                intent.destination,
+                keccak256(abi.encode(intent.route)),
+                keccak256(abi.encode(intent.reward))
+            );
+    }
+}

--- a/contracts/deposit/StandingDepositAddress_USDCTransfer_Solana.sol
+++ b/contracts/deposit/StandingDepositAddress_USDCTransfer_Solana.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {StandingDepositAddress} from "./StandingDepositAddress.sol";
+import {IIntentSource} from "../interfaces/IIntentSource.sol";
+import {Reward, RewardToken, IntentLib} from "../types/Intent.sol";
+import {Endian} from "../libs/Endian.sol";
+
+/**
+ * @title IStandingSolanaFactory
+ * @notice Config surface the Solana standing factory exposes to its clone template.
+ */
+interface IStandingSolanaFactory {
+    function SOURCE_TOKEN() external view returns (address);
+
+    function DESTINATION_TOKEN() external view returns (bytes32);
+
+    function PORTAL_ADDRESS() external view returns (address);
+
+    function PROVER_ADDRESS() external view returns (address);
+
+    function DESTINATION_PORTAL() external view returns (bytes32);
+
+    function PORTAL_PDA() external view returns (bytes32);
+
+    function EXECUTOR_ATA() external view returns (bytes32);
+
+    function PROTOCOL_VERSION() external view returns (uint32);
+
+    function REWARD_RATE() external view returns (uint256);
+}
+
+/**
+ * @title StandingDepositAddress_USDCTransfer_Solana
+ * @notice STANDING cross-chain streaming deposit template for USDC -> Solana: ONE standing intent per
+ *         deposit address, settled with the plain {StreamingPolicy} (NOT the flash policy — escrow (EVM)
+ *         and execution (Solana) live on different chains, so a solver genuinely fronts capital on Solana
+ *         and is repaid from the EVM pool after the batch is bridged back).
+ * @dev source = this EVM chain (holds the USDC reward pool); destination = Solana (1399811149). The reward
+ *      is a SINGLE PURE-RATE leg on the source USDC (`rate = REWARD_RATE >= WAD`, `flat == 0`): the rate
+ *      spread is the ONLY fee channel (a streaming `flat` is charged once per intent lifetime, wrong for a
+ *      reusable deposit address). `publishAndFund` marks it `Funded` with zero pull; deposits are direct
+ *      transfers into the pool ({sweep}); the whitelisted relay bridges Solana batch commitments via
+ *      {IStreamingPolicy-recordBatch}; permissionless `settleStream` pays each solver `fulfilled * rate /
+ *      WAD`; the keeper exits via `closeStream`.
+ *
+ *      SCOPE: the EVM half (publish / pool / relay-record / settle / close / epoch) is fully functional and
+ *      testable now. The route bytes are a DETERMINISTIC PLACEHOLDER Borsh encoding (amount == 0, deadline
+ *      == max) — the real re-fulfillable SVM streaming program (variable per-slice amount + actual SPL
+ *      delivery) is a documented out-of-repo follow-up. The one-shot template's per-deposit u64
+ *      `AmountTooLarge` guard is deleted (there is no per-deposit amount under streaming; the u64 SPL
+ *      constraint is enforced per slice on the SVM side).
+ */
+contract StandingDepositAddress_USDCTransfer_Solana is StandingDepositAddress {
+    // ============ Constants ============
+
+    /// @notice Solana chain id.
+    uint64 public constant DESTINATION_CHAIN = 1399811149;
+
+    /// @notice Solana SPL Token Program ID.
+    bytes32 public constant SPL_TOKEN_PROGRAM_ID =
+        0x06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9;
+
+    /// @notice Token decimals for USDC on Solana.
+    uint8 public constant TOKEN_DECIMALS = 6;
+
+    // ============ Immutables ============
+
+    IStandingSolanaFactory internal immutable FACTORY;
+
+    // ============ Storage ============
+
+    /// @notice Whether the stream for a given epoch has been published/funded (idempotency hint).
+    mapping(uint256 => bool) public opened;
+
+    // ============ Constructor ============
+
+    constructor() {
+        FACTORY = IStandingSolanaFactory(msg.sender);
+    }
+
+    // ============ External ============
+
+    /**
+     * @notice Publish + fund the standing cross-chain streaming intent for the current epoch.
+     * @return intentHash The standing intent hash.
+     * @return pool The source-chain escrow pool Account (deposits are swept here).
+     */
+    function openStream()
+        external
+        nonReentrant
+        returns (bytes32 intentHash, address pool)
+    {
+        return _openStreamInternal();
+    }
+
+    /// @notice The standing intent (so a keeper can call settleStream / closeStream).
+    function getStandingIntent()
+        external
+        view
+        returns (
+            uint32 protocolVersion,
+            uint64 source,
+            uint64 destination,
+            bytes32 routeHash,
+            Reward memory reward
+        )
+    {
+        protocolVersion = FACTORY.PROTOCOL_VERSION();
+        source = uint64(block.chainid);
+        destination = DESTINATION_CHAIN;
+        routeHash = keccak256(_encodeRoute());
+        reward = _buildReward();
+    }
+
+    // ============ Internal: base hooks ============
+
+    function _factory() internal view override returns (address) {
+        return address(FACTORY);
+    }
+
+    function _portalAddress() internal view override returns (address) {
+        return FACTORY.PORTAL_ADDRESS();
+    }
+
+    function _sourceToken() internal view override returns (address) {
+        return FACTORY.SOURCE_TOKEN();
+    }
+
+    function _depositPoolAccount() internal view override returns (address) {
+        Reward memory reward = _buildReward();
+        return
+            IIntentSource(FACTORY.PORTAL_ADDRESS()).intentAccountAddress(
+                FACTORY.PROTOCOL_VERSION(),
+                uint64(block.chainid),
+                DESTINATION_CHAIN,
+                _encodeRoute(),
+                reward
+            );
+    }
+
+    function _currentEpochIntentHashes()
+        internal
+        view
+        override
+        returns (bytes32[] memory hashes)
+    {
+        hashes = new bytes32[](1);
+        hashes[0] = IntentLib.hashIntent(
+            FACTORY.PROTOCOL_VERSION(),
+            uint64(block.chainid),
+            DESTINATION_CHAIN,
+            keccak256(_encodeRoute()),
+            keccak256(abi.encode(_buildReward()))
+        );
+    }
+
+    function _open() internal override {
+        _openStreamInternal();
+    }
+
+    // ============ Internal: build + publish ============
+
+    function _openStreamInternal()
+        internal
+        returns (bytes32 intentHash, address pool)
+    {
+        if (!initialized) revert NotInitialized();
+
+        bytes memory routeBytes = _encodeRoute();
+        Reward memory reward = _buildReward();
+
+        // Rate-only leg => escrow target 0 => Funded with zero token pull. Idempotent while Initial/Funded.
+        (intentHash, pool) = IIntentSource(FACTORY.PORTAL_ADDRESS())
+            .publishAndFund(
+                FACTORY.PROTOCOL_VERSION(),
+                uint64(block.chainid),
+                DESTINATION_CHAIN,
+                routeBytes,
+                reward,
+                false
+            );
+
+        opened[epoch] = true;
+    }
+
+    function _buildReward() internal view returns (Reward memory reward) {
+        RewardToken[] memory rw = new RewardToken[](1);
+        rw[0] = RewardToken({
+            token: FACTORY.SOURCE_TOKEN(),
+            rate: FACTORY.REWARD_RATE(),
+            flat: 0
+        });
+        reward = Reward({
+            deadline: type(uint64).max,
+            keeper: depositor,
+            prover: FACTORY.PROVER_ADDRESS(),
+            tokens: rw,
+            hooks: ""
+        });
+    }
+
+    /**
+     * @notice Deterministic PLACEHOLDER Borsh route for the current epoch (amount == 0, deadline == max).
+     * @dev Preserves the one-shot template's field layout exactly (only the salt/deadline/amount VALUES
+     *      change), so the encoding is a valid, stable Borsh route the SVM program layout expects. The
+     *      per-slice amount is chosen by the solver and enforced on the SVM side, so a baked placeholder is
+     *      correct; the salt carries the epoch (via {_saltForEpoch}) so a `reopen` mints a fresh hash/pool.
+     */
+    function _encodeRoute() internal view returns (bytes memory) {
+        bytes32 salt = _saltForEpoch();
+        uint64 deadline = type(uint64).max;
+
+        bytes32 destinationToken = FACTORY.DESTINATION_TOKEN();
+
+        // SPL transfer_checked instruction data: discriminator + amount (u64 LE, placeholder 0) + decimals.
+        bytes memory instructionData = abi.encodePacked(
+            bytes1(0x0c),
+            Endian.toLittleEndian64(0), // placeholder amount = 0
+            TOKEN_DECIMALS
+        );
+
+        bytes memory calldataWithAccounts = abi.encodePacked(
+            Endian.toLittleEndian32(uint32(instructionData.length)),
+            instructionData,
+            bytes1(0x04), // account_count
+            Endian.toLittleEndian32(4), // accounts.length
+            // accounts[0]: Executor ATA (source token account) — writable, not signer
+            FACTORY.EXECUTOR_ATA(),
+            bytes1(0x00),
+            bytes1(0x01),
+            // accounts[1]: Token mint — read-only, not signer
+            destinationToken,
+            bytes1(0x00),
+            bytes1(0x00),
+            // accounts[2]: Recipient ATA — writable, not signer
+            destinationAddress,
+            bytes1(0x00),
+            bytes1(0x01),
+            // accounts[3]: Executor authority (Portal PDA) — read-only, not signer
+            FACTORY.PORTAL_PDA(),
+            bytes1(0x00),
+            bytes1(0x00)
+        );
+
+        return
+            abi.encodePacked(
+                salt,
+                Endian.toLittleEndian64(deadline),
+                FACTORY.DESTINATION_PORTAL(),
+                Endian.toLittleEndian64(0), // native_amount = 0
+                Endian.toLittleEndian32(1), // tokens.length = 1
+                destinationToken,
+                Endian.toLittleEndian64(0), // tokens[0].amount = 0 (placeholder)
+                Endian.toLittleEndian32(1), // calls.length = 1
+                SPL_TOKEN_PROGRAM_ID,
+                Endian.toLittleEndian32(uint32(calldataWithAccounts.length)),
+                calldataWithAccounts
+            );
+    }
+}

--- a/contracts/deposit/StandingDepositFactory_CCTPMint.sol
+++ b/contracts/deposit/StandingDepositFactory_CCTPMint.sol
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Clones} from "../account/Clones.sol";
+import {WAD} from "../types/Intent.sol";
+import {CCTPBurnRuntime} from "../runtime/CCTPBurnRuntime.sol";
+import {StandingDepositAddress_CCTPMint} from "./StandingDepositAddress_CCTPMint.sol";
+
+/**
+ * @title StandingDepositFactory_CCTPMint
+ * @notice Shared base for the STANDING CCTP + Gateway deposit factories (Arc and GatewayERC20). Deploys
+ *         deterministic (CREATE2) deposit clones of the ONE shared {StandingDepositAddress_CCTPMint}
+ *         template, and holds the family config as public immutables (the template reads them via the
+ *         {IStandingCCTPFactory} getters).
+ * @dev NEW standing factory — it does NOT touch the immutable one-shot {BaseDepositFactory} /
+ *      DepositFactory_CCTPMint_* contracts. It deploys its OWN source-side {CCTPBurnRuntime} in the
+ *      constructor (mirroring how {BaseDepositFactory} deploys {MulticallRuntime}); the destination-side
+ *      {GatewayDepositRuntime} lives on the destination chain, so it is a config address (deployed by the
+ *      deploy script and committed into intent 2's route hash -> account2).
+ *
+ *      Fee is the reward-leg rate spread ONLY (never a payload fee): `RATE_1 >= WAD` is the source-pool
+ *      spread; `RATE_2 == WAD` gives the user the full CCTP net. Constructor sanity checks reject the
+ *      config footguns that would BRICK a published pool: `RATE_* < WAD` (slice > pool, underfunded
+ *      advance) and `MAX_FEE_BPS >= FEE_DENOMINATOR` (CCTP maxFee >= slice, burn rejected).
+ */
+abstract contract StandingDepositFactory_CCTPMint {
+    using Clones for address;
+
+    // ============ Config passed to the base ctor ============
+
+    struct CCTPConfig {
+        address sourceToken;
+        address portal;
+        uint32 protocolVersion;
+        address streamingFlashPolicy;
+        address gatewayDepositRuntime;
+        uint64 destinationChainId;
+        uint32 destinationDomain;
+        address cctpTokenMessenger;
+        address destUsdc;
+        address gateway;
+        uint256 rate1;
+        uint256 rate2;
+        uint256 minSlice1;
+        uint256 minSlice2;
+        uint256 maxFeeBps;
+    }
+
+    // ============ Constants ============
+
+    /// @notice Denominator for `MAX_FEE_BPS` (matches CCTP / the one-shot templates).
+    uint256 public constant FEE_DENOMINATOR = 100_000;
+
+    // ============ Immutables (IStandingCCTPFactory surface) ============
+
+    address public immutable SOURCE_TOKEN;
+    address public immutable PORTAL_ADDRESS;
+    uint32 public immutable PROTOCOL_VERSION;
+    address public immutable STREAMING_FLASH_POLICY;
+    address public immutable CCTP_BURN_RUNTIME;
+    address public immutable GATEWAY_DEPOSIT_RUNTIME;
+    uint64 public immutable DESTINATION_CHAIN_ID;
+    uint32 public immutable DESTINATION_DOMAIN;
+    address public immutable CCTP_TOKEN_MESSENGER;
+    address public immutable DEST_USDC;
+    address public immutable GATEWAY_ADDRESS;
+    uint256 public immutable RATE_1;
+    uint256 public immutable RATE_2;
+    uint256 public immutable MIN_SLICE_1;
+    uint256 public immutable MIN_SLICE_2;
+    uint256 public immutable MAX_FEE_BPS;
+
+    /// @notice The shared standing deposit template cloned per (destinationAddress, depositor).
+    address public immutable DEPOSIT_IMPLEMENTATION;
+
+    // ============ Events ============
+
+    event DepositContractDeployed(
+        address indexed destinationAddress,
+        address indexed depositContract
+    );
+
+    // ============ Errors ============
+
+    error InvalidSourceToken();
+    error InvalidPortalAddress();
+    error InvalidStreamingFlashPolicy();
+    error InvalidGatewayDepositRuntime();
+    error InvalidDestinationChainId();
+    error InvalidCCTPTokenMessenger();
+    error InvalidDestUsdc();
+    error InvalidGatewayAddress();
+    /// @notice `rate < WAD` would make the slice exceed the pool and underfund the direct-mode advance.
+    error RateBelowWad(uint256 rate);
+    /// @notice `maxFeeBps >= FEE_DENOMINATOR` makes the CCTP maxFee >= slice, so the burn is rejected.
+    error MaxFeeBpsTooLarge(uint256 maxFeeBps);
+
+    // ============ Constructor ============
+
+    constructor(CCTPConfig memory cfg) {
+        if (cfg.sourceToken == address(0)) revert InvalidSourceToken();
+        if (cfg.portal == address(0)) revert InvalidPortalAddress();
+        if (cfg.streamingFlashPolicy == address(0)) {
+            revert InvalidStreamingFlashPolicy();
+        }
+        if (cfg.gatewayDepositRuntime == address(0)) {
+            revert InvalidGatewayDepositRuntime();
+        }
+        if (cfg.destinationChainId == 0) revert InvalidDestinationChainId();
+        if (cfg.cctpTokenMessenger == address(0)) {
+            revert InvalidCCTPTokenMessenger();
+        }
+        if (cfg.destUsdc == address(0)) revert InvalidDestUsdc();
+        if (cfg.gateway == address(0)) revert InvalidGatewayAddress();
+        if (cfg.rate1 < WAD) revert RateBelowWad(cfg.rate1);
+        if (cfg.rate2 < WAD) revert RateBelowWad(cfg.rate2);
+        if (cfg.maxFeeBps >= FEE_DENOMINATOR) {
+            revert MaxFeeBpsTooLarge(cfg.maxFeeBps);
+        }
+
+        SOURCE_TOKEN = cfg.sourceToken;
+        PORTAL_ADDRESS = cfg.portal;
+        PROTOCOL_VERSION = cfg.protocolVersion;
+        STREAMING_FLASH_POLICY = cfg.streamingFlashPolicy;
+        GATEWAY_DEPOSIT_RUNTIME = cfg.gatewayDepositRuntime;
+        DESTINATION_CHAIN_ID = cfg.destinationChainId;
+        DESTINATION_DOMAIN = cfg.destinationDomain;
+        CCTP_TOKEN_MESSENGER = cfg.cctpTokenMessenger;
+        DEST_USDC = cfg.destUsdc;
+        GATEWAY_ADDRESS = cfg.gateway;
+        RATE_1 = cfg.rate1;
+        RATE_2 = cfg.rate2;
+        MIN_SLICE_1 = cfg.minSlice1;
+        MIN_SLICE_2 = cfg.minSlice2;
+        MAX_FEE_BPS = cfg.maxFeeBps;
+
+        // Deploy the source-side balance-reading burn runtime (config-only payloads reference it).
+        CCTP_BURN_RUNTIME = address(new CCTPBurnRuntime());
+
+        // Deploy the shared standing template implementation cloned per user.
+        DEPOSIT_IMPLEMENTATION = address(new StandingDepositAddress_CCTPMint());
+    }
+
+    // ============ External ============
+
+    /**
+     * @notice Deploy a deterministic standing deposit address for a user.
+     * @param destinationAddress User's destination (Gateway recipient) address.
+     * @param depositor Keeper / refund recipient on the source chain.
+     * @return deployed The deployed clone address.
+     */
+    function deploy(
+        address destinationAddress,
+        address depositor
+    ) external returns (address deployed) {
+        bytes32 salt = _getSalt(destinationAddress, depositor);
+        deployed = DEPOSIT_IMPLEMENTATION.clone(salt);
+        StandingDepositAddress_CCTPMint(deployed).initialize(
+            bytes32(uint256(uint160(destinationAddress))),
+            depositor
+        );
+        emit DepositContractDeployed(destinationAddress, deployed);
+    }
+
+    /// @notice Predict a user's deterministic deposit address.
+    function getDepositAddress(
+        address destinationAddress,
+        address depositor
+    ) public view returns (address) {
+        bytes32 salt = _getSalt(destinationAddress, depositor);
+        return DEPOSIT_IMPLEMENTATION.predict(salt, bytes1(0xff));
+    }
+
+    /// @notice Whether a user's deposit address has been deployed.
+    function isDeployed(
+        address destinationAddress,
+        address depositor
+    ) external view returns (bool) {
+        return getDepositAddress(destinationAddress, depositor).code.length > 0;
+    }
+
+    /// @notice The full family config (discovery for solvers/keepers).
+    function getConfiguration() external view returns (CCTPConfig memory cfg) {
+        cfg = CCTPConfig({
+            sourceToken: SOURCE_TOKEN,
+            portal: PORTAL_ADDRESS,
+            protocolVersion: PROTOCOL_VERSION,
+            streamingFlashPolicy: STREAMING_FLASH_POLICY,
+            gatewayDepositRuntime: GATEWAY_DEPOSIT_RUNTIME,
+            destinationChainId: DESTINATION_CHAIN_ID,
+            destinationDomain: DESTINATION_DOMAIN,
+            cctpTokenMessenger: CCTP_TOKEN_MESSENGER,
+            destUsdc: DEST_USDC,
+            gateway: GATEWAY_ADDRESS,
+            rate1: RATE_1,
+            rate2: RATE_2,
+            minSlice1: MIN_SLICE_1,
+            minSlice2: MIN_SLICE_2,
+            maxFeeBps: MAX_FEE_BPS
+        });
+    }
+
+    // ============ Internal ============
+
+    function _getSalt(
+        address destinationAddress,
+        address depositor
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(destinationAddress, depositor));
+    }
+}

--- a/contracts/deposit/StandingDepositFactory_CCTPMint_Arc.sol
+++ b/contracts/deposit/StandingDepositFactory_CCTPMint_Arc.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {WAD} from "../types/Intent.sol";
+import {StandingDepositFactory_CCTPMint} from "./StandingDepositFactory_CCTPMint.sol";
+
+/**
+ * @title StandingDepositFactory_CCTPMint_Arc
+ * @notice STANDING CCTP + Gateway deposit factory for Arc. Arc historically had ZERO protocol fee, so both
+ *         reward-leg rates default to `WAD` (net-zero solver economics; the operator runs the draw-down as
+ *         a gas-paid service and the user receives the full CCTP net).
+ * @dev Arc's CCTP TokenMessenger mints the 6-decimal `arcUsdc` ERC20 (NOT native), so intent 2's pool /
+ *      input legs are that ERC20 — there is NO 1e12 native scaling (deleted from the one-shot template).
+ *      This makes Arc structurally identical to the GatewayERC20 family, hence the shared template/base.
+ */
+contract StandingDepositFactory_CCTPMint_Arc is StandingDepositFactory_CCTPMint {
+    /**
+     * @param sourceToken Source USDC (ERC20) on the source chain.
+     * @param portal Portal (PortalProxy) address.
+     * @param protocolVersion Registered protocol version the intents are pinned to.
+     * @param streamingFlashPolicy {StreamingFlashPolicy} address (same on source and Arc via CREATE3).
+     * @param gatewayDepositRuntime {GatewayDepositRuntime} address on Arc (config; deployed by the script).
+     * @param arcChainId Arc chain id (intent 2's source == destination).
+     * @param destinationDomain CCTP destination domain for Arc.
+     * @param cctpTokenMessenger CCTP TokenMessengerV2 on the source chain.
+     * @param arcUsdc 6-decimal arcUsdc ERC20 on Arc (the CCTP mint token).
+     * @param gateway Gateway contract on Arc.
+     * @param minSlice1 Source-pool dust floor.
+     * @param minSlice2 Destination-pool dust floor.
+     * @param maxFeeBps CCTP fast-deposit fee cap (denominator FEE_DENOMINATOR).
+     */
+    constructor(
+        address sourceToken,
+        address portal,
+        uint32 protocolVersion,
+        address streamingFlashPolicy,
+        address gatewayDepositRuntime,
+        uint64 arcChainId,
+        uint32 destinationDomain,
+        address cctpTokenMessenger,
+        address arcUsdc,
+        address gateway,
+        uint256 minSlice1,
+        uint256 minSlice2,
+        uint256 maxFeeBps
+    )
+        StandingDepositFactory_CCTPMint(
+            CCTPConfig({
+                sourceToken: sourceToken,
+                portal: portal,
+                protocolVersion: protocolVersion,
+                streamingFlashPolicy: streamingFlashPolicy,
+                gatewayDepositRuntime: gatewayDepositRuntime,
+                destinationChainId: arcChainId,
+                destinationDomain: destinationDomain,
+                cctpTokenMessenger: cctpTokenMessenger,
+                destUsdc: arcUsdc,
+                gateway: gateway,
+                rate1: WAD, // zero protocol spread (Arc parity)
+                rate2: WAD, // user receives the full CCTP net
+                minSlice1: minSlice1,
+                minSlice2: minSlice2,
+                maxFeeBps: maxFeeBps
+            })
+        )
+    {}
+}

--- a/contracts/deposit/StandingDepositFactory_CCTPMint_GatewayERC20.sol
+++ b/contracts/deposit/StandingDepositFactory_CCTPMint_GatewayERC20.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {WAD} from "../types/Intent.sol";
+import {StandingDepositFactory_CCTPMint} from "./StandingDepositFactory_CCTPMint.sol";
+
+/**
+ * @title StandingDepositFactory_CCTPMint_GatewayERC20
+ * @notice STANDING CCTP + Gateway deposit factory for ERC20 destinations. The one-shot template's fixed
+ *         absolute FLAT_FEE becomes a PROPORTIONAL per-slice reward-leg rate spread (the flash model cannot
+ *         express a per-deposit flat, and payload fees are forbidden).
+ * @dev `RATE_1 = WAD * FEE_DENOMINATOR / (FEE_DENOMINATOR - protocolFeeBps)` (>= WAD), so the per-slice
+ *      margin `pool * (1 - WAD/RATE_1) ≈ pool * protocolFeeBps/FEE_DENOMINATOR` is the protocol fee taken
+ *      as solver margin. `protocolFeeBps == 0` reproduces the pre-feature zero-fee behavior (`RATE_1 ==
+ *      WAD`). The old `AmountBelowFlatFee` guard is replaced by the pool's `MIN_SLICE_1` dust floor
+ *      (`SliceBelowFloor`). `RATE_2 == WAD` (user receives the full CCTP net).
+ */
+contract StandingDepositFactory_CCTPMint_GatewayERC20 is
+    StandingDepositFactory_CCTPMint
+{
+    /// @notice `protocolFeeBps >= FEE_DENOMINATOR` would divide by zero / invert the rate.
+    error ProtocolFeeBpsTooLarge(uint256 protocolFeeBps);
+
+    /**
+     * @param sourceToken Source USDC (ERC20) on the source chain.
+     * @param portal Portal (PortalProxy) address.
+     * @param protocolVersion Registered protocol version the intents are pinned to.
+     * @param streamingFlashPolicy {StreamingFlashPolicy} address (same on both chains via CREATE3).
+     * @param gatewayDepositRuntime {GatewayDepositRuntime} address on the destination (config).
+     * @param destinationChainId Destination chain id (intent 2's source == destination).
+     * @param destinationDomain CCTP destination domain.
+     * @param cctpTokenMessenger CCTP TokenMessengerV2 on the source chain.
+     * @param destinationUsdc USDC ERC20 on the destination chain.
+     * @param gateway Gateway contract on the destination chain.
+     * @param minSlice1 Source-pool dust floor.
+     * @param minSlice2 Destination-pool dust floor.
+     * @param maxFeeBps CCTP fast-deposit fee cap (denominator FEE_DENOMINATOR).
+     * @param protocolFeeBps Eco protocol fee in the same denominator (0 == no fee); becomes the RATE_1
+     *        spread.
+     */
+    constructor(
+        address sourceToken,
+        address portal,
+        uint32 protocolVersion,
+        address streamingFlashPolicy,
+        address gatewayDepositRuntime,
+        uint64 destinationChainId,
+        uint32 destinationDomain,
+        address cctpTokenMessenger,
+        address destinationUsdc,
+        address gateway,
+        uint256 minSlice1,
+        uint256 minSlice2,
+        uint256 maxFeeBps,
+        uint256 protocolFeeBps
+    )
+        StandingDepositFactory_CCTPMint(
+            _cfg(
+                sourceToken,
+                portal,
+                protocolVersion,
+                streamingFlashPolicy,
+                gatewayDepositRuntime,
+                destinationChainId,
+                destinationDomain,
+                cctpTokenMessenger,
+                destinationUsdc,
+                gateway,
+                minSlice1,
+                minSlice2,
+                maxFeeBps,
+                protocolFeeBps
+            )
+        )
+    {}
+
+    /**
+     * @notice Builds the base config, converting the proportional protocol fee (bps) into RATE_1.
+     * @dev A free function-style helper (internal pure) keeps the derivation off the initializer list.
+     *      Reverts {ProtocolFeeBpsTooLarge} before the (unreachable) division by zero.
+     */
+    function _cfg(
+        address sourceToken,
+        address portal,
+        uint32 protocolVersion,
+        address streamingFlashPolicy,
+        address gatewayDepositRuntime,
+        uint64 destinationChainId,
+        uint32 destinationDomain,
+        address cctpTokenMessenger,
+        address destinationUsdc,
+        address gateway,
+        uint256 minSlice1,
+        uint256 minSlice2,
+        uint256 maxFeeBps,
+        uint256 protocolFeeBps
+    ) internal pure returns (CCTPConfig memory) {
+        if (protocolFeeBps >= FEE_DENOMINATOR) {
+            revert ProtocolFeeBpsTooLarge(protocolFeeBps);
+        }
+        uint256 rate1 = (WAD * FEE_DENOMINATOR) /
+            (FEE_DENOMINATOR - protocolFeeBps);
+        return
+            CCTPConfig({
+                sourceToken: sourceToken,
+                portal: portal,
+                protocolVersion: protocolVersion,
+                streamingFlashPolicy: streamingFlashPolicy,
+                gatewayDepositRuntime: gatewayDepositRuntime,
+                destinationChainId: destinationChainId,
+                destinationDomain: destinationDomain,
+                cctpTokenMessenger: cctpTokenMessenger,
+                destUsdc: destinationUsdc,
+                gateway: gateway,
+                rate1: rate1,
+                rate2: WAD,
+                minSlice1: minSlice1,
+                minSlice2: minSlice2,
+                maxFeeBps: maxFeeBps
+            });
+    }
+}

--- a/contracts/deposit/StandingDepositFactory_USDCTransfer_Solana.sol
+++ b/contracts/deposit/StandingDepositFactory_USDCTransfer_Solana.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Clones} from "../account/Clones.sol";
+import {WAD} from "../types/Intent.sol";
+import {StandingDepositAddress_USDCTransfer_Solana} from "./StandingDepositAddress_USDCTransfer_Solana.sol";
+
+/**
+ * @title StandingDepositFactory_USDCTransfer_Solana
+ * @notice STANDING cross-chain streaming deposit factory for USDC -> Solana. Standalone (does NOT inherit
+ *         {BaseDepositFactory} and deploys NO runtime — the Solana route is opaque Borsh executed by the
+ *         out-of-repo SVM program). Config-shape mirror of the one-shot factory plus PROTOCOL_VERSION and
+ *         REWARD_RATE (and dropping INTENT_DEADLINE_DURATION — deadlines are now `type(uint64).max`).
+ * @dev PROVER_ADDRESS points at a {StreamingPolicy} (constructed with the whitelisted relay set by the
+ *      deploy script). `REWARD_RATE >= WAD` is the solver spread (the ONLY fee channel); `REWARD_RATE ==
+ *      WAD` is the zero-spread operator-run default.
+ */
+contract StandingDepositFactory_USDCTransfer_Solana {
+    using Clones for address;
+
+    // ============ Constants ============
+
+    /// @notice Solana chain id.
+    uint64 public constant DESTINATION_CHAIN = 1399811149;
+
+    // ============ Immutables (IStandingSolanaFactory surface) ============
+
+    address public immutable SOURCE_TOKEN;
+    bytes32 public immutable DESTINATION_TOKEN;
+    address public immutable PORTAL_ADDRESS;
+    address public immutable PROVER_ADDRESS;
+    bytes32 public immutable DESTINATION_PORTAL;
+    bytes32 public immutable PORTAL_PDA;
+    bytes32 public immutable EXECUTOR_ATA;
+    uint32 public immutable PROTOCOL_VERSION;
+    uint256 public immutable REWARD_RATE;
+
+    address public immutable DEPOSIT_IMPLEMENTATION;
+
+    // ============ Events ============
+
+    event DepositContractDeployed(
+        bytes32 indexed destinationAddress,
+        address indexed depositAddress
+    );
+
+    // ============ Errors ============
+
+    error InvalidSourceToken();
+    error InvalidDestinationToken();
+    error InvalidPortalAddress();
+    error InvalidProverAddress();
+    error InvalidDestinationPortal();
+    error InvalidPortalPDA();
+    error InvalidExecutorATA();
+    error InvalidDestinationAddress();
+    error RewardRateBelowWad(uint256 rate);
+
+    // ============ Constructor ============
+
+    constructor(
+        address _sourceToken,
+        bytes32 _destinationToken,
+        address _portalAddress,
+        address _proverAddress,
+        bytes32 _destinationPortal,
+        bytes32 _portalPDA,
+        bytes32 _executorATA,
+        uint32 _protocolVersion,
+        uint256 _rewardRate
+    ) {
+        if (_sourceToken == address(0)) revert InvalidSourceToken();
+        if (_destinationToken == bytes32(0)) revert InvalidDestinationToken();
+        if (_portalAddress == address(0)) revert InvalidPortalAddress();
+        if (_proverAddress == address(0)) revert InvalidProverAddress();
+        if (_destinationPortal == bytes32(0)) revert InvalidDestinationPortal();
+        if (_portalPDA == bytes32(0)) revert InvalidPortalPDA();
+        if (_executorATA == bytes32(0)) revert InvalidExecutorATA();
+        if (_rewardRate < WAD) revert RewardRateBelowWad(_rewardRate);
+
+        SOURCE_TOKEN = _sourceToken;
+        DESTINATION_TOKEN = _destinationToken;
+        PORTAL_ADDRESS = _portalAddress;
+        PROVER_ADDRESS = _proverAddress;
+        DESTINATION_PORTAL = _destinationPortal;
+        PORTAL_PDA = _portalPDA;
+        EXECUTOR_ATA = _executorATA;
+        PROTOCOL_VERSION = _protocolVersion;
+        REWARD_RATE = _rewardRate;
+
+        DEPOSIT_IMPLEMENTATION = address(
+            new StandingDepositAddress_USDCTransfer_Solana()
+        );
+    }
+
+    // ============ External ============
+
+    /**
+     * @notice Deploy a deterministic standing deposit address for a user.
+     * @param destinationAddress Recipient's Associated Token Account (ATA) on Solana.
+     * @param depositor Keeper / refund recipient on the source chain.
+     * @return deployed The deployed clone address.
+     */
+    function deploy(
+        bytes32 destinationAddress,
+        address depositor
+    ) external returns (address deployed) {
+        if (destinationAddress == bytes32(0)) {
+            revert InvalidDestinationAddress();
+        }
+        bytes32 salt = _getSalt(destinationAddress, depositor);
+        deployed = DEPOSIT_IMPLEMENTATION.clone(salt);
+        StandingDepositAddress_USDCTransfer_Solana(deployed).initialize(
+            destinationAddress,
+            depositor
+        );
+        emit DepositContractDeployed(destinationAddress, deployed);
+    }
+
+    /// @notice Predict a user's deterministic deposit address.
+    function getDepositAddress(
+        bytes32 destinationAddress,
+        address depositor
+    ) public view returns (address) {
+        bytes32 salt = _getSalt(destinationAddress, depositor);
+        return DEPOSIT_IMPLEMENTATION.predict(salt, bytes1(0xff));
+    }
+
+    /// @notice Whether a user's deposit address has been deployed.
+    function isDeployed(
+        bytes32 destinationAddress,
+        address depositor
+    ) external view returns (bool) {
+        return getDepositAddress(destinationAddress, depositor).code.length > 0;
+    }
+
+    /**
+     * @notice Full factory configuration (discovery).
+     */
+    function getConfiguration()
+        external
+        view
+        returns (
+            uint64 destinationChain,
+            address sourceToken,
+            bytes32 destinationToken,
+            address portalAddress,
+            address proverAddress,
+            bytes32 destinationPortal,
+            bytes32 portalPDA,
+            bytes32 executorATA,
+            uint32 protocolVersion,
+            uint256 rewardRate
+        )
+    {
+        return (
+            DESTINATION_CHAIN,
+            SOURCE_TOKEN,
+            DESTINATION_TOKEN,
+            PORTAL_ADDRESS,
+            PROVER_ADDRESS,
+            DESTINATION_PORTAL,
+            PORTAL_PDA,
+            EXECUTOR_ATA,
+            PROTOCOL_VERSION,
+            REWARD_RATE
+        );
+    }
+
+    // ============ Internal ============
+
+    function _getSalt(
+        bytes32 destinationAddress,
+        address depositor
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(destinationAddress, depositor));
+    }
+}

--- a/contracts/runtime/CCTPBurnRuntime.sol
+++ b/contracts/runtime/CCTPBurnRuntime.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @notice Minimal CCTP v2 TokenMessenger surface used by {CCTPBurnRuntime}.
+ * @dev Mirrors the `depositForBurn` selector the one-shot deposit templates encode by hand
+ *      (`depositForBurn(uint256,uint32,bytes32,address,bytes32,uint256,uint32)`).
+ */
+interface ITokenMessengerV2 {
+    function depositForBurn(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32 destinationCaller,
+        uint256 maxFee,
+        uint32 minFinalityThreshold
+    ) external;
+}
+
+/**
+ * @title CCTPBurnRuntime
+ * @notice BALANCE-READING v3 runtime for a STANDING CCTP-burn flash pool: the payload commits CONFIG
+ *         ONLY (`abi.encode(token, messenger, destinationDomain, mintRecipient, maxFeeBps)`), never an
+ *         amount. Delegatecalled in the per-intent {Account}'s context, it burns the Account's ENTIRE
+ *         balance of `token` via CCTP, minting to the fixed `mintRecipient` (the destination pool Account).
+ *
+ * @dev STATELESS singleton reached exclusively via `delegatecall` from the Account (mirrors
+ *      {MulticallRuntime}): the Account forwards `Route.payload` verbatim as calldata, so this contract's
+ *      {fallback} decodes it and acts as the Account (`address(this) == Account`, balances/approvals are
+ *      the Account's). It holds NO storage of its own, so one deployed instance is safe to share across
+ *      every Account / slice.
+ *
+ *      Why a balance-reading runtime (not {MulticallRuntime}): under the standing-pool full-pool-advance
+ *      flash model each slice's burn amount varies with the current pool, so it CANNOT be baked into the
+ *      hash-committed payload. The amount `x` is read LIVE (`balanceOf(this)`); the CCTP `maxFee` is
+ *      derived from it (`ceil(x * maxFeeBps / FEE_DENOMINATOR)`). This is safe BY CONSTRUCTION: the flash
+ *      policy's full-pool advance empties the Account before the Inbox stages exactly the slice `x` back,
+ *      so the only balance this runtime can see or burn is that slice.
+ *
+ *      `forceApprove` is used because a fully-consumed CCTP burn leaves the allowance at 0, and a stray
+ *      non-zero -> non-zero approve would revert on USDC.
+ */
+contract CCTPBurnRuntime {
+    using SafeERC20 for IERC20;
+
+    /// @notice Denominator for `maxFeeBps` (100_000 => 1 unit == 0.001%). Matches the deposit templates.
+    uint256 internal constant FEE_DENOMINATOR = 100_000;
+
+    /**
+     * @notice Burn the Account's whole balance of the configured token via CCTP.
+     * @dev Reached via `delegatecall` from the Account with `Route.payload` as calldata:
+     *      `abi.encode(address token, address messenger, uint32 destinationDomain, bytes32 mintRecipient,
+     *      uint256 maxFeeBps)`. `mintRecipient` is the fixed destination pool Account (config, not an
+     *      amount).
+     */
+    fallback() external payable {
+        (
+            address token,
+            address messenger,
+            uint32 destinationDomain,
+            bytes32 mintRecipient,
+            uint256 maxFeeBps
+        ) = abi.decode(
+                msg.data,
+                (address, address, uint32, bytes32, uint256)
+            );
+
+        uint256 x = IERC20(token).balanceOf(address(this));
+
+        // CCTP fast-deposit fee, rounded UP so the user never overpays and the burn is never rejected for
+        // an under-quoted fee. (A deployer-supplied `maxFeeBps < FEE_DENOMINATOR` keeps `maxFee < x`.)
+        uint256 maxFee = (x * maxFeeBps + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
+
+        IERC20(token).forceApprove(messenger, x);
+        ITokenMessengerV2(messenger).depositForBurn(
+            x,
+            destinationDomain,
+            mintRecipient,
+            token,
+            bytes32(0), // destinationCaller: anyone may complete the mint
+            maxFee,
+            0 // minFinalityThreshold: fast finality
+        );
+    }
+
+    /// @notice Accept native (never used by CCTP; present for delegatecall-context symmetry).
+    receive() external payable {}
+}

--- a/contracts/runtime/CCTPBurnRuntime.sol
+++ b/contracts/runtime/CCTPBurnRuntime.sol
@@ -72,7 +72,9 @@ contract CCTPBurnRuntime {
         uint256 x = IERC20(token).balanceOf(address(this));
 
         // CCTP fast-deposit fee, rounded UP so the user never overpays and the burn is never rejected for
-        // an under-quoted fee. (A deployer-supplied `maxFeeBps < FEE_DENOMINATOR` keeps `maxFee < x`.)
+        // an under-quoted fee. A deployer-supplied `maxFeeBps < FEE_DENOMINATOR` keeps `maxFee <= x`
+        // (equality only at the pathological boundary of a near-100% fee on a near-dust slice, itself
+        // blocked by the `MIN_SLICE_1` floor in StreamingFlashPolicy before this runtime runs).
         uint256 maxFee = (x * maxFeeBps + FEE_DENOMINATOR - 1) / FEE_DENOMINATOR;
 
         IERC20(token).forceApprove(messenger, x);

--- a/contracts/runtime/GatewayDepositRuntime.sol
+++ b/contracts/runtime/GatewayDepositRuntime.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @notice Minimal Gateway surface used by {GatewayDepositRuntime}.
+ * @dev Mirrors the `depositFor(address,address,uint256)` selector the one-shot deposit templates encode
+ *      by hand.
+ */
+interface IGateway {
+    function depositFor(address token, address recipient, uint256 amount) external;
+}
+
+/**
+ * @title GatewayDepositRuntime
+ * @notice BALANCE-READING v3 runtime for a STANDING Gateway-deposit flash pool (the destination leg of the
+ *         CCTP deposit families): the payload commits CONFIG ONLY (`abi.encode(token, gateway, recipient)`),
+ *         never an amount. Delegatecalled in the per-intent {Account}'s context, it deposits the Account's
+ *         ENTIRE balance of `token` into the Gateway for `recipient` (the user).
+ *
+ * @dev STATELESS singleton reached exclusively via `delegatecall` from the Account (mirrors
+ *      {MulticallRuntime} / the test {SweepRuntime}): the Account forwards `Route.payload` verbatim, so
+ *      this contract's {fallback} decodes it and acts as the Account. It holds NO storage of its own.
+ *
+ *      Under the destination flash pool `rate == WAD`, so the slice equals the whole pool and the user
+ *      receives the full CCTP mint. The amount is read LIVE (`balanceOf(this)`) because the per-slice
+ *      amount varies with the pool and cannot be baked into the hash-committed payload. `forceApprove`
+ *      handles the allowance-returns-to-0 case cleanly.
+ */
+contract GatewayDepositRuntime {
+    using SafeERC20 for IERC20;
+
+    /**
+     * @notice Deposit the Account's whole balance of the configured token into the Gateway for the user.
+     * @dev Reached via `delegatecall` from the Account with `Route.payload` as calldata:
+     *      `abi.encode(address token, address gateway, address recipient)`.
+     */
+    fallback() external payable {
+        (address token, address gateway, address recipient) = abi.decode(
+            msg.data,
+            (address, address, address)
+        );
+
+        uint256 x = IERC20(token).balanceOf(address(this));
+
+        IERC20(token).forceApprove(gateway, x);
+        IGateway(gateway).depositFor(token, recipient, x);
+    }
+
+    /// @notice Accept native (present for delegatecall-context symmetry).
+    receive() external payable {}
+}

--- a/docs/v3/12-standing-deposits.md
+++ b/docs/v3/12-standing-deposits.md
@@ -127,9 +127,22 @@ a new env-gated (`DEPLOY_DEPOSIT_FACTORIES`, off by default) block deploys the t
   delivering; keeper honesty). Inherent to cross-chain streaming; the flash CCTP legs are atomic and
   immune.
 - **Epoch rotation vs in-flight CCTP** — a burn under epoch N names `account2(N)` as `mintRecipient`; if
-  the keeper `closeStream`+`reopen`s to N+1 while that CCTP message is in flight, the late mint lands at a
-  now-terminal `account2(N)` (recoverable only via destination `recoverToken`). **Rotate epochs only
-  after in-flight CCTP has drained.**
+  the keeper `closeStream`+`reopen`s to N+1 while that CCTP message is in flight, the late mint lands at
+  `account2(N)` on the destination chain. Note `reopen` closes only intent 1 (the source pool — see the
+  cross-chain-keeper item below), so `account2(N)` (intent 2) is **not** closed and the late mint is fully
+  recoverable: the primary path is a normal `flashSlice(intent2 N)` on the destination chain, which
+  delivers the mint to the intended end-user; the fallback is a keeper `closeStream(intent2 N)`, which
+  refunds it to `reward.keeper` (the depositor). Note `recoverToken` does **not** apply here — the minted
+  token is intent 2's reward-leg token, which `_validateRecover` rejects (`InvalidRecoverToken`).
+  Operationally, **rotate epochs only after in-flight CCTP has drained.**
+- **Deposit sweep during the `close`→`reopen` window** — `sweep`/`fundPool` are permissionless and route
+  the clone's balance into the *current-epoch* pool Account. Between a keeper's `closeStream(intent1 N)`
+  and `reopen` (which bumps the epoch), the current-epoch account is the now-closed `account1(N)`, so a
+  straggler sweep parks funds there and `flashSlice`/`settleStream` on it revert (closed/terminal). No
+  funds are lost or misdirected: `closeStream` has no status gate and `hasUnsettledFulfillment` is always
+  false for a flash pool, so the keeper re-invokes `closeStream(intent1 N)` to refund the swept balance to
+  the depositor, and `reopen` still proceeds (its gate only requires intent 1 `Refunded`). Mitigation:
+  pause deposits during rotation, or batch `closeStream`+`reopen` atomically from a contract keeper.
 - **Cross-chain keeper UX for CCTP intent 2** — its `closeStream`, status, and dust-reclaim are all
   destination-chain (Arc) keeper actions, so `reopen`'s gate only checks intent 1 (the source pool);
   intent 2's destination-side `Refunded` status is not readable on the source chain. A depositor who

--- a/docs/v3/12-standing-deposits.md
+++ b/docs/v3/12-standing-deposits.md
@@ -1,0 +1,138 @@
+# PR12 — standing deposit-address streaming (deposit template migration)
+
+**Branch:** `v3/12-deposit-streaming` (base `v3/11-same-chain-flash`)
+
+## Goal
+
+Migrate the reusable deposit-address templates from **"every deposit publishes + funds a FRESH one-shot
+intent"** to **"ONE STANDING intent per deposit address, drawn down per deposit"**, riding the
+`StreamingFlashPolicy` / `StreamingPolicy` machinery shipped in PR11 — with **ZERO diffs to the core**
+(Portal / IntentSource / Inbox / Account / all existing policies / `BaseDepositAddress` /
+`BaseDepositFactory` / the three OLD one-shot templates + factories are all untouched). The only new
+bytecode lives under `contracts/deposit/` and `contracts/runtime/`.
+
+Deposit clones are immutable CREATE2 contracts, so a migration is **new templates/factories**, never an
+in-place upgrade. The three OLD one-shot templates/factories are LEFT IN PLACE (deletion is deferred to a
+human deploy-confirmation — nothing on-chain changes when they are eventually removed).
+
+## What ships
+
+New, additive only:
+
+- `contracts/runtime/CCTPBurnRuntime.sol` — stateless balance-reading delegatecall runtime: burns the
+  Account's whole balance of the configured token via CCTP `depositForBurn`, minting to a fixed
+  `mintRecipient`. Payload commits **CONFIG ONLY** (`token, messenger, destinationDomain, mintRecipient,
+  maxFeeBps`); the amount `x` and `maxFee = ceil(x * maxFeeBps / 100000)` are derived LIVE.
+- `contracts/runtime/GatewayDepositRuntime.sol` — stateless balance-reading runtime: deposits the
+  Account's whole balance of the configured token into the Gateway for the user. Payload: `token, gateway,
+  recipient`.
+- `contracts/deposit/StandingDepositAddress.sol` — thin base: init, direct-transfer top-up
+  (`sweep`/`fundPool`/`fundPoolWithApproval`), `poolAccount()`, the salt-epoch scheme, keeper `reopen`.
+- `contracts/deposit/StandingDepositAddress_CCTPMint.sol` — the ONE parameterized CCTP + Gateway template,
+  shared by both families; `contracts/deposit/StandingDepositFactory_CCTPMint{,_Arc,_GatewayERC20}.sol`.
+- `contracts/deposit/StandingDepositAddress_USDCTransfer_Solana.sol` + its standalone factory.
+
+## CCTP families → two standing `StreamingFlashPolicy` pools
+
+Both the Arc and GatewayERC20 families become **two standing flash pools** per deposit address:
+
+- **Intent 1 (CCTP burn)** — a same-chain pool on the SOURCE chain (`source == destination ==
+  block.chainid`), runtime `CCTPBurnRuntime`, reward leg `{sourceUSDC, rate: RATE_1, flat: 0}`. Rate-only
+  leg ⇒ `publishAndFund` marks it `Funded` with **zero token pull**. Deposits are swept into its escrow
+  Account; solvers draw it down with `flashSlice(pv, route1, reward1, claimant, "")` in **DIRECT mode**
+  (reward token == input token == USDC ⇒ **zero solver capital**). The slice is burned via CCTP to
+  `account2`; the margin `pool - slice` is the fee.
+- **Intent 2 (Gateway deposit)** — a same-chain pool on the DESTINATION chain (`source == destination ==
+  DESTINATION_CHAIN_ID`), runtime `GatewayDepositRuntime`, reward leg `{destUSDC, rate: WAD, flat: 0}`.
+  Driven by `flashSlice` on the destination chain; the user receives the full CCTP net (margin 0 at
+  `rate == WAD`).
+
+### The source-chain-id FIX
+
+The one-shot templates committed intent 2 with `source = block.chainid` while its escrow (the CCTP mint)
+lands on the destination chain. Every source-side settle op is `onlySourceChain(source)` and
+`flashSlice` hard-commits `block.chainid` on BOTH hash sides, so settlement could only ever run where
+`source == destination == block.chainid` — masked in tests by forcing the two chain ids equal. PR12
+commits `source = DESTINATION_CHAIN_ID`, so `flashSlice` / `settleStream` / `closeStream` run on the
+chain the mint actually lands on. `publish()` is ungated, so the source clone legally publishes intent 2
+(source = Arc) for discovery + to pin `account2`; `publishAndFund` (gated) is used ONLY for intent 1.
+
+`account2` is STABLE (its hash has no timestamp; the Account CREATE2 salt is uniform cross-chain), so
+intent 1 can bake a fixed `mintRecipient = bytes32(account2)` with **no circularity**.
+
+### Arc: 6-dec `arcUsdc` ERC20, no scaling
+
+Arc's CCTP TokenMessenger mints the **6-decimal `arcUsdc` ERC20** (not native), so intent 2's pool/input
+legs are that ERC20 and the `1e12 NATIVE_USDC_SCALING` is **deleted**. This makes Arc structurally
+identical to the GatewayERC20 family — hence the single shared template.
+
+### Fee = reward-leg rate spread ONLY (never a payload fee)
+
+- Arc: `RATE_1 = RATE_2 = WAD` (zero protocol spread; the operator runs the draw-down as a gas-paid
+  service, user receives the full net).
+- GatewayERC20: `RATE_1 = WAD * 100000 / (100000 - protocolFeeBps)` (≥ WAD) — the old fixed absolute
+  `FLAT_FEE` becomes a PROPORTIONAL per-slice spread (`margin ≈ pool * protocolFeeBps / 100000`).
+  `protocolFeeBps == 0` reproduces the pre-feature zero-fee behavior (`RATE_1 == WAD`). The old
+  `AmountBelowFlatFee` guard is replaced by the pool's `MIN_SLICE_1` dust floor (`SliceBelowFloor`).
+
+`draw-down = operator-run`: the default rate is `WAD` (zero user spread), a per-factory config knob.
+Constructor sanity checks reject the config footguns that BRICK a published pool: `RATE_* < WAD` (slice >
+pool, underfunded advance) and `maxFeeBps >= 100000` (CCTP maxFee ≥ slice, burn rejected).
+
+## Solana family → one cross-chain standing `StreamingPolicy` intent
+
+`StandingDepositAddress_USDCTransfer_Solana` publishes ONE cross-chain standing streaming intent: source =
+this EVM chain (holds the USDC pool), destination = Solana (`1399811149`), a single pure-rate reward leg
+on the source USDC (`rate = REWARD_RATE >= WAD`, `flat == 0` — a streaming `flat` is charged once per
+intent lifetime, wrong for a reusable address, so the rate spread is the only fee channel). Flash does NOT
+apply: escrow (EVM) and execution (Solana) are on different chains with two distinct Model-C accounts, so
+a solver genuinely fronts USDC on Solana and is repaid from the EVM pool after the batch is bridged back
+(a whitelisted relay `recordBatch` → permissionless `settleStream` paying `fulfilled * rate / WAD`).
+
+**Placeholder route (documented residual):** the EVM half is fully functional and testable now (publish /
+pool / relay-record / settle / close / epoch). The route bytes are a DETERMINISTIC PLACEHOLDER Borsh
+encoding (amount == 0, deadline == max) — the one-shot template's per-deposit u64 `AmountTooLarge` guard
+is deleted (there is no per-deposit amount under streaming; the u64 SPL constraint is enforced per slice
+on the SVM side). **The real re-fulfillable SVM streaming program (variable per-slice amount + actual SPL
+`transfer_checked` delivery) is a required out-of-repo follow-up; the EVM placeholder route is NOT
+executable as-is.**
+
+## Salt-epoch lifecycle
+
+The route salt is `keccak256(abi.encode(address(this), epoch))` — deterministic (no `block.timestamp`),
+so the standing hash and pool address are STABLE and collision-free (no same-block warp dance). Deadlines
+are `type(uint64).max` so the permissionless post-deadline `refund` can never terminate a pool; the keeper
+exit is `closeStream` per pool. Because `closeStream` is terminal (`Refunded`) and a `Refunded` hash can
+never be re-published, a keeper `reopen` (bump `epoch`, re-open under fresh hashes) is the only restart
+path. `reopen` is keeper-only and gated on the current epoch's **source-chain** intents being `Refunded`.
+
+## Deploy + packaging
+
+`scripts/DeployV3.s.sol` (additive): the flash block also deploys the `GatewayDepositRuntime` via CREATE3
+(uniform cross-chain address, committed into intent-2's route hash → `account2`); `StreamingFlashPolicy`
+(both chains, one CREATE3 address) and the Solana `StreamingPolicy(portal, relays)` are already deployed;
+a new env-gated (`DEPLOY_DEPOSIT_FACTORIES`, off by default) block deploys the three standing factories
+(the CCTP factory self-deploys its own source-side `CCTPBurnRuntime`). `sr-build-package.ts`
+`CONTRACT_TYPES` gains the two runtimes and three factories (length 16 → 21).
+
+## Documented residual risks / boundaries
+
+- **Placeholder Solana route** — not executable until the out-of-repo SVM streaming program lands.
+- **Solana relay is fully trusted for pool integrity** — a malicious relay + colluding settler can
+  fabricate a `batchHash` + matching preimage to mint payouts for slices never delivered on Solana. A
+  bridge-backed `StreamingPolicy` subclass (real mailbox proof) is the mandatory production hardening.
+- **Solana cross-chain close window** — `hasUnsettledFulfillment` reads only the local EVM policy, so a
+  slice delivered on Solana but not yet proven+relayed is invisible; a keeper `closeStream` in that
+  latency window strands the solver's delivery. Off-chain mitigation (solver checks source status before
+  delivering; keeper honesty). Inherent to cross-chain streaming; the flash CCTP legs are atomic and
+  immune.
+- **Epoch rotation vs in-flight CCTP** — a burn under epoch N names `account2(N)` as `mintRecipient`; if
+  the keeper `closeStream`+`reopen`s to N+1 while that CCTP message is in flight, the late mint lands at a
+  now-terminal `account2(N)` (recoverable only via destination `recoverToken`). **Rotate epochs only
+  after in-flight CCTP has drained.**
+- **Cross-chain keeper UX for CCTP intent 2** — its `closeStream`, status, and dust-reclaim are all
+  destination-chain (Arc) keeper actions, so `reopen`'s gate only checks intent 1 (the source pool);
+  intent 2's destination-side `Refunded` status is not readable on the source chain. A depositor who
+  cannot operate on Arc cannot reclaim intent-2 dust (consider a protocol keeper for intent 2).
+- **Zero-margin legs need an operator** — at `rate == WAD` a permissionless solver has no incentive to run
+  the slice; the protocol operator runs those `flashSlice` calls (economic, not a safety hole).

--- a/docs/v3/migration-loss-inventory.md
+++ b/docs/v3/migration-loss-inventory.md
@@ -87,7 +87,15 @@ Downstream gas/size expectations should use the per-branch value, not a single g
 
 ## Deferred (tracked, not lost)
 - Deposit-address migration onto standing streaming intents — deferred to a PR6b follow-up; the H2
-  anti-poison guard and all deposit families stay functional in the meantime.
+  anti-poison guard and all deposit families stay functional in the meantime. **DELIVERED in PR12**
+  ([`12-standing-deposits.md`](./12-standing-deposits.md)): NEW standing templates/factories +
+  balance-reading runtimes, ZERO core diffs; the three OLD one-shot templates/factories are left in place
+  (deletion deferred to a human deploy-confirmation). Remaining residuals from PR12 (all documented in
+  `12-standing-deposits.md`): the Solana placeholder Borsh route is not executable until the out-of-repo
+  SVM streaming program lands; the Solana relay is fully trusted for pool integrity (bridge-backed
+  subclass is the production hardening); the cross-chain close window and epoch-vs-in-flight-CCTP boundary
+  are off-chain-mitigated; CCTP intent-2 (destination pool) close/reclaim is a destination-chain keeper
+  action, so `reopen` only gates on the source pool.
 - Root/generated docs (`README.md`, `contracts/README.md`, `localprover_flows.md`,
   `deposit_address_userflow.md`, and the `CLAUDE.md`/`SECURITY.md` policy docs) still carry v2/pre-rename
   wording (`Vault`, `Prover`, `.creator`) and pre-v3 architecture. PR8 authors the NEW v3 docs

--- a/scripts/DeployV3.s.sol
+++ b/scripts/DeployV3.s.sol
@@ -23,6 +23,14 @@ import {Account as EcoAccount} from "../contracts/account/Account.sol";
 import {AccountTron} from "../contracts/tron/AccountTron.sol";
 import {MulticallRuntime} from "../contracts/runtime/MulticallRuntime.sol";
 
+// Standing-deposit balance-reading runtime (destination Gateway leg; PR12)
+import {GatewayDepositRuntime} from "../contracts/runtime/GatewayDepositRuntime.sol";
+
+// Standing-deposit factories (PR12; deploy their own CCTPBurnRuntime / clone template)
+import {StandingDepositFactory_CCTPMint_Arc} from "../contracts/deposit/StandingDepositFactory_CCTPMint_Arc.sol";
+import {StandingDepositFactory_CCTPMint_GatewayERC20} from "../contracts/deposit/StandingDepositFactory_CCTPMint_GatewayERC20.sol";
+import {StandingDepositFactory_USDCTransfer_Solana} from "../contracts/deposit/StandingDepositFactory_USDCTransfer_Solana.sol";
+
 // Same-chain settlement (portal-only ctor)
 import {LocalPolicy} from "../contracts/prover/LocalPolicy.sol";
 import {LocalPolicyTron} from "../contracts/tron/LocalPolicyTron.sol";
@@ -125,6 +133,31 @@ contract DeployV3 is Script {
         bool deployLocalPolicy;
         // same-chain zero-capital flash policies (EVM only — no Tron variants yet)
         bool deployFlashPolicies;
+        // standing-deposit factories (PR12; env-driven, off by default — chain/route-specific config)
+        bool deployDepositFactories;
+        DepositConfig deposit;
+    }
+
+    /// @notice Route-specific config for the standing-deposit factories (all from env; PR12).
+    struct DepositConfig {
+        uint32 protocolVersion; // pinned intent protocol version
+        address sourceToken; // source USDC
+        // CCTP families (Arc + GatewayERC20 share the destination shape)
+        address cctpMessenger; // CCTP TokenMessengerV2 on source
+        uint32 cctpDomain; // CCTP destination domain
+        uint64 destChainId; // destination (Arc) chain id
+        address destUsdc; // arcUsdc / destination USDC (6-dec ERC20)
+        address gateway; // destination Gateway
+        uint256 minSlice1; // source-pool dust floor
+        uint256 minSlice2; // destination-pool dust floor
+        uint256 maxFeeBps; // CCTP fast-deposit fee cap
+        uint256 gatewayFeeBps; // GatewayERC20 protocol fee (0 == none)
+        // Solana family
+        bytes32 solanaDestToken;
+        bytes32 solanaDestPortal;
+        bytes32 solanaPortalPda;
+        bytes32 solanaExecutorAta;
+        uint256 solanaRewardRate; // >= WAD spread
     }
 
     struct Deployment {
@@ -144,6 +177,11 @@ contract DeployV3 is Script {
         address dutchDecayPolicy;
         address sameChainFlashPolicy;
         address streamingFlashPolicy;
+        // Standing-deposit runtime + factories (PR12)
+        address gatewayDepositRuntime;
+        address standingDepositFactoryArc;
+        address standingDepositFactoryGatewayERC20;
+        address standingDepositFactorySolana;
     }
 
     // --- Entry points -------------------------------------------------------
@@ -288,6 +326,15 @@ contract DeployV3 is Script {
                 _contractSalt(cfg.salt, "STREAMING_FLASH_POLICY")
             );
             console.log("StreamingFlashPolicy:", dep.streamingFlashPolicy);
+
+            // Destination-side balance-reading Gateway runtime (PR12). No ctor args => CREATE3 gives a
+            // uniform cross-chain address, committed into the CCTP standing intent-2 route hash -> account2.
+            dep.gatewayDepositRuntime = _deployCreate3(
+                type(GatewayDepositRuntime).creationCode,
+                cfg.deployer,
+                _contractSalt(cfg.salt, "GATEWAY_DEPOSIT_RUNTIME")
+            );
+            console.log("GatewayDepositRuntime:", dep.gatewayDepositRuntime);
         }
 
         // 3. Transport policies (CREATE3, self-referencing right-aligned whitelist).
@@ -297,6 +344,89 @@ contract DeployV3 is Script {
         if (cfg.deploySchedulePolicies) {
             _deploySchedulePolicies(cfg, dep);
         }
+
+        // 5. Standing-deposit factories (PR12; env-driven, off by default).
+        if (cfg.deployDepositFactories) {
+            _deployDepositFactories(cfg, dep);
+        }
+    }
+
+    // --- Standing-deposit factories (PR12) ---------------------------------
+
+    /**
+     * @notice Deploy the three NEW standing-deposit factories. Each is chain/route-specific config, so
+     *         they use plain `new` (no cross-chain address matching). The CCTP factories self-deploy their
+     *         own source-side {CCTPBurnRuntime}; the Solana factory deploys no runtime.
+     * @dev Requires the flash policies (CCTP) and the streaming policy (Solana) to have been deployed.
+     */
+    function _deployDepositFactories(
+        Config memory cfg,
+        Deployment memory dep
+    ) internal {
+        DepositConfig memory d = cfg.deposit;
+
+        dep.standingDepositFactoryArc = address(
+            new StandingDepositFactory_CCTPMint_Arc(
+                d.sourceToken,
+                dep.portal,
+                d.protocolVersion,
+                dep.streamingFlashPolicy,
+                dep.gatewayDepositRuntime,
+                d.destChainId,
+                d.cctpDomain,
+                d.cctpMessenger,
+                d.destUsdc,
+                d.gateway,
+                d.minSlice1,
+                d.minSlice2,
+                d.maxFeeBps
+            )
+        );
+        console.log(
+            "StandingDepositFactory_CCTPMint_Arc:",
+            dep.standingDepositFactoryArc
+        );
+
+        dep.standingDepositFactoryGatewayERC20 = address(
+            new StandingDepositFactory_CCTPMint_GatewayERC20(
+                d.sourceToken,
+                dep.portal,
+                d.protocolVersion,
+                dep.streamingFlashPolicy,
+                dep.gatewayDepositRuntime,
+                d.destChainId,
+                d.cctpDomain,
+                d.cctpMessenger,
+                d.destUsdc,
+                d.gateway,
+                d.minSlice1,
+                d.minSlice2,
+                d.maxFeeBps,
+                d.gatewayFeeBps
+            )
+        );
+        console.log(
+            "StandingDepositFactory_CCTPMint_GatewayERC20:",
+            dep.standingDepositFactoryGatewayERC20
+        );
+
+        dep.standingDepositFactorySolana = address(
+            new StandingDepositFactory_USDCTransfer_Solana(
+                d.sourceToken,
+                d.solanaDestToken,
+                dep.portal,
+                dep.streamingPolicy,
+                d.solanaDestPortal,
+                d.solanaPortalPda,
+                d.solanaExecutorAta,
+                d.protocolVersion,
+                d.solanaRewardRate
+            )
+        );
+        console.log(
+            "StandingDepositFactory_USDCTransfer_Solana:",
+            dep.standingDepositFactorySolana
+        );
     }
 
     // --- Transport policies -------------------------------------------------
@@ -552,6 +682,36 @@ contract DeployV3 is Script {
             false
         );
         cfg.scheduleRelays = _envPeers("SCHEDULE_RELAYS");
+        cfg.deployDepositFactories = vm.envOr(
+            "DEPLOY_DEPOSIT_FACTORIES",
+            false
+        );
+        if (cfg.deployDepositFactories) {
+            cfg.deposit = _readDepositConfig();
+        }
+    }
+
+    function _readDepositConfig()
+        internal
+        view
+        returns (DepositConfig memory d)
+    {
+        d.protocolVersion = uint32(vm.envOr("DEPOSIT_PROTOCOL_VERSION", uint256(1)));
+        d.sourceToken = vm.envOr("DEPOSIT_SOURCE_TOKEN", address(0));
+        d.cctpMessenger = vm.envOr("DEPOSIT_CCTP_MESSENGER", address(0));
+        d.cctpDomain = uint32(vm.envOr("DEPOSIT_CCTP_DOMAIN", uint256(0)));
+        d.destChainId = uint64(vm.envOr("DEPOSIT_DEST_CHAIN_ID", uint256(0)));
+        d.destUsdc = vm.envOr("DEPOSIT_DEST_USDC", address(0));
+        d.gateway = vm.envOr("DEPOSIT_GATEWAY", address(0));
+        d.minSlice1 = vm.envOr("DEPOSIT_MIN_SLICE_1", uint256(0));
+        d.minSlice2 = vm.envOr("DEPOSIT_MIN_SLICE_2", uint256(0));
+        d.maxFeeBps = vm.envOr("DEPOSIT_MAX_FEE_BPS", uint256(0));
+        d.gatewayFeeBps = vm.envOr("DEPOSIT_GATEWAY_FEE_BPS", uint256(0));
+        d.solanaDestToken = vm.envOr("DEPOSIT_SOLANA_DEST_TOKEN", bytes32(0));
+        d.solanaDestPortal = vm.envOr("DEPOSIT_SOLANA_DEST_PORTAL", bytes32(0));
+        d.solanaPortalPda = vm.envOr("DEPOSIT_SOLANA_PORTAL_PDA", bytes32(0));
+        d.solanaExecutorAta = vm.envOr("DEPOSIT_SOLANA_EXECUTOR_ATA", bytes32(0));
+        d.solanaRewardRate = vm.envOr("DEPOSIT_SOLANA_REWARD_RATE", uint256(0));
     }
 
     function _envPeers(
@@ -585,6 +745,31 @@ contract DeployV3 is Script {
         _writeLine(path, dep.dutchDecayPolicy, "DutchDecayPolicy");
         _writeLine(path, dep.sameChainFlashPolicy, "SameChainFlashPolicy");
         _writeLine(path, dep.streamingFlashPolicy, "StreamingFlashPolicy");
+        _writeLine(path, dep.gatewayDepositRuntime, "GatewayDepositRuntime");
+        // The CCTP factories self-deploy their CCTPBurnRuntime; record the Arc factory's instance.
+        if (dep.standingDepositFactoryArc != address(0)) {
+            _writeLine(
+                path,
+                StandingDepositFactory_CCTPMint_Arc(dep.standingDepositFactoryArc)
+                    .CCTP_BURN_RUNTIME(),
+                "CCTPBurnRuntime"
+            );
+        }
+        _writeLine(
+            path,
+            dep.standingDepositFactoryArc,
+            "StandingDepositFactory_CCTPMint_Arc"
+        );
+        _writeLine(
+            path,
+            dep.standingDepositFactoryGatewayERC20,
+            "StandingDepositFactory_CCTPMint_GatewayERC20"
+        );
+        _writeLine(
+            path,
+            dep.standingDepositFactorySolana,
+            "StandingDepositFactory_USDCTransfer_Solana"
+        );
     }
 
     function _writeLine(

--- a/scripts/semantic-release/sr-build-package.ts
+++ b/scripts/semantic-release/sr-build-package.ts
@@ -50,6 +50,12 @@ export const CONTRACT_TYPES = [
   'DutchDecayPolicy',
   'SameChainFlashPolicy',
   'StreamingFlashPolicy',
+  // PR12: standing-deposit balance-reading runtimes + standing factories
+  'CCTPBurnRuntime',
+  'GatewayDepositRuntime',
+  'StandingDepositFactory_CCTPMint_Arc',
+  'StandingDepositFactory_CCTPMint_GatewayERC20',
+  'StandingDepositFactory_USDCTransfer_Solana',
 ] as const
 
 const execPromise = promisify(exec)

--- a/scripts/semantic-release/tests/sr-build-package.spec.ts
+++ b/scripts/semantic-release/tests/sr-build-package.spec.ts
@@ -160,9 +160,19 @@ describe('Semantic Release Build Package', () => {
       // PR11: the same-chain zero-capital flash policies are also recorded.
       expect(CONTRACT_TYPES).toContain('SameChainFlashPolicy')
       expect(CONTRACT_TYPES).toContain('StreamingFlashPolicy')
+      // PR12: standing-deposit balance-reading runtimes + standing factories.
+      expect(CONTRACT_TYPES).toContain('CCTPBurnRuntime')
+      expect(CONTRACT_TYPES).toContain('GatewayDepositRuntime')
+      expect(CONTRACT_TYPES).toContain('StandingDepositFactory_CCTPMint_Arc')
+      expect(CONTRACT_TYPES).toContain(
+        'StandingDepositFactory_CCTPMint_GatewayERC20',
+      )
+      expect(CONTRACT_TYPES).toContain(
+        'StandingDepositFactory_USDCTransfer_Solana',
+      )
       // No pre-rename names remain.
       expect(CONTRACT_TYPES).not.toContain('HyperProver')
-      expect(CONTRACT_TYPES.length).toBe(16)
+      expect(CONTRACT_TYPES.length).toBe(21)
     })
   })
 })

--- a/test/deposit/StandingDepositAddress_CCTPMint.t.sol
+++ b/test/deposit/StandingDepositAddress_CCTPMint.t.sol
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {BaseTest} from "../BaseTest.sol";
+import {StreamingFlashPolicy} from "../../contracts/prover/StreamingFlashPolicy.sol";
+import {IStreamingFlashPolicy} from "../../contracts/interfaces/IStreamingFlashPolicy.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {CCTPBurnRuntime} from "../../contracts/runtime/CCTPBurnRuntime.sol";
+import {GatewayDepositRuntime} from "../../contracts/runtime/GatewayDepositRuntime.sol";
+import {StandingDepositAddress_CCTPMint} from "../../contracts/deposit/StandingDepositAddress_CCTPMint.sol";
+import {StandingDepositFactory_CCTPMint_Arc} from "../../contracts/deposit/StandingDepositFactory_CCTPMint_Arc.sol";
+import {StandingDepositFactory_CCTPMint_GatewayERC20} from "../../contracts/deposit/StandingDepositFactory_CCTPMint_GatewayERC20.sol";
+import {StandingDepositAddress} from "../../contracts/deposit/StandingDepositAddress.sol";
+import {TestERC20} from "../../contracts/test/TestERC20.sol";
+import {Intent, WAD} from "../../contracts/types/Intent.sol";
+
+// ---------------------------------------------------------------------------
+// Mocks + delegatecall harness
+// ---------------------------------------------------------------------------
+
+/// @notice Mock CCTP v2 TokenMessenger: pulls the burn amount (so the Account is drained) + records args.
+contract MockTokenMessengerV2 {
+    uint256 public lastAmount;
+    uint32 public lastDomain;
+    bytes32 public lastMintRecipient;
+    address public lastBurnToken;
+    uint256 public lastMaxFee;
+    uint256 public burnCount;
+
+    function depositForBurn(
+        uint256 amount,
+        uint32 destinationDomain,
+        bytes32 mintRecipient,
+        address burnToken,
+        bytes32,
+        uint256 maxFee,
+        uint32
+    ) external {
+        IERC20(burnToken).transferFrom(msg.sender, address(this), amount);
+        lastAmount = amount;
+        lastDomain = destinationDomain;
+        lastMintRecipient = mintRecipient;
+        lastBurnToken = burnToken;
+        lastMaxFee = maxFee;
+        burnCount += 1;
+    }
+}
+
+/// @notice Mock Gateway: pulls the deposit (Account drained) + records the credited recipient/amount.
+contract MockGatewayPull {
+    address public lastToken;
+    address public lastRecipient;
+    uint256 public lastAmount;
+    uint256 public depositCount;
+
+    function depositFor(address token, address recipient, uint256 amount) external {
+        IERC20(token).transferFrom(msg.sender, address(this), amount);
+        lastToken = token;
+        lastRecipient = recipient;
+        lastAmount = amount;
+        depositCount += 1;
+    }
+}
+
+/// @notice Minimal delegatecall harness (stands in for an {Account}) for balance-reading runtime units.
+contract RuntimeHarness {
+    function run(address runtime, bytes calldata payload) external payable {
+        (bool ok, bytes memory ret) = runtime.delegatecall(payload);
+        if (!ok) {
+            assembly {
+                revert(add(ret, 0x20), mload(ret))
+            }
+        }
+    }
+
+    receive() external payable {}
+}
+
+/**
+ * @title StandingDepositAddress_CCTPMintTest
+ * @notice PR12 standing CCTP + Gateway deposit migration: the two balance-reading runtimes as delegatecall
+ *         units, intent-1 CCTP-burn flash pool (direct mode, zero solver capital), intent-2 Gateway flash
+ *         pool on a simulated Arc, the fee-as-rate model, standing-hash stability, closeStream/reopen epoch
+ *         rotation, and poison protection — with money conservation on every lifecycle test.
+ */
+contract StandingDepositAddress_CCTPMintTest is BaseTest {
+    StreamingFlashPolicy internal flash;
+    GatewayDepositRuntime internal gatewayRuntime;
+    CCTPBurnRuntime internal cctpRuntime; // standalone (for unit)
+    MockTokenMessengerV2 internal messenger;
+    MockGatewayPull internal gateway;
+
+    address internal user; // destination recipient
+    address internal solver; // flash claimant
+
+    uint256 internal constant FLOOR = 100;
+    uint32 internal constant DEST_DOMAIN = 6;
+    uint256 internal constant MAX_FEE_BPS = 13; // 1.3 bps
+    uint256 internal constant FEE_DENOMINATOR = 100_000;
+
+    function setUp() public override {
+        super.setUp();
+        user = makeAddr("cctpUser");
+        solver = makeAddr("cctpSolver");
+
+        vm.startPrank(deployer);
+        flash = new StreamingFlashPolicy(address(portal));
+        gatewayRuntime = new GatewayDepositRuntime();
+        cctpRuntime = new CCTPBurnRuntime();
+        vm.stopPrank();
+
+        messenger = new MockTokenMessengerV2();
+        gateway = new MockGatewayPull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Factory helpers (source token == tokenA; destination "arcUsdc" == tokenB)
+    // -----------------------------------------------------------------------
+
+    function _arcFactory()
+        internal
+        returns (StandingDepositFactory_CCTPMint_Arc f)
+    {
+        f = new StandingDepositFactory_CCTPMint_Arc(
+            address(tokenA), // source USDC
+            address(portal),
+            PROTOCOL_VERSION,
+            address(flash),
+            address(gatewayRuntime),
+            CHAIN_ID, // arcChainId == block.chainid (simulated Arc)
+            DEST_DOMAIN,
+            address(messenger),
+            address(tokenB), // arcUsdc (6-dec ERC20)
+            address(gateway),
+            FLOOR,
+            FLOOR,
+            MAX_FEE_BPS
+        );
+    }
+
+    function _gwFactory(
+        uint256 protocolFeeBps
+    ) internal returns (StandingDepositFactory_CCTPMint_GatewayERC20 f) {
+        f = new StandingDepositFactory_CCTPMint_GatewayERC20(
+            address(tokenA),
+            address(portal),
+            PROTOCOL_VERSION,
+            address(flash),
+            address(gatewayRuntime),
+            CHAIN_ID,
+            DEST_DOMAIN,
+            address(messenger),
+            address(tokenB),
+            address(gateway),
+            FLOOR,
+            FLOOR,
+            MAX_FEE_BPS,
+            protocolFeeBps
+        );
+    }
+
+    function _b32(address a) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(a)));
+    }
+
+    function _sliceIntent1(
+        StandingDepositAddress_CCTPMint clone,
+        address claimant
+    ) internal {
+        (Intent memory i1, ) = clone.getStandingIntents();
+        vm.prank(solver);
+        flash.flashSlice(PROTOCOL_VERSION, i1.route, i1.reward, _b32(claimant), "");
+    }
+
+    function _sliceIntent2(
+        StandingDepositAddress_CCTPMint clone,
+        address claimant
+    ) internal {
+        (, Intent memory i2) = clone.getStandingIntents();
+        vm.prank(solver);
+        flash.flashSlice(PROTOCOL_VERSION, i2.route, i2.reward, _b32(claimant), "");
+    }
+
+    // -----------------------------------------------------------------------
+    // Runtime units
+    // -----------------------------------------------------------------------
+
+    function test_cctpBurnRuntime_unit_readsBalance_burnsAndDrains() public {
+        RuntimeHarness harness = new RuntimeHarness();
+        uint256 x = 1_000_000;
+        tokenA.mint(address(harness), x);
+
+        bytes32 mintRecipient = keccak256("account2");
+        harness.run(
+            address(cctpRuntime),
+            abi.encode(
+                address(tokenA),
+                address(messenger),
+                DEST_DOMAIN,
+                mintRecipient,
+                MAX_FEE_BPS
+            )
+        );
+
+        uint256 expectedMaxFee = (x * MAX_FEE_BPS + FEE_DENOMINATOR - 1) /
+            FEE_DENOMINATOR;
+        assertEq(messenger.lastAmount(), x, "burned whole balance");
+        assertEq(messenger.lastMaxFee(), expectedMaxFee, "maxFee = ceil(x*bps)");
+        assertEq(messenger.lastMintRecipient(), mintRecipient, "mintRecipient");
+        assertEq(messenger.lastDomain(), DEST_DOMAIN);
+        assertEq(tokenA.balanceOf(address(harness)), 0, "Account drained");
+        assertEq(tokenA.balanceOf(address(messenger)), x);
+    }
+
+    function test_gatewayDepositRuntime_unit_readsBalance_depositsAndDrains()
+        public
+    {
+        RuntimeHarness harness = new RuntimeHarness();
+        uint256 x = 500;
+        tokenB.mint(address(harness), x);
+
+        harness.run(
+            address(gatewayRuntime),
+            abi.encode(address(tokenB), address(gateway), user)
+        );
+
+        assertEq(gateway.lastToken(), address(tokenB));
+        assertEq(gateway.lastRecipient(), user, "user credited");
+        assertEq(gateway.lastAmount(), x);
+        assertEq(tokenB.balanceOf(address(harness)), 0, "Account drained");
+        assertEq(tokenB.balanceOf(address(gateway)), x);
+    }
+
+    // -----------------------------------------------------------------------
+    // Intent 1: CCTP-burn flash pool (direct mode, zero solver capital)
+    // -----------------------------------------------------------------------
+
+    function test_intent1_flashSlice_directMode_burnsToAccount2_zeroCapital()
+        public
+    {
+        StandingDepositFactory_CCTPMint_Arc f = _arcFactory();
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(user, keeper)
+        );
+        (address account1, address account2) = clone.openStreams();
+
+        // Deposit D into the clone, then sweep it into the source pool by direct transfer.
+        uint256 D = 1000;
+        tokenA.mint(address(clone), D);
+        assertEq(tokenA.balanceOf(solver), 0, "solver fronts ZERO capital");
+        clone.sweep();
+        assertEq(tokenA.balanceOf(account1), D, "pool funded by sweep");
+        assertEq(tokenA.balanceOf(address(clone)), 0, "clone swept clean");
+
+        // Conservation participants for tokenA (source leg).
+        address[] memory p = new address[](6);
+        p[0] = account1;
+        p[1] = address(flash);
+        p[2] = solver;
+        p[3] = address(clone);
+        p[4] = keeper;
+        p[5] = address(messenger);
+        uint256 sum = _sum(tokenA, p);
+
+        _sliceIntent1(clone, solver);
+
+        // Arc rate1 == WAD => slice == pool, margin 0; the whole pool is burned via CCTP to account2.
+        assertEq(messenger.lastAmount(), D, "whole pool burned");
+        assertEq(messenger.lastMintRecipient(), _b32(account2), "mint to account2");
+        assertEq(tokenA.balanceOf(account1), 0, "pool advanced + consumed");
+        assertEq(tokenA.balanceOf(solver), 0, "solver still fronted ZERO");
+        assertEq(tokenA.balanceOf(address(flash)), 0, "nothing strands in policy");
+        assertEq(_sum(tokenA, p), sum, "tokenA conserved");
+
+        (bytes32 ih1, ) = _hashes(clone);
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih1)),
+            uint256(IIntentSource.Status.Funded),
+            "pool stays Funded"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Intent 2: Gateway flash pool on a simulated Arc (source==dest==ARC)
+    // -----------------------------------------------------------------------
+
+    function test_intent2_flashSlice_gatewayCredited_marginZeroAtWad() public {
+        StandingDepositFactory_CCTPMint_Arc f = _arcFactory();
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(user, keeper)
+        );
+        (, address account2) = clone.openStreams();
+
+        // Simulate the CCTP mint landing at account2 (6-dec arcUsdc == tokenB).
+        uint256 minted = 990;
+        tokenB.mint(account2, minted);
+
+        address claimant2 = makeAddr("arcOperator");
+        address[] memory p = new address[](5);
+        p[0] = account2;
+        p[1] = address(flash);
+        p[2] = claimant2;
+        p[3] = address(gateway);
+        p[4] = user;
+        uint256 sum = _sum(tokenB, p);
+
+        _sliceIntent2(clone, claimant2);
+
+        assertEq(gateway.lastRecipient(), user, "gateway credits the user");
+        assertEq(gateway.lastAmount(), minted, "full CCTP mint deposited");
+        assertEq(tokenB.balanceOf(account2), 0, "account2 drained");
+        assertEq(tokenB.balanceOf(claimant2), 0, "margin 0 at rate2==WAD");
+        assertEq(_sum(tokenB, p), sum, "tokenB conserved");
+    }
+
+    // -----------------------------------------------------------------------
+    // GatewayERC20 fee-as-rate: proportional margin, zero-fee reproduction, dust floor
+    // -----------------------------------------------------------------------
+
+    function test_gatewayERC20_feeAsRate_proportionalMargin() public {
+        // 1% protocol fee (1000 / 100000).
+        StandingDepositFactory_CCTPMint_GatewayERC20 f = _gwFactory(1000);
+        assertGt(f.RATE_1(), WAD, "fee => rate1 > WAD");
+        assertEq(f.RATE_2(), WAD);
+
+        // Deposit 1000 -> slice 990, margin 10 (1%).
+        _runGwSlice(f, makeAddr("u1"), makeAddr("s1"), 1000, 990, 10);
+        // Deposit 500 -> slice 495, margin 5 (1%).
+        _runGwSlice(f, makeAddr("u2"), makeAddr("s2"), 500, 495, 5);
+    }
+
+    function test_gatewayERC20_zeroFee_reproducesNoSpread() public {
+        StandingDepositFactory_CCTPMint_GatewayERC20 f = _gwFactory(0);
+        assertEq(f.RATE_1(), WAD, "0 bps => rate1 == WAD");
+        // Deposit 1000 -> slice 1000, margin 0.
+        _runGwSlice(f, makeAddr("z1"), makeAddr("zs1"), 1000, 1000, 0);
+    }
+
+    function test_gatewayERC20_subFloorPool_revertsSliceBelowFloor() public {
+        StandingDepositFactory_CCTPMint_GatewayERC20 f = _gwFactory(0);
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(makeAddr("dustUser"), keeper)
+        );
+        clone.openStreams();
+        // Pool below the MIN_SLICE_1 floor (rate1 == WAD => slice == pool).
+        tokenA.mint(address(clone), FLOOR - 1);
+        clone.sweep();
+
+        (Intent memory i1, ) = clone.getStandingIntents();
+        vm.prank(solver);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStreamingFlashPolicy.SliceBelowFloor.selector,
+                0,
+                FLOOR - 1,
+                FLOOR
+            )
+        );
+        flash.flashSlice(PROTOCOL_VERSION, i1.route, i1.reward, _b32(solver), "");
+    }
+
+    function _runGwSlice(
+        StandingDepositFactory_CCTPMint_GatewayERC20 f,
+        address u,
+        address s,
+        uint256 deposit,
+        uint256 expectedSlice,
+        uint256 expectedMargin
+    ) internal {
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(u, keeper)
+        );
+        (address account1, ) = clone.openStreams();
+        tokenA.mint(address(clone), deposit);
+        clone.sweep();
+
+        uint256 msgBefore = tokenA.balanceOf(address(messenger));
+        (Intent memory i1, ) = clone.getStandingIntents();
+        vm.prank(solver);
+        flash.flashSlice(PROTOCOL_VERSION, i1.route, i1.reward, _b32(s), "");
+
+        assertEq(
+            tokenA.balanceOf(address(messenger)) - msgBefore,
+            expectedSlice,
+            "slice burned == floor(pool*WAD/rate1)"
+        );
+        assertEq(tokenA.balanceOf(s), expectedMargin, "margin == protocol fee");
+        assertEq(tokenA.balanceOf(account1), 0, "pool consumed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing-hash stability: two deposits in the same block => SAME hash/accounts
+    // -----------------------------------------------------------------------
+
+    function test_standingHash_stable_noTimestampDependence() public {
+        StandingDepositFactory_CCTPMint_Arc f = _arcFactory();
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(user, keeper)
+        );
+        clone.openStreams();
+
+        (bytes32 ih1a, bytes32 ih2a) = _hashes(clone);
+        (address a1a, address a2a) = clone.getAccounts();
+
+        // Warp time; a second "deposit" must resolve to the SAME hashes/accounts (no timestamp in salt).
+        vm.warp(block.timestamp + 5000);
+        (bytes32 ih1b, bytes32 ih2b) = _hashes(clone);
+        (address a1b, address a2b) = clone.getAccounts();
+
+        assertEq(ih1a, ih1b, "ih1 stable across time");
+        assertEq(ih2a, ih2b, "ih2 stable across time");
+        assertEq(a1a, a1b, "account1 stable");
+        assertEq(a2a, a2b, "account2 stable");
+    }
+
+    // -----------------------------------------------------------------------
+    // closeStream keeper exit + epoch rotation
+    // -----------------------------------------------------------------------
+
+    function test_closeStream_bothIntents_thenReopen_rotatesEpoch() public {
+        StandingDepositFactory_CCTPMint_Arc f = _arcFactory();
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(user, keeper)
+        );
+        (address account1, address account2) = clone.openStreams();
+
+        // Fund the source pool + simulate an Arc mint left in account2.
+        tokenA.mint(address(clone), 1000);
+        clone.sweep();
+        tokenB.mint(account2, 300);
+
+        (Intent memory i1, Intent memory i2) = clone.getStandingIntents();
+        bytes32 rh1 = keccak256(abi.encode(i1.route));
+        bytes32 rh2 = keccak256(abi.encode(i2.route));
+        (bytes32 ih1, ) = _hashes(clone);
+
+        // reopen before close reverts (source pool intent1 not Refunded).
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                StandingDepositAddress.EpochNotClosed.selector,
+                ih1
+            )
+        );
+        clone.reopen();
+
+        // Keeper closes intent1 (source) -> refunds un-sliced pool to keeper.
+        vm.prank(keeper);
+        intentSource.closeStream(PROTOCOL_VERSION, CHAIN_ID, CHAIN_ID, rh1, i1.reward);
+        assertEq(tokenA.balanceOf(keeper), 1000, "source pool refunded");
+        assertEq(tokenA.balanceOf(account1), 0);
+
+        // Keeper closes intent2 (destination/Arc pool) -> refunds arcUsdc dust to keeper.
+        vm.prank(keeper);
+        intentSource.closeStream(PROTOCOL_VERSION, CHAIN_ID, CHAIN_ID, rh2, i2.reward);
+        assertEq(tokenB.balanceOf(keeper), 300, "arc dust refunded");
+        assertEq(tokenB.balanceOf(account2), 0);
+
+        // Old hashes are now terminal (Refunded).
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih1)),
+            uint256(IIntentSource.Status.Refunded)
+        );
+
+        // Non-keeper reopen reverts.
+        vm.prank(otherPerson);
+        vm.expectRevert(StandingDepositAddress.NotKeeper.selector);
+        clone.reopen();
+
+        // Keeper reopen bumps the epoch and republishes under a NEW hash.
+        vm.prank(keeper);
+        clone.reopen();
+        assertEq(clone.epoch(), 1, "epoch bumped");
+        (bytes32 ih1b, ) = _hashes(clone);
+        assertTrue(ih1b != ih1, "new epoch => new hash");
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih1b)),
+            uint256(IIntentSource.Status.Funded),
+            "new pool funded"
+        );
+
+        // Re-publishing the OLD (Refunded) intent1 hash is rejected.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.IntentAlreadyExists.selector,
+                ih1
+            )
+        );
+        intentSource.publish(
+            i1.protocolVersion,
+            i1.source,
+            i1.destination,
+            abi.encode(i1.route),
+            i1.reward
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Poison protection: plain fulfill naming the flash policy reverts NotFlashSession
+    // -----------------------------------------------------------------------
+
+    function test_plainFulfill_reverts_notFlashSession() public {
+        StandingDepositFactory_CCTPMint_Arc f = _arcFactory();
+        StandingDepositAddress_CCTPMint clone = StandingDepositAddress_CCTPMint(
+            f.deploy(user, keeper)
+        );
+        clone.openStreams();
+        (bytes32 ih1, ) = _hashes(clone);
+        (Intent memory i1, ) = clone.getStandingIntents();
+
+        uint256[] memory provided = new uint256[](1);
+        provided[0] = FLOOR;
+        tokenA.mint(otherPerson, FLOOR);
+        vm.startPrank(otherPerson);
+        tokenA.approve(address(portal), FLOOR);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IStreamingFlashPolicy.NotFlashSession.selector,
+                ih1
+            )
+        );
+        inbox.fulfill(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            CHAIN_ID,
+            i1.route,
+            i1.reward,
+            _b32(otherPerson),
+            provided,
+            address(flash)
+        );
+        vm.stopPrank();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    function _hashes(
+        StandingDepositAddress_CCTPMint clone
+    ) internal view returns (bytes32 ih1, bytes32 ih2) {
+        (Intent memory i1, Intent memory i2) = clone.getStandingIntents();
+        ih1 = _hashIntent(i1);
+        ih2 = _hashIntent(i2);
+    }
+
+    function _sum(
+        TestERC20 t,
+        address[] memory who
+    ) internal view returns (uint256 s) {
+        for (uint256 i; i < who.length; ++i) {
+            s += t.balanceOf(who[i]);
+        }
+    }
+}

--- a/test/deposit/StandingDepositAddress_USDCTransfer_Solana.t.sol
+++ b/test/deposit/StandingDepositAddress_USDCTransfer_Solana.t.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {BaseTest} from "../BaseTest.sol";
+import {StreamingPolicy} from "../../contracts/prover/StreamingPolicy.sol";
+import {IStreamingPolicy} from "../../contracts/interfaces/IStreamingPolicy.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {IAccount} from "../../contracts/interfaces/IAccount.sol";
+import {StandingDepositAddress_USDCTransfer_Solana} from "../../contracts/deposit/StandingDepositAddress_USDCTransfer_Solana.sol";
+import {StandingDepositFactory_USDCTransfer_Solana} from "../../contracts/deposit/StandingDepositFactory_USDCTransfer_Solana.sol";
+import {StandingDepositAddress} from "../../contracts/deposit/StandingDepositAddress.sol";
+import {TestERC20} from "../../contracts/test/TestERC20.sol";
+import {Reward, IntentLib, WAD} from "../../contracts/types/Intent.sol";
+
+/**
+ * @title StandingDepositAddress_USDCTransfer_SolanaTest
+ * @notice PR12 standing cross-chain streaming deposit for USDC -> Solana: deterministic standing publish,
+ *         direct-transfer pool growth, settle via a simulated whitelisted relay (recordBatch) + StreamBatch
+ *         preimage paying `fulfilled * rate / WAD`, L1 under-funded recoverability, keeper closeStream, and
+ *         salt-epoch reopen — with money conservation.
+ */
+contract StandingDepositAddress_USDCTransfer_SolanaTest is BaseTest {
+    StreamingPolicy internal stream;
+    StandingDepositFactory_USDCTransfer_Solana internal factory;
+
+    uint64 internal constant SOLANA = 1399811149;
+    uint256 internal constant REWARD_RATE = 1.001e18; // 10 bps spread
+    bytes32 internal constant DEST_TOKEN = bytes32(uint256(0xABCD));
+    bytes32 internal constant DEST_PORTAL = bytes32(uint256(0xBEEF));
+    bytes32 internal constant PORTAL_PDA = bytes32(uint256(0xCAFE));
+    bytes32 internal constant EXECUTOR_ATA = bytes32(uint256(0xF00D));
+
+    bytes32 internal userATA; // Solana recipient ATA
+    address internal solverClaimant; // solver's EVM payout address
+
+    function setUp() public override {
+        super.setUp();
+        userATA = keccak256("userATA");
+        solverClaimant = makeAddr("solanaSolver");
+
+        // StreamingPolicy trusting the Portal, whitelisting THIS test as the cross-chain relay.
+        bytes32[] memory relays = new bytes32[](1);
+        relays[0] = bytes32(uint256(uint160(address(this))));
+        vm.prank(deployer);
+        stream = new StreamingPolicy(address(portal), relays);
+
+        factory = new StandingDepositFactory_USDCTransfer_Solana(
+            address(tokenA),
+            DEST_TOKEN,
+            address(portal),
+            address(stream),
+            DEST_PORTAL,
+            PORTAL_PDA,
+            EXECUTOR_ATA,
+            PROTOCOL_VERSION,
+            REWARD_RATE
+        );
+    }
+
+    function _clone()
+        internal
+        returns (StandingDepositAddress_USDCTransfer_Solana c)
+    {
+        c = StandingDepositAddress_USDCTransfer_Solana(
+            factory.deploy(userATA, keeper)
+        );
+    }
+
+    function _ih(
+        StandingDepositAddress_USDCTransfer_Solana c
+    ) internal view returns (bytes32) {
+        (
+            uint32 pv,
+            uint64 source,
+            uint64 destination,
+            bytes32 routeHash,
+            Reward memory reward
+        ) = c.getStandingIntent();
+        return
+            IntentLib.hashIntent(
+                pv,
+                source,
+                destination,
+                routeHash,
+                keccak256(abi.encode(reward))
+            );
+    }
+
+    function _slice(
+        address slotClaimant,
+        uint256 amount
+    ) internal pure returns (IStreamingPolicy.StreamSlice memory s) {
+        uint256[] memory f = new uint256[](1);
+        f[0] = amount;
+        s = IStreamingPolicy.StreamSlice({
+            claimant: bytes32(uint256(uint160(slotClaimant))),
+            fulfilled: f
+        });
+    }
+
+    function _oneBatch(
+        uint256 nonce,
+        IStreamingPolicy.StreamSlice[] memory slices
+    ) internal pure returns (bytes memory) {
+        IStreamingPolicy.StreamBatch[]
+            memory batches = new IStreamingPolicy.StreamBatch[](1);
+        batches[0] = IStreamingPolicy.StreamBatch({nonce: nonce, slices: slices});
+        return abi.encode(batches);
+    }
+
+    function _batchHash(
+        bytes32 intentHash,
+        uint256 nonce,
+        IStreamingPolicy.StreamSlice[] memory slices
+    ) internal pure returns (bytes32) {
+        bytes32[] memory sh = new bytes32[](slices.length);
+        for (uint256 i; i < slices.length; ++i) {
+            sh[i] = IntentLib.fulfillmentHash(
+                intentHash,
+                slices[i].claimant,
+                slices[i].fulfilled
+            );
+        }
+        return keccak256(abi.encode(intentHash, nonce, sh));
+    }
+
+    // -----------------------------------------------------------------------
+    // Standing publish deterministic + timestamp-independent + config threading
+    // -----------------------------------------------------------------------
+
+    function test_openStream_deterministic_timestampIndependent() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+
+        (bytes32 ihA, address poolA) = c.openStream();
+        (
+            uint32 pv,
+            uint64 source,
+            uint64 destination,
+            ,
+            Reward memory reward
+        ) = c.getStandingIntent();
+        assertEq(pv, PROTOCOL_VERSION, "protocolVersion threaded");
+        assertEq(source, CHAIN_ID);
+        assertEq(destination, SOLANA);
+        assertEq(reward.deadline, type(uint64).max, "deadline max");
+        assertEq(reward.prover, address(stream));
+        assertEq(reward.tokens.length, 1);
+        assertEq(reward.tokens[0].token, address(tokenA));
+        assertEq(reward.tokens[0].rate, REWARD_RATE);
+        assertEq(reward.tokens[0].flat, 0, "pure rate leg");
+
+        // Warp; a second call must return the SAME hash + pool (no block.timestamp in the route salt).
+        vm.warp(block.timestamp + 9999);
+        (bytes32 ihB, address poolB) = c.openStream();
+        assertEq(ihA, ihB, "intentHash stable across time");
+        assertEq(poolA, poolB, "pool stable across time");
+        assertEq(
+            uint256(intentSource.getRewardStatus(ihA)),
+            uint256(IIntentSource.Status.Funded),
+            "funded with zero pull (rate-only leg)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Deposit = direct transfer grows the pool; fund() is a no-op once Funded
+    // -----------------------------------------------------------------------
+
+    function test_deposit_directTransfer_growsPool() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+        (bytes32 ih, address pool) = c.openStream();
+
+        // Deposit via the clone + sweep, and via a direct transfer straight to the pool.
+        tokenA.mint(address(c), 3000);
+        c.sweep();
+        assertEq(tokenA.balanceOf(pool), 3000);
+        tokenA.mint(pool, 2000); // direct transfer top-up
+        assertEq(tokenA.balanceOf(pool), 5000, "pool accumulates");
+
+        // A big deposit (> uint64.max) is fine — no per-deposit u64 AmountTooLarge guard anymore.
+        uint256 huge = uint256(type(uint64).max) + 1;
+        tokenA.mint(address(c), huge);
+        c.sweep();
+        assertEq(tokenA.balanceOf(pool), 5000 + huge, "no u64 cap on deposits");
+
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih)),
+            uint256(IIntentSource.Status.Funded)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-chain settle via simulated relay + preimage
+    // -----------------------------------------------------------------------
+
+    function test_settle_crossChain_paysRateSpread_conserved() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+        (bytes32 ih, address pool) = c.openStream();
+        (, , , bytes32 routeHash, Reward memory reward) = c.getStandingIntent();
+
+        tokenA.mint(pool, 5000);
+
+        uint256 f = 1000;
+        uint256 payout = (f * REWARD_RATE) / WAD; // 1001
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](1);
+        slices[0] = _slice(solverClaimant, f);
+
+        // Relay bridges the Solana-proven batch commitment.
+        stream.recordBatch(ih, SOLANA, _batchHash(ih, 0, slices));
+        assertEq(stream.srcBatches(ih).length, 1);
+
+        // Mismatched preimage reverts.
+        IStreamingPolicy.StreamSlice[]
+            memory wrong = new IStreamingPolicy.StreamSlice[](1);
+        wrong[0] = _slice(solverClaimant, f + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(IStreamingPolicy.UnknownBatch.selector, ih)
+        );
+        intentSource.settleStream(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            SOLANA,
+            routeHash,
+            reward,
+            _oneBatch(0, wrong)
+        );
+
+        uint256 poolBefore = tokenA.balanceOf(pool);
+        intentSource.settleStream(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            SOLANA,
+            routeHash,
+            reward,
+            _oneBatch(0, slices)
+        );
+
+        assertEq(tokenA.balanceOf(solverClaimant), payout, "paid f*rate/WAD");
+        assertEq(tokenA.balanceOf(pool), poolBefore - payout, "residual kept");
+        assertEq(stream.srcBatches(ih).length, 0, "batch consumed");
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih)),
+            uint256(IIntentSource.Status.Funded),
+            "stays Funded (re-fulfillable)"
+        );
+        // Conservation: pool + claimant unchanged in aggregate.
+        assertEq(
+            tokenA.balanceOf(pool) + tokenA.balanceOf(solverClaimant),
+            5000,
+            "tokenA conserved"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // L1: over-large batch reverts, then settles after a top-up (recoverable)
+    // -----------------------------------------------------------------------
+
+    function test_settle_overLargeBatch_revertsThenSettlesAfterTopUp() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+        (bytes32 ih, address pool) = c.openStream();
+        (, , , bytes32 routeHash, Reward memory reward) = c.getStandingIntent();
+
+        tokenA.mint(pool, 1500);
+
+        uint256 f = 1000;
+        uint256 payout = (f * REWARD_RATE) / WAD; // 1001
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](2);
+        slices[0] = _slice(solverClaimant, f);
+        slices[1] = _slice(makeAddr("solver2"), f);
+        stream.recordBatch(ih, SOLANA, _batchHash(ih, 0, slices));
+
+        // Second slice can't be paid from the remaining 499 -> whole settle reverts, batch preserved.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccount.StreamSlicePayoutExceedsBalance.selector,
+                address(tokenA),
+                payout,
+                1500 - payout
+            )
+        );
+        intentSource.settleStream(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            SOLANA,
+            routeHash,
+            reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(stream.srcBatches(ih).length, 1, "batch preserved");
+        assertEq(tokenA.balanceOf(solverClaimant), 0, "nothing paid (atomic)");
+
+        // Top up; the same batch now settles fully.
+        tokenA.mint(pool, 1000);
+        intentSource.settleStream(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            SOLANA,
+            routeHash,
+            reward,
+            _oneBatch(0, slices)
+        );
+        assertEq(tokenA.balanceOf(solverClaimant), payout);
+        assertEq(tokenA.balanceOf(makeAddr("solver2")), payout);
+        assertEq(stream.srcBatches(ih).length, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // closeStream keeper exit; blocked while a batch is unsettled (C2)
+    // -----------------------------------------------------------------------
+
+    function test_closeStream_keeperExit_blockedWhileUnsettled() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+        (bytes32 ih, address pool) = c.openStream();
+        (, , , bytes32 routeHash, Reward memory reward) = c.getStandingIntent();
+        tokenA.mint(pool, 5000);
+
+        IStreamingPolicy.StreamSlice[]
+            memory slices = new IStreamingPolicy.StreamSlice[](1);
+        slices[0] = _slice(solverClaimant, 1000);
+        stream.recordBatch(ih, SOLANA, _batchHash(ih, 0, slices));
+
+        // Blocked while unsettled (C2 anti-rug).
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.PendingProofBlocksClose.selector,
+                ih
+            )
+        );
+        intentSource.closeStream(PROTOCOL_VERSION, CHAIN_ID, SOLANA, routeHash, reward);
+
+        // Settle, then close: keeper reclaims the remainder.
+        intentSource.settleStream(
+            PROTOCOL_VERSION,
+            CHAIN_ID,
+            SOLANA,
+            routeHash,
+            reward,
+            _oneBatch(0, slices)
+        );
+        uint256 remainder = tokenA.balanceOf(pool);
+        vm.prank(keeper);
+        intentSource.closeStream(PROTOCOL_VERSION, CHAIN_ID, SOLANA, routeHash, reward);
+        assertEq(tokenA.balanceOf(keeper), remainder, "keeper reclaims remainder");
+        assertEq(tokenA.balanceOf(pool), 0);
+        assertTrue(stream.closed(ih));
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih)),
+            uint256(IIntentSource.Status.Refunded)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Salt-epoch reopen
+    // -----------------------------------------------------------------------
+
+    function test_reopen_epochRotation() public {
+        StandingDepositAddress_USDCTransfer_Solana c = _clone();
+        (bytes32 ih0, address pool0) = c.openStream();
+        (, , , bytes32 routeHash, Reward memory reward) = c.getStandingIntent();
+        tokenA.mint(pool0, 1000);
+
+        // reopen before close reverts.
+        vm.prank(keeper);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                StandingDepositAddress.EpochNotClosed.selector,
+                ih0
+            )
+        );
+        c.reopen();
+
+        // non-keeper reopen reverts.
+        vm.prank(otherPerson);
+        vm.expectRevert(StandingDepositAddress.NotKeeper.selector);
+        c.reopen();
+
+        // Close the current epoch's stream.
+        vm.prank(keeper);
+        intentSource.closeStream(PROTOCOL_VERSION, CHAIN_ID, SOLANA, routeHash, reward);
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih0)),
+            uint256(IIntentSource.Status.Refunded)
+        );
+
+        // Re-publishing the old (Refunded) hash is rejected.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.IntentAlreadyExists.selector,
+                ih0
+            )
+        );
+        c.openStream();
+
+        // reopen bumps the epoch and republishes under a NEW hash + pool.
+        vm.prank(keeper);
+        c.reopen();
+        assertEq(c.epoch(), 1);
+        bytes32 ih1 = _ih(c);
+        assertTrue(ih1 != ih0, "new epoch => new hash");
+        assertEq(
+            uint256(intentSource.getRewardStatus(ih1)),
+            uint256(IIntentSource.Status.Funded),
+            "new pool funded"
+        );
+
+        // The new pool is a fresh address (per-epoch) and accepts deposits.
+        address pool1 = c.poolAccount();
+        assertTrue(pool1 != pool0, "new epoch => new pool address");
+        tokenA.mint(pool1, 2000);
+        assertEq(tokenA.balanceOf(pool1), 2000, "new pool accepts deposits");
+    }
+}


### PR DESCRIPTION
## What

Migrates the reusable deposit-address templates from "every deposit publishes+funds a FRESH one-shot intent" to **one STANDING intent per deposit address**, drawn down per deposit with **zero solver capital** — riding the PR11 flash/streaming policies. New standing contracts ship alongside the untouched one-shot templates (deposit clones are immutable CREATE2, so migration is additive).

- **Both CCTP families** (Arc + GatewayERC20, now **one parameterized template**) become two same-chain `StreamingFlashPolicy` pools: intent 1 (CCTP burn) on the source chain, intent 2 (Gateway deposit) on the destination chain. Deposits are direct transfers into the pool; an operator draws them down with `flashSlice`. Fees are the reward-leg **rate spread** (default WAD = no user haircut; GatewayERC20's flat fee re-expressed as a proportional rate).
- **Fixes a latent bug**: the one-shot intent 2 committed `source = block.chainid` while its CCTP-mint escrow lands on the destination chain, so `onlySourceChain` settlement could never run where the funds are (masked in tests by forcing the chain ids equal). The standing intent 2 commits `source == destination == destChain`, and `account2` (the stable mint recipient) is baked into intent 1.
- **Solana** becomes one true cross-chain `StreamingPolicy` stream (EVM escrow pool + whitelisted-relay `recordBatch` + `settleStream`), with a deterministic placeholder Borsh route; real SVM execution is a documented follow-up.
- **Two new balance-reading runtimes** (`CCTPBurnRuntime`, `GatewayDepositRuntime`): stateless, delegatecalled in the Account, read the staged slice via `balanceOf` and compute the live CCTP `maxFee` — config-only payloads, no baked amounts.

## Zero core diffs

Nothing existing is modified — `BaseDepositAddress`, the three old templates/factories, and every core contract (Portal/IntentSource/Inbox/Account/StreamingPolicy/StreamingFlashPolicy) are byte-identical. `Portal`/`PortalTron` stay **23,564 B** (optimizer untouched). New contracts all well under EIP-170.

## Safety

- Adversarial review (4 attack lenses → skeptical verify): **7 findings, all refuted (0 confirmed-real)** — the one high-severity flag (Arc native-vs-ERC20) is the intended design decision, not a bug; three doc/comment inaccuracies were corrected (notably: the epoch-rotation late-mint recovers via `flashSlice`/`closeStream`, not `recoverToken`).
- 16 new tests (runtime units + zero-capital lifecycle + fee-as-rate + epoch rotation + poison protection + Solana relay settle), every lifecycle test asserts money conservation across all participants.

## Gates

`forge test` 709/0 · `hardhat test` 112 · `jest` all suites.

## Docs

`docs/v3/12-standing-deposits.md` (design, fee-as-rate model, epoch lifecycle, the source-bug fix, and the documented residuals: placeholder-Solana, relay trust, cross-chain keeper UX, epoch-vs-in-flight-CCTP, sweep window); `migration-loss-inventory.md` updated.

Stacked on #406. Completes the v3 train (PR1–PR12) — this is the deposit-streaming migration originally deferred as PR6b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4pnnevHt2zFJwDqPyJreT