### PR TITLE
feat: per-deployment native/ERC20 alias support in recovery + reward validation

### DIFF
--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -258,6 +258,8 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
         bytes memory route,
         Reward memory reward
     ) public returns (bytes32 intentHash, address vault) {
+        _requireNoNativeAliasConflict(reward);
+
         (intentHash, , ) = getIntentHash(destination, route, reward);
         vault = _getVault(intentHash);
 
@@ -628,6 +630,10 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
         address funder,
         bool allowPartial
     ) internal onlyFundable(intentHash) {
+        // Reject a reward-token leg regardless of entry point. `publish` already checks this, but
+        // `fund`/`fundFor` can escrow an intent directly without a prior `publish` call.
+        _requireNoNativeAliasConflict(reward);
+
         bool fullyFunded = _fundNative(vault, reward.nativeAmount);
 
         uint256 rewardsLength = reward.tokens.length;
@@ -723,6 +729,10 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
         address funder,
         address permitContract
     ) internal onlyFundable(intentHash) returns (address vault) {
+        // Reject a reward-token leg regardless of entry point — see the matching check and comment in
+        // {_fundIntent}.
+        _requireNoNativeAliasConflict(reward);
+
         vault = _getOrDeployVault(intentHash);
         bool fullyFunded = IVault(vault).fundFor{value: msg.value}(
             reward,
@@ -765,6 +775,30 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
         }
 
         return true;
+    }
+
+    /**
+     * @notice Reverts if a reward's native amount and its token legs both claim the same underlying
+     *         funds
+     * @dev On a deployment where {NATIVE_ERC20} is configured (non-zero), its ERC20 balance mirrors the
+     *      vault's native balance 1:1 — a native amount and a {NATIVE_ERC20} leg are two interfaces onto
+     *      the SAME underlying funds, not two independent amounts. Funding one would silently satisfy
+     *      the other's balance check for free, and payout would then short whichever is processed second
+     *      against an already-drained vault. No-op unless {NATIVE_ERC20} is configured and the reward
+     *      actually carries a non-zero native amount.
+     * @param reward Reward structure to validate
+     */
+    function _requireNoNativeAliasConflict(Reward memory reward) internal view {
+        if (NATIVE_ERC20 == address(0) || reward.nativeAmount == 0) {
+            return;
+        }
+
+        uint256 rewardsLength = reward.tokens.length;
+        for (uint256 i; i < rewardsLength; ++i) {
+            if (reward.tokens[i].token == NATIVE_ERC20) {
+                revert RewardTokensNotUnique(NATIVE_ERC20);
+            }
+        }
     }
 
     /**

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -34,6 +34,11 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
 
     /// @dev Implementation contract address for vault cloning
     address private immutable VAULT_IMPLEMENTATION;
+    /// @dev ERC20 token address that this deployment's native asset is aliased to (i.e. its balance
+    ///      mirrors `address(this).balance` on every vault), or `address(0)` if this deployment has no
+    ///      such alias. Used only to keep {recoverToken} from treating the native and aliased-ERC20
+    ///      views of the same underlying balance as two independent, separately recoverable assets.
+    address private immutable NATIVE_ERC20;
     /// @dev Tracks the lifecycle status of each intent's rewards
     mapping(bytes32 => Status) private rewardStatuses;
 
@@ -41,10 +46,17 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
      * @notice Initializes the IntentSource contract
      * @param vaultImplementation Address of the vault implementation used for cloning
      * @param create2Prefix CREATE2 prefix byte for the target chain (0xff for EVM, 0x41 for Tron)
+     * @param nativeErc20 ERC20 token address aliased to this deployment's native asset, or
+     *        `address(0)` if none. See {NATIVE_ERC20}.
      */
-    constructor(address vaultImplementation, bytes1 create2Prefix) {
+    constructor(
+        address vaultImplementation,
+        bytes1 create2Prefix,
+        address nativeErc20
+    ) {
         VAULT_IMPLEMENTATION = vaultImplementation;
         CREATE2_PREFIX = create2Prefix;
+        NATIVE_ERC20 = nativeErc20;
     }
 
     /**
@@ -825,14 +837,19 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
 
     /**
      * @notice Validates that token can be recovered (not zero address and not a reward token)
-     * @dev Prevents recovery of reward tokens and zero address, allows recovery of mistaken transfers
+     * @dev Prevents recovery of reward tokens and zero address, allows recovery of mistaken transfers.
+     *      On a deployment where {NATIVE_ERC20} is configured, its ERC20 balance mirrors
+     *      `address(this).balance` on every vault — they are two views of one underlying balance, not
+     *      independent balances. A reward's native amount and a {NATIVE_ERC20} leg are therefore treated
+     *      as the same asset here: recovery of {NATIVE_ERC20} is also blocked whenever the reward carries
+     *      a non-zero native amount, even though `token` never literally appears in `reward.tokens`.
      * @param reward Reward structure containing token list
      * @param token Address of the token to recover
      */
     function _validateRecover(
         Reward calldata reward,
         address token
-    ) internal pure {
+    ) internal view {
         if (token == address(0)) {
             revert InvalidRecoverToken(token);
         }
@@ -842,6 +859,14 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
             if (reward.tokens[i].token == token) {
                 revert InvalidRecoverToken(token);
             }
+        }
+
+        if (
+            NATIVE_ERC20 != address(0) &&
+            token == NATIVE_ERC20 &&
+            reward.nativeAmount != 0
+        ) {
+            revert InvalidRecoverToken(token);
         }
     }
 

--- a/contracts/IntentSource.sol
+++ b/contracts/IntentSource.sol
@@ -895,11 +895,7 @@ abstract contract IntentSource is OriginSettler, IIntentSource {
             }
         }
 
-        if (
-            NATIVE_ERC20 != address(0) &&
-            token == NATIVE_ERC20 &&
-            reward.nativeAmount != 0
-        ) {
+        if (token == NATIVE_ERC20 && reward.nativeAmount != 0) {
             revert InvalidRecoverToken(token);
         }
     }

--- a/contracts/Portal.sol
+++ b/contracts/Portal.sol
@@ -17,6 +17,10 @@ contract Portal is IntentSource, Inbox, Semver {
     /**
      * @notice Initializes the Portal contract
      * @dev Creates a unified entry point combining source and destination chain functionality
+     * @param nativeErc20 ERC20 token address aliased to this deployment's native asset, or
+     *        `address(0)` if none. See {IntentSource-NATIVE_ERC20}.
      */
-    constructor() IntentSource(address(new Vault()), bytes1(0xff)) {}
+    constructor(
+        address nativeErc20
+    ) IntentSource(address(new Vault()), bytes1(0xff), nativeErc20) {}
 }

--- a/contracts/PortalTron.sol
+++ b/contracts/PortalTron.sol
@@ -14,5 +14,12 @@ import {VaultTron} from "./vault/VaultTron.sol";
  *      tokens such as Tron USDT.
  */
 contract PortalTron is IntentSource, Inbox, Semver {
-    constructor() IntentSource(address(new VaultTron()), bytes1(0x41)) {}
+    /**
+     * @notice Initializes the PortalTron contract
+     * @param nativeErc20 ERC20 token address aliased to this deployment's native asset, or
+     *        `address(0)` if none. See {IntentSource-NATIVE_ERC20}.
+     */
+    constructor(
+        address nativeErc20
+    ) IntentSource(address(new VaultTron()), bytes1(0x41), nativeErc20) {}
 }

--- a/contracts/interfaces/IIntentSource.sol
+++ b/contracts/interfaces/IIntentSource.sol
@@ -65,6 +65,11 @@ interface IIntentSource {
     /// @notice Thrown when caller is not the reward creator
     error NotCreatorCaller(address caller);
 
+    /// @notice Thrown when a reward token duplicates value already committed elsewhere in the reward
+    ///         (e.g. it is this deployment's configured native/ERC20 alias while the reward also carries
+    ///         a non-zero native amount)
+    error RewardTokensNotUnique(address token);
+
     /**
      * @notice Signals the creation of a new cross-chain intent
      * @param intentHash Unique identifier of the intent

--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -253,8 +253,9 @@ contract Deploy is Script {
     function deployPortal(
         DeploymentContext memory ctx
     ) internal returns (address portal) {
+        // No native/ERC20 alias on this deployment (nativeErc20 = address(0)).
         (ctx.portal) = deployWithCreate2(
-            type(Portal).creationCode,
+            abi.encodePacked(type(Portal).creationCode, abi.encode(address(0))),
             ctx.portalSalt
         );
         console.log("Portal :", ctx.portal);

--- a/scripts/tron/deploy-evm-tron.ts
+++ b/scripts/tron/deploy-evm-tron.ts
@@ -261,13 +261,21 @@ class EvmDeployer {
 
     const { bytecode } = loadArtifact('Portal')
     const creationCode = bytecode.startsWith('0x') ? bytecode : '0x' + bytecode
+    const constructorArgs = this.abiCoder.encode(
+      ['address'],
+      [ethers.ZeroAddress],
+    )
+    const initCode = ethers.concat([
+      ethers.getBytes(creationCode),
+      ethers.getBytes(constructorArgs),
+    ])
     const create3 = new ethers.Contract(
       this.cfg.create3Deployer,
       CREATE3_ABI,
       this.wallet,
     )
     console.log(`  ${this.tag()} Deploying Portal via CREATE3...`)
-    const tx = await create3.deploy(creationCode, portalSalt)
+    const tx = await create3.deploy(initCode, portalSalt)
     const receipt = await tx.wait()
 
     const finalCode = await this.provider.getCode(predicted)
@@ -474,6 +482,10 @@ class TronDeployer {
 
     const { abi, bytecode } = loadArtifact('PortalTron')
     const bytecodeHex = bytecode.startsWith('0x') ? bytecode.slice(2) : bytecode
+    const abiCoder = ethers.AbiCoder.defaultAbiCoder()
+    const rawParameter = abiCoder
+      .encode(['address'], [ethers.ZeroAddress])
+      .slice(2)
 
     console.log('  [Tron] Deploying PortalTron via createSmartContract...')
     const deployerHex = this.tronWeb.defaultAddress.hex as string
@@ -485,6 +497,7 @@ class TronDeployer {
         callValue: 0,
         userFeePercentage: 100,
         originEnergyLimit: 10_000_000,
+        rawParameter,
       },
       deployerHex,
     )

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -58,7 +58,7 @@ contract BaseTest is Test {
         vm.startPrank(deployer);
 
         // Deploy core contracts
-        portal = new Portal();
+        portal = new Portal(address(0));
         // Set backward compatibility aliases
         intentSource = IIntentSource(address(portal));
         inbox = Inbox(payable(address(portal)));

--- a/test/DestinationSettler.spec.ts
+++ b/test/DestinationSettler.spec.ts
@@ -50,7 +50,7 @@ describe('Destination Settler Test', (): void => {
     ).deploy(ethers.ZeroAddress)
     const [owner, creator, solver, dstAddr] = await ethers.getSigners()
     const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portal = await portalFactory.deploy(ethers.ZeroAddress)
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
     const prover = await (
       await ethers.getContractFactory('TestProver')

--- a/test/HyperProver.spec.ts
+++ b/test/HyperProver.spec.ts
@@ -83,7 +83,7 @@ describe('HyperProver Test', (): void => {
       await ethers.getContractFactory('TestMailbox')
     ).deploy(ethers.ZeroAddress) // No processor needed for these tests
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portal = await (await ethers.getContractFactory('Portal')).deploy(ethers.ZeroAddress)
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const token = await (

--- a/test/Inbox.spec.ts
+++ b/test/Inbox.spec.ts
@@ -47,7 +47,7 @@ describe('Inbox Test', (): void => {
   }> {
     const [owner, solver, dstAddr] = await ethers.getSigners()
     const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portal = await portalFactory.deploy(ethers.ZeroAddress)
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
     const executor = await ethers.getContractAt(
       'Executor',
@@ -189,7 +189,7 @@ describe('Inbox Test', (): void => {
     it('should revert via InvalidHash if all intent data was input correctly, but the intent used a different inbox on creation', async () => {
       const anotherPortal = await (
         await ethers.getContractFactory('Portal')
-      ).deploy()
+      ).deploy(ethers.ZeroAddress)
       const anotherInbox = await ethers.getContractAt(
         'Inbox',
         await anotherPortal.getAddress(),

--- a/test/LayerZeroProver.spec.ts
+++ b/test/LayerZeroProver.spec.ts
@@ -79,7 +79,7 @@ describe('LayerZeroProver Test', (): void => {
       .getContractFactory('TestLayerZeroEndpoint')
       .then((factory) => factory.deploy())
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portal = await (await ethers.getContractFactory('Portal')).deploy(ethers.ZeroAddress)
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const token = await (

--- a/test/MetaProver.spec.ts
+++ b/test/MetaProver.spec.ts
@@ -121,7 +121,7 @@ describe('MetaProver Test', (): void => {
       await ethers.getContractFactory('TestMetaRouter')
     ).deploy(ethers.ZeroAddress)
 
-    const portal = await (await ethers.getContractFactory('Portal')).deploy()
+    const portal = await (await ethers.getContractFactory('Portal')).deploy(ethers.ZeroAddress)
     const inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     const token = await (

--- a/test/NativeErc20Dual.t.sol
+++ b/test/NativeErc20Dual.t.sol
@@ -1,0 +1,727 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "./BaseTest.sol";
+import {MockDualInterfaceToken} from "./mocks/MockDualInterfaceToken.sol";
+import {PortalRecoverHarness} from "./mocks/PortalRecoverHarness.sol";
+import {IIntentSource} from "../contracts/interfaces/IIntentSource.sol";
+import {IVault} from "../contracts/interfaces/IVault.sol";
+import {PortalTron} from "../contracts/PortalTron.sol";
+import {IOriginSettler} from "../contracts/interfaces/ERC7683/IOriginSettler.sol";
+import {GaslessCrossChainOrder, OnchainCrossChainOrder, OrderData, Output, ORDER_DATA_TYPEHASH} from "../contracts/types/ERC7683.sol";
+
+/**
+ * @title NativeErc20DualTest
+ * @notice The tests the existing {NativeErc20RecoveryTest} cannot express. That suite uses a plain
+ *         {TestERC20} whose token balance is an independent mapping, so it can only prove the
+ *         native-alias guard "reverts on declaration" — never that, absent the guard, a native
+ *         reward really walks out through the ERC20 interface.
+ *
+ *         This suite drives a {MockDualInterfaceToken}: an ERC20 whose `balanceOf(a)` IS `a.balance`
+ *         and whose `transfer` moves native — the Arc double-count, where the native asset and a
+ *         specific ERC20 (USDC) are two views of ONE balance. That makes the drain path real, so we
+ *         can show it is OPEN before the fix (via {PortalRecoverHarness}, which is `recoverToken`
+ *         minus the guard) and CLOSED after it, and can exercise the valid reward shapes
+ *         (native-only, alias-ERC20-leg-only) end-to-end (fund → withdraw → refund) on an
+ *         alias-configured deployment.
+ *
+ * @dev Coverage map (mirrors the PR review's three-shape table):
+ *      - MOCK SANITY: the dual token genuinely aliases native (grounds every test below).
+ *      - P1 EXPLOIT: native reward drainable via the alias before the fix; blocked after.
+ *      - P1 ROW 2  : alias-ERC20-leg-only reward funds/withdraws/refunds; its recover is blocked
+ *                    by the existing reward-tokens loop.
+ *      - P2 ROW 1  : native-only reward withdraw/refund payouts on an alias deployment.
+ *      - P2 7683   : the guard fires on publishAndFund / publishAndFundFor / signed openFor.
+ *      - P3        : alias token at a non-zero leg index; partial funding; PortalTron.
+ */
+contract NativeErc20DualTest is BaseTest {
+    MockDualInterfaceToken internal dual; // the Arc-like native alias (USDC)
+    Portal internal aliasPortal; // deployed with `dual` as NATIVE_ERC20
+    IIntentSource internal aliasSource;
+
+    uint256 internal constant NATIVE_REWARD = 2 ether;
+    uint256 internal constant LEG_AMOUNT = 500; // small vs. the actors' native balances
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.startPrank(deployer);
+        dual = new MockDualInterfaceToken("Arc USDC", "USDC");
+        aliasPortal = new Portal(address(dual));
+        vm.stopPrank();
+
+        aliasSource = IIntentSource(address(aliasPortal));
+
+        // The dual token's balance IS native, so fund actors with native to give them "USDC".
+        _fundUserNative(creator, 100 ether);
+        _fundUserNative(claimant, 1 ether);
+        _fundUserNative(otherPerson, 10 ether);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    function _oneLeg(
+        address token,
+        uint256 amount
+    ) internal pure returns (TokenAmount[] memory legs) {
+        legs = new TokenAmount[](1);
+        legs[0] = TokenAmount({token: token, amount: amount});
+    }
+
+    /// @notice Builds a minimal (no calls) intent against `portalAddr`, salt-keyed for a unique hash.
+    function _intentOn(
+        address portalAddr,
+        bytes32 saltValue,
+        uint256 nativeAmount,
+        TokenAmount[] memory rewardLegs
+    ) internal view returns (Intent memory) {
+        Route memory _route = Route({
+            salt: saltValue,
+            deadline: uint64(expiry),
+            portal: portalAddr,
+            nativeAmount: 0,
+            tokens: new TokenAmount[](0),
+            calls: new Call[](0)
+        });
+
+        Reward memory _reward = Reward({
+            deadline: uint64(expiry),
+            creator: creator,
+            prover: address(prover),
+            nativeAmount: nativeAmount,
+            tokens: rewardLegs
+        });
+
+        return Intent({destination: CHAIN_ID, route: _route, reward: _reward});
+    }
+
+    function _routeHash(Intent memory _intent) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_intent.route));
+    }
+
+    /// @notice Approves `aliasPortal` to pull `amount` of the dual token from `creator`.
+    function _approveDual(uint256 amount) internal {
+        vm.prank(creator);
+        dual.approve(address(aliasPortal), amount);
+    }
+
+    // ==================================================================== MOCK SANITY
+
+    /// @notice The dual token's ERC20 balance mirrors native, and transferring it moves native on
+    ///         both sides. Without this, every drain assertion below would be meaningless.
+    function testMock_erc20BalanceMirrorsNative() public {
+        address alice = makeAddr("alice");
+        address bob = makeAddr("bob");
+        vm.deal(alice, 5 ether);
+        vm.deal(bob, 0);
+
+        // ERC20 view == native balance.
+        assertEq(dual.balanceOf(alice), 5 ether);
+        assertEq(dual.balanceOf(bob), 0);
+
+        // An ERC20 transfer moves native.
+        vm.prank(alice);
+        dual.transfer(bob, 2 ether);
+
+        assertEq(alice.balance, 3 ether);
+        assertEq(bob.balance, 2 ether);
+        assertEq(dual.balanceOf(alice), 3 ether);
+        assertEq(dual.balanceOf(bob), 2 ether);
+
+        // A real native payout is reflected in the ERC20 view too — one balance, two interfaces.
+        vm.deal(bob, bob.balance + 1 ether);
+        assertEq(dual.balanceOf(bob), 3 ether);
+    }
+
+    // ==================================================================== P1 EXPLOIT REGRESSION
+
+    /// @notice BEFORE THE FIX: a native reward can be clawed back through the alias-ERC20 interface.
+    ///         `recoverToken` is meant to reclaim only *mistaken* transfers — never reward funds — but
+    ///         because the alias token's balance IS the vault's native balance, recovering the alias
+    ///         drains the escrowed native reward (here, back to the creator). {PortalRecoverHarness}
+    ///         is `recoverToken` with the eligibility guard removed, i.e. the pre-fix code path.
+    function testExploit_nativeRewardDrainableViaAliasBeforeFix() public {
+        vm.prank(deployer);
+        PortalRecoverHarness unfixed = new PortalRecoverHarness(address(dual));
+
+        Intent memory nativeReward = _intentOn(
+            address(unfixed),
+            keccak256("exploit-before"),
+            NATIVE_REWARD,
+            new TokenAmount[](0)
+        );
+
+        vm.prank(creator);
+        IIntentSource(address(unfixed)).publishAndFund{value: NATIVE_REWARD}(
+            nativeReward,
+            false
+        );
+
+        address vault = IIntentSource(address(unfixed)).intentVaultAddress(
+            nativeReward
+        );
+        assertEq(
+            vault.balance,
+            NATIVE_REWARD,
+            "vault escrows the native reward"
+        );
+        assertEq(
+            dual.balanceOf(vault),
+            NATIVE_REWARD,
+            "alias view sees the same balance"
+        );
+
+        uint256 creatorBefore = creator.balance;
+
+        // The drain: recover the alias token. No guard -> vault.recover moves the native out.
+        unfixed.recoverTokenUnsafe(
+            nativeReward.destination,
+            _routeHash(nativeReward),
+            nativeReward.reward,
+            address(dual)
+        );
+
+        assertEq(vault.balance, 0, "native reward drained out of the vault");
+        assertEq(
+            creator.balance,
+            creatorBefore + NATIVE_REWARD,
+            "reward clawed back to the creator via the ERC20 door"
+        );
+    }
+
+    /// @notice AFTER THE FIX: the identical recovery on a stock {Portal} is rejected up front, and the
+    ///         native reward stays escrowed for the solver.
+    function testExploit_nativeRewardRecoverBlockedAfterFix() public {
+        // reward.tokens is EMPTY, so the reward-tokens loop and the zero-address check in
+        // _validateRecover cannot fire for `dual`; the revert below is attributable solely to the
+        // native-alias branch the fix added.
+        Intent memory nativeReward = _intentOn(
+            address(aliasPortal),
+            keccak256("exploit-after"),
+            NATIVE_REWARD,
+            new TokenAmount[](0)
+        );
+
+        vm.prank(creator);
+        aliasSource.publishAndFund{value: NATIVE_REWARD}(nativeReward, false);
+
+        address vault = aliasSource.intentVaultAddress(nativeReward);
+        assertEq(vault.balance, NATIVE_REWARD);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.InvalidRecoverToken.selector,
+                address(dual)
+            )
+        );
+        aliasSource.recoverToken(
+            nativeReward.destination,
+            _routeHash(nativeReward),
+            nativeReward.reward,
+            address(dual)
+        );
+
+        assertEq(vault.balance, NATIVE_REWARD, "reward remains escrowed");
+    }
+
+    // ==================================================================== P1 ROW 2: alias-ERC20-leg-only
+
+    /// @notice A reward whose only leg is the alias token (nativeAmount == 0) is a valid shape — the
+    ///         guard is inert. It funds by moving real native creator -> vault, and withdraws that
+    ///         native out to the claimant through the ERC20 interface.
+    function testRow2_aliasErc20LegOnly_fundsAndWithdrawsToClaimant() public {
+        Intent memory legIntent = _intentOn(
+            address(aliasPortal),
+            keccak256("row2-withdraw"),
+            0,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        _approveDual(LEG_AMOUNT);
+        vm.prank(creator);
+        aliasSource.publishAndFund(legIntent, false);
+
+        address vault = aliasSource.intentVaultAddress(legIntent);
+        assertTrue(
+            aliasSource.isIntentFunded(legIntent),
+            "leg funded from native"
+        );
+        assertEq(
+            vault.balance,
+            LEG_AMOUNT,
+            "funding moved native into the vault"
+        );
+
+        bytes32 intentHash = _hashIntent(legIntent);
+        _addProof(intentHash, CHAIN_ID, claimant);
+
+        uint256 claimantBefore = claimant.balance;
+        vm.prank(otherPerson);
+        aliasSource.withdraw(
+            legIntent.destination,
+            _routeHash(legIntent),
+            legIntent.reward
+        );
+
+        assertEq(vault.balance, 0, "vault emptied on withdraw");
+        assertEq(
+            claimant.balance,
+            claimantBefore + LEG_AMOUNT,
+            "claimant paid the alias leg as native"
+        );
+        assertFalse(aliasSource.isIntentFunded(legIntent));
+    }
+
+    /// @notice The same alias-ERC20-leg-only reward refunds its native back to the creator after the
+    ///         deadline passes without a proof.
+    function testRow2_aliasErc20LegOnly_refundsToCreatorAfterExpiry() public {
+        Intent memory legIntent = _intentOn(
+            address(aliasPortal),
+            keccak256("row2-refund"),
+            0,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        _approveDual(LEG_AMOUNT);
+        vm.prank(creator);
+        aliasSource.publishAndFund(legIntent, false);
+
+        address vault = aliasSource.intentVaultAddress(legIntent);
+        assertEq(vault.balance, LEG_AMOUNT);
+
+        _timeTravel(expiry + 1);
+
+        uint256 creatorBefore = creator.balance;
+        vm.prank(otherPerson);
+        aliasSource.refund(
+            legIntent.destination,
+            _routeHash(legIntent),
+            legIntent.reward
+        );
+
+        assertEq(vault.balance, 0, "vault swept on refund");
+        assertEq(
+            creator.balance,
+            creatorBefore + LEG_AMOUNT,
+            "alias leg refunded to creator as native"
+        );
+    }
+
+    /// @notice When the alias token is a *declared reward leg* (nativeAmount == 0), recovering it is
+    ///         blocked by the existing reward-tokens loop — the same-asset branch is not even reached.
+    function testRow2_aliasErc20Leg_recoverBlockedByRewardTokensLoop() public {
+        Intent memory legIntent = _intentOn(
+            address(aliasPortal),
+            keccak256("row2-recover"),
+            0,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        _approveDual(LEG_AMOUNT);
+        vm.prank(creator);
+        aliasSource.publishAndFund(legIntent, false);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.InvalidRecoverToken.selector,
+                address(dual)
+            )
+        );
+        aliasSource.recoverToken(
+            legIntent.destination,
+            _routeHash(legIntent),
+            legIntent.reward,
+            address(dual)
+        );
+    }
+
+    // ==================================================================== P2 ROW 1: native-only payouts
+
+    /// @notice A native-only reward withdraws to the claimant on an alias-configured deployment.
+    function testNativeOnly_withdrawPaysClaimant_onAliasDeployment() public {
+        Intent memory nativeReward = _intentOn(
+            address(aliasPortal),
+            keccak256("native-withdraw"),
+            NATIVE_REWARD,
+            new TokenAmount[](0)
+        );
+
+        vm.prank(creator);
+        aliasSource.publishAndFund{value: NATIVE_REWARD}(nativeReward, false);
+
+        address vault = aliasSource.intentVaultAddress(nativeReward);
+        assertEq(vault.balance, NATIVE_REWARD);
+
+        bytes32 intentHash = _hashIntent(nativeReward);
+        _addProof(intentHash, CHAIN_ID, claimant);
+
+        uint256 claimantBefore = claimant.balance;
+        vm.prank(otherPerson);
+        aliasSource.withdraw(
+            nativeReward.destination,
+            _routeHash(nativeReward),
+            nativeReward.reward
+        );
+
+        assertEq(claimant.balance, claimantBefore + NATIVE_REWARD);
+        assertFalse(aliasSource.isIntentFunded(nativeReward));
+    }
+
+    /// @notice A native-only reward refunds to the creator after expiry on an alias deployment.
+    function testNativeOnly_refundReturnsToCreator_onAliasDeployment() public {
+        Intent memory nativeReward = _intentOn(
+            address(aliasPortal),
+            keccak256("native-refund"),
+            NATIVE_REWARD,
+            new TokenAmount[](0)
+        );
+
+        vm.prank(creator);
+        aliasSource.publishAndFund{value: NATIVE_REWARD}(nativeReward, false);
+
+        address vault = aliasSource.intentVaultAddress(nativeReward);
+        assertEq(vault.balance, NATIVE_REWARD);
+
+        _timeTravel(expiry + 1);
+
+        uint256 creatorBefore = creator.balance;
+        vm.prank(otherPerson);
+        aliasSource.refund(
+            nativeReward.destination,
+            _routeHash(nativeReward),
+            nativeReward.reward
+        );
+
+        assertEq(vault.balance, 0);
+        assertEq(creator.balance, creatorBefore + NATIVE_REWARD);
+    }
+
+    // ==================================================================== P2 7683: guard on every entry
+
+    /// @notice The guard fires on `publishAndFund` — a native amount plus an alias-token leg is rejected.
+    function testPublishAndFund_revertsOnNativePlusAliasLeg() public {
+        Intent memory conflict = _intentOn(
+            address(aliasPortal),
+            keccak256("paf-conflict"),
+            NATIVE_REWARD,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(creator);
+        aliasSource.publishAndFund{value: NATIVE_REWARD}(conflict, false);
+    }
+
+    /// @notice The guard fires on `publishAndFundFor`, the funded-on-behalf entry point.
+    function testPublishAndFundFor_revertsOnNativePlusAliasLeg() public {
+        Intent memory conflict = _intentOn(
+            address(aliasPortal),
+            keccak256("paff-conflict"),
+            NATIVE_REWARD,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(otherPerson);
+        aliasSource.publishAndFundFor{value: NATIVE_REWARD}(
+            conflict,
+            false,
+            creator,
+            address(0)
+        );
+    }
+
+    /// @notice The guard fires on the gasless ERC-7683 `openFor` path — the untrusted-input surface
+    ///         where a solver submits a user's signed order. A native+alias-leg reward is rejected
+    ///         before any funds move.
+    function testOpenFor_revertsOnNativePlusAliasLeg() public {
+        (address user, uint256 userPk) = makeAddrAndKey("gaslessUser");
+
+        // The conflicting reward, carried inside the signed order.
+        Reward memory conflictReward = Reward({
+            deadline: uint64(expiry),
+            creator: user,
+            prover: address(prover),
+            nativeAmount: NATIVE_REWARD,
+            tokens: _oneLeg(address(dual), LEG_AMOUNT)
+        });
+
+        Route memory orderRoute = Route({
+            salt: keccak256("openfor-conflict"),
+            deadline: uint64(expiry),
+            portal: address(aliasPortal),
+            nativeAmount: 0,
+            tokens: new TokenAmount[](0),
+            calls: new Call[](0)
+        });
+
+        OrderData memory od = OrderData({
+            destination: CHAIN_ID,
+            route: abi.encode(orderRoute),
+            reward: conflictReward,
+            routePortal: bytes32(uint256(uint160(address(aliasPortal)))),
+            routeDeadline: uint64(expiry),
+            maxSpent: new Output[](0)
+        });
+        bytes memory orderData = abi.encode(od);
+
+        GaslessCrossChainOrder memory order = GaslessCrossChainOrder({
+            originSettler: address(aliasPortal),
+            user: user,
+            nonce: 1,
+            originChainId: block.chainid,
+            openDeadline: uint32(block.timestamp + 3600),
+            fillDeadline: uint32(block.timestamp + 7200),
+            orderDataType: ORDER_DATA_TYPEHASH,
+            orderData: orderData
+        });
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                aliasPortal.GASLESS_CROSSCHAIN_ORDER_TYPEHASH(),
+                order.originSettler,
+                order.user,
+                order.nonce,
+                order.originChainId,
+                order.openDeadline,
+                order.fillDeadline,
+                order.orderDataType,
+                keccak256(order.orderData)
+            )
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                hex"1901",
+                aliasPortal.domainSeparatorV4(),
+                structHash
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPk, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(otherPerson); // the solver submits the user's signed order
+        aliasPortal.openFor{value: NATIVE_REWARD}(order, signature, "");
+    }
+
+    /// @notice The guard also fires on the onchain ERC-7683 `open` path (user is msg.sender), the
+    ///         sibling of the gasless `openFor` entry point.
+    function testOpen_revertsOnNativePlusAliasLeg() public {
+        Reward memory conflictReward = Reward({
+            deadline: uint64(expiry),
+            creator: creator,
+            prover: address(prover),
+            nativeAmount: NATIVE_REWARD,
+            tokens: _oneLeg(address(dual), LEG_AMOUNT)
+        });
+
+        Route memory orderRoute = Route({
+            salt: keccak256("open-conflict"),
+            deadline: uint64(expiry),
+            portal: address(aliasPortal),
+            nativeAmount: 0,
+            tokens: new TokenAmount[](0),
+            calls: new Call[](0)
+        });
+
+        OrderData memory od = OrderData({
+            destination: CHAIN_ID,
+            route: abi.encode(orderRoute),
+            reward: conflictReward,
+            routePortal: bytes32(uint256(uint160(address(aliasPortal)))),
+            routeDeadline: uint64(expiry),
+            maxSpent: new Output[](0)
+        });
+
+        OnchainCrossChainOrder memory order = OnchainCrossChainOrder({
+            fillDeadline: uint32(block.timestamp + 7200),
+            orderDataType: ORDER_DATA_TYPEHASH,
+            orderData: abi.encode(od)
+        });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(creator);
+        aliasPortal.open{value: NATIVE_REWARD}(order);
+    }
+
+    // ==================================================================== VALID MULTI-LEG COEXISTENCE
+
+    /// @notice A valid reward may carry the alias token as ONE leg beside an ordinary ERC20 leg (with
+    ///         no native amount). A single withdraw must pay the ordinary leg from its own token
+    ///         balance AND the alias leg as native — proving per-leg payout is correct when the alias
+    ///         sits at a non-zero index of a funded, withdrawable reward (not just a revert case).
+    function testRow2_aliasLegPlusRealErc20Leg_fundsAndWithdraws() public {
+        uint256 tokenLeg = MINT_AMOUNT;
+
+        TokenAmount[] memory legs = new TokenAmount[](2);
+        legs[0] = TokenAmount({token: address(tokenA), amount: tokenLeg});
+        legs[1] = TokenAmount({token: address(dual), amount: LEG_AMOUNT});
+
+        Intent memory coexist = _intentOn(
+            address(aliasPortal),
+            keccak256("coexist"),
+            0,
+            legs
+        );
+
+        // creator must fund both legs: tokenA (real ERC20) and dual (native), each approved to aliasPortal.
+        vm.startPrank(creator);
+        tokenA.mint(creator, tokenLeg);
+        tokenA.approve(address(aliasPortal), tokenLeg);
+        dual.approve(address(aliasPortal), LEG_AMOUNT);
+        vm.stopPrank();
+
+        vm.prank(creator);
+        aliasSource.publishAndFund(coexist, false);
+
+        address vault = aliasSource.intentVaultAddress(coexist);
+        assertTrue(aliasSource.isIntentFunded(coexist));
+        assertEq(tokenA.balanceOf(vault), tokenLeg, "real ERC20 leg escrowed");
+        assertEq(vault.balance, LEG_AMOUNT, "alias leg escrowed as native");
+
+        bytes32 intentHash = _hashIntent(coexist);
+        _addProof(intentHash, CHAIN_ID, claimant);
+
+        uint256 claimantNativeBefore = claimant.balance;
+        vm.prank(otherPerson);
+        aliasSource.withdraw(
+            coexist.destination,
+            _routeHash(coexist),
+            coexist.reward
+        );
+
+        assertEq(
+            tokenA.balanceOf(claimant),
+            tokenLeg,
+            "ordinary leg paid in tokens"
+        );
+        assertEq(
+            claimant.balance,
+            claimantNativeBefore + LEG_AMOUNT,
+            "alias leg paid as native"
+        );
+        assertEq(tokenA.balanceOf(vault), 0);
+        assertEq(vault.balance, 0);
+    }
+
+    // ==================================================================== DEFAULT-DEPLOYMENT INERTNESS
+
+    /// @notice On a default deployment (`NATIVE_ERC20 == address(0)`), the funding guard is inert: a
+    ///         legitimate reward with BOTH a native amount and an ordinary ERC20 leg funds normally.
+    ///         Guards against the fix over-blocking normal (non-alias) chains.
+    function testDefaultDeployment_nativePlusErc20LegAllowed() public {
+        _mintAndApprove(creator, MINT_AMOUNT); // approves the default `portal` for tokenA
+
+        Intent memory ok = _intentOn(
+            address(portal),
+            keccak256("default-native-plus-erc20"),
+            NATIVE_REWARD,
+            _oneLeg(address(tokenA), MINT_AMOUNT)
+        );
+
+        vm.prank(creator);
+        intentSource.publishAndFund{value: NATIVE_REWARD}(ok, false);
+
+        assertTrue(
+            intentSource.isIntentFunded(ok),
+            "native+ERC20 reward funds on a default deployment"
+        );
+    }
+
+    // ==================================================================== P3: index / partial / Tron
+
+    /// @notice The guard scans every leg, not just index 0 — an alias token at a non-zero index still
+    ///         collides with a native amount.
+    function testGuard_scansAllLegs_aliasAtNonZeroIndex() public {
+        TokenAmount[] memory legs = new TokenAmount[](2);
+        legs[0] = TokenAmount({token: address(tokenA), amount: LEG_AMOUNT});
+        legs[1] = TokenAmount({token: address(dual), amount: LEG_AMOUNT});
+
+        Intent memory conflict = _intentOn(
+            address(aliasPortal),
+            keccak256("nonzero-index"),
+            NATIVE_REWARD,
+            legs
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(creator);
+        aliasSource.publish(conflict);
+    }
+
+    /// @notice Partial funding of an alias-ERC20 leg behaves consistently: the vault's native balance
+    ///         tracks exactly what was funded, and the intent is not marked fully funded.
+    function testPartialFunding_aliasErc20Leg() public {
+        Intent memory legIntent = _intentOn(
+            address(aliasPortal),
+            keccak256("partial"),
+            0,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        // Approve only half, so only half the leg can be pulled.
+        _approveDual(LEG_AMOUNT / 2);
+        vm.prank(creator);
+        aliasSource.publishAndFund(legIntent, true);
+
+        address vault = aliasSource.intentVaultAddress(legIntent);
+        assertEq(
+            vault.balance,
+            LEG_AMOUNT / 2,
+            "vault holds the partially funded native"
+        );
+        assertEq(dual.balanceOf(vault), LEG_AMOUNT / 2, "alias view agrees");
+        assertFalse(
+            aliasSource.isIntentFunded(legIntent),
+            "not fully funded on a partial fund"
+        );
+    }
+
+    /// @notice The Tron portal variant received the same constructor change; its guard fires on a
+    ///         native+alias-leg reward too (publish rejects before any vault work).
+    function testPortalTron_guardRevertsOnNativePlusAliasLeg() public {
+        vm.prank(deployer);
+        PortalTron tronPortal = new PortalTron(address(dual));
+
+        Intent memory conflict = _intentOn(
+            address(tronPortal),
+            keccak256("tron-conflict"),
+            NATIVE_REWARD,
+            _oneLeg(address(dual), LEG_AMOUNT)
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(dual)
+            )
+        );
+        vm.prank(creator);
+        IIntentSource(address(tronPortal)).publish(conflict);
+    }
+}

--- a/test/NativeErc20Recovery.t.sol
+++ b/test/NativeErc20Recovery.t.sol
@@ -61,6 +61,41 @@ contract NativeErc20RecoveryTest is BaseTest {
         return Intent({destination: CHAIN_ID, route: _route, reward: _reward});
     }
 
+    /// @notice Builds an intent whose reward carries BOTH a native amount and an explicit token leg
+    ///         for the alias token — the shape the funding-time guard must reject.
+    function _aliasIntentWithTokenLeg(
+        bytes32 saltValue,
+        uint256 nativeAmount,
+        uint256 tokenLegAmount
+    ) internal view returns (Intent memory) {
+        TokenAmount[] memory noTokens = new TokenAmount[](0);
+        TokenAmount[] memory tokenLeg = new TokenAmount[](1);
+        tokenLeg[0] = TokenAmount({
+            token: address(aliasToken),
+            amount: tokenLegAmount
+        });
+        Call[] memory noCalls = new Call[](0);
+
+        Route memory _route = Route({
+            salt: saltValue,
+            deadline: uint64(expiry),
+            portal: address(aliasPortal),
+            nativeAmount: 0,
+            tokens: noTokens,
+            calls: noCalls
+        });
+
+        Reward memory _reward = Reward({
+            deadline: uint64(expiry),
+            creator: creator,
+            prover: address(prover),
+            nativeAmount: nativeAmount,
+            tokens: tokenLeg
+        });
+
+        return Intent({destination: CHAIN_ID, route: _route, reward: _reward});
+    }
+
     function _publishAndFundAlias(
         Intent memory _intent
     ) internal returns (bytes32 intentHash, address vault) {
@@ -161,5 +196,51 @@ contract NativeErc20RecoveryTest is BaseTest {
 
         assertEq(unrelatedToken.balanceOf(vault), 0);
         assertEq(unrelatedToken.balanceOf(creator), MINT_AMOUNT);
+    }
+
+    /// @notice A reward's native amount and an explicit alias-token leg mirror the same underlying
+    ///         funds — a reward may not declare both at once. `publish` must reject it up front.
+    function testPublish_revertsWhenNativeAndAliasLegsBothPresent() public {
+        Intent memory doubleLegIntent = _aliasIntentWithTokenLeg(
+            bytes32(uint256(4)),
+            NATIVE_LEG_AMOUNT,
+            MINT_AMOUNT
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(aliasToken)
+            )
+        );
+        aliasIntentSource.publish(doubleLegIntent);
+    }
+
+    /// @notice The same guard applies on `fundFor`, which can escrow a reward directly without a
+    ///         prior `publish` call — the check must not be bypassable through that entry point.
+    function testFundFor_revertsWhenNativeAndAliasLegsBothPresent_withoutPriorPublish()
+        public
+    {
+        Intent memory doubleLegIntent = _aliasIntentWithTokenLeg(
+            bytes32(uint256(5)),
+            NATIVE_LEG_AMOUNT,
+            MINT_AMOUNT
+        );
+        bytes32 routeHash = keccak256(abi.encode(doubleLegIntent.route));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(aliasToken)
+            )
+        );
+        aliasIntentSource.fundFor(
+            doubleLegIntent.destination,
+            routeHash,
+            doubleLegIntent.reward,
+            false,
+            creator,
+            address(0)
+        );
     }
 }

--- a/test/NativeErc20Recovery.t.sol
+++ b/test/NativeErc20Recovery.t.sol
@@ -243,4 +243,31 @@ contract NativeErc20RecoveryTest is BaseTest {
             address(0)
         );
     }
+
+    /// @notice The same guard applies on `fund`, which can also escrow a reward directly without a
+    ///         prior `publish` call — the check must not be bypassable through that entry point either.
+    function testFund_revertsWhenNativeAndAliasLegsBothPresent_withoutPriorPublish()
+        public
+    {
+        Intent memory doubleLegIntent = _aliasIntentWithTokenLeg(
+            bytes32(uint256(6)),
+            NATIVE_LEG_AMOUNT,
+            MINT_AMOUNT
+        );
+        bytes32 routeHash = keccak256(abi.encode(doubleLegIntent.route));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.RewardTokensNotUnique.selector,
+                address(aliasToken)
+            )
+        );
+        vm.prank(creator);
+        aliasIntentSource.fund(
+            doubleLegIntent.destination,
+            routeHash,
+            doubleLegIntent.reward,
+            false
+        );
+    }
 }

--- a/test/NativeErc20Recovery.t.sol
+++ b/test/NativeErc20Recovery.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "./BaseTest.sol";
+import {IIntentSource} from "../contracts/interfaces/IIntentSource.sol";
+
+/**
+ * @title NativeErc20RecoveryTest
+ * @notice Tests for the NATIVE_ERC20 recovery-eligibility check in {IntentSource-_validateRecover}.
+ * @dev The shared `portal` fixture from {BaseTest} is deployed with `nativeErc20 = address(0)`,
+ *      which keeps the check fully inert (default deployment behavior). `aliasPortal` is a second
+ *      deployment configured with a real ERC20 token as its native/ERC20 alias, used to exercise
+ *      the check itself.
+ */
+contract NativeErc20RecoveryTest is BaseTest {
+    Portal internal aliasPortal;
+    IIntentSource internal aliasIntentSource;
+    TestERC20 internal aliasToken;
+
+    uint256 internal constant NATIVE_LEG_AMOUNT = 1 ether;
+
+    function setUp() public override {
+        super.setUp();
+        _mintAndApprove(creator, MINT_AMOUNT);
+        _fundUserNative(creator, 100 ether);
+
+        vm.startPrank(deployer);
+        aliasToken = new TestERC20("Alias Token", "ALIAS");
+        aliasPortal = new Portal(address(aliasToken));
+        vm.stopPrank();
+
+        aliasIntentSource = IIntentSource(address(aliasPortal));
+    }
+
+    /// @notice Builds a minimal intent against `aliasPortal` with no reward tokens, only an
+    ///         optional native leg, so the alias token never appears in `reward.tokens` directly.
+    function _aliasIntent(
+        bytes32 saltValue,
+        uint256 nativeAmount
+    ) internal view returns (Intent memory) {
+        TokenAmount[] memory noTokens = new TokenAmount[](0);
+        Call[] memory noCalls = new Call[](0);
+
+        Route memory _route = Route({
+            salt: saltValue,
+            deadline: uint64(expiry),
+            portal: address(aliasPortal),
+            nativeAmount: 0,
+            tokens: noTokens,
+            calls: noCalls
+        });
+
+        Reward memory _reward = Reward({
+            deadline: uint64(expiry),
+            creator: creator,
+            prover: address(prover),
+            nativeAmount: nativeAmount,
+            tokens: noTokens
+        });
+
+        return Intent({destination: CHAIN_ID, route: _route, reward: _reward});
+    }
+
+    function _publishAndFundAlias(
+        Intent memory _intent
+    ) internal returns (bytes32 intentHash, address vault) {
+        vm.prank(creator);
+        (intentHash, vault) = aliasIntentSource.publishAndFund{
+            value: _intent.reward.nativeAmount
+        }(_intent, false);
+    }
+
+    /// @notice On the default deployment (`nativeErc20 = address(0)`), recovering an unrelated
+    ///         token mistakenly sent to a funded vault behaves exactly as before.
+    function testRecover_defaultDeployment_stillWorks() public {
+        _publishAndFund(intent, false);
+
+        TestERC20 strayToken = new TestERC20("Stray Token", "STRAY");
+        address vault = intentSource.intentVaultAddress(intent);
+        strayToken.mint(vault, MINT_AMOUNT);
+
+        vm.prank(creator);
+        intentSource.recoverToken(
+            intent.destination,
+            keccak256(abi.encode(intent.route)),
+            intent.reward,
+            address(strayToken)
+        );
+
+        assertEq(strayToken.balanceOf(vault), 0);
+        assertEq(strayToken.balanceOf(creator), MINT_AMOUNT);
+    }
+
+    /// @notice On a deployment with a configured alias, the alias token can't be recovered while
+    ///         the reward still carries a non-zero native leg.
+    function testRecover_aliasToken_blockedWhenNativeLegPresent() public {
+        Intent memory aliasIntent = _aliasIntent(
+            bytes32(uint256(1)),
+            NATIVE_LEG_AMOUNT
+        );
+        (, address vault) = _publishAndFundAlias(aliasIntent);
+
+        aliasToken.mint(vault, MINT_AMOUNT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IIntentSource.InvalidRecoverToken.selector,
+                address(aliasToken)
+            )
+        );
+        vm.prank(creator);
+        aliasIntentSource.recoverToken(
+            aliasIntent.destination,
+            keccak256(abi.encode(aliasIntent.route)),
+            aliasIntent.reward,
+            address(aliasToken)
+        );
+    }
+
+    /// @notice The same alias token remains recoverable for an intent whose reward has no native
+    ///         leg — the check only blocks recovery when there's a native amount to protect.
+    function testRecover_aliasToken_allowedWhenNoNativeLeg() public {
+        Intent memory aliasIntent = _aliasIntent(bytes32(uint256(2)), 0);
+        (, address vault) = _publishAndFundAlias(aliasIntent);
+
+        aliasToken.mint(vault, MINT_AMOUNT);
+
+        vm.prank(creator);
+        aliasIntentSource.recoverToken(
+            aliasIntent.destination,
+            keccak256(abi.encode(aliasIntent.route)),
+            aliasIntent.reward,
+            address(aliasToken)
+        );
+
+        assertEq(aliasToken.balanceOf(vault), 0);
+        assertEq(aliasToken.balanceOf(creator), MINT_AMOUNT);
+    }
+
+    /// @notice A genuinely unrelated token — neither the alias nor a reward token — stays
+    ///         recoverable even when the reward carries a native leg.
+    function testRecover_unrelatedToken_stillAllowedAlongsideNativeLeg()
+        public
+    {
+        Intent memory aliasIntent = _aliasIntent(
+            bytes32(uint256(3)),
+            NATIVE_LEG_AMOUNT
+        );
+        (, address vault) = _publishAndFundAlias(aliasIntent);
+
+        TestERC20 unrelatedToken = new TestERC20("Unrelated Token", "UNRL");
+        unrelatedToken.mint(vault, MINT_AMOUNT);
+
+        vm.prank(creator);
+        aliasIntentSource.recoverToken(
+            aliasIntent.destination,
+            keccak256(abi.encode(aliasIntent.route)),
+            aliasIntent.reward,
+            address(unrelatedToken)
+        );
+
+        assertEq(unrelatedToken.balanceOf(vault), 0);
+        assertEq(unrelatedToken.balanceOf(creator), MINT_AMOUNT);
+    }
+}

--- a/test/OriginSettler.spec.ts
+++ b/test/OriginSettler.spec.ts
@@ -73,7 +73,7 @@ describe('Origin Settler Test', (): void => {
     const [creator, owner, otherPerson] = await ethers.getSigners()
 
     const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portal = await portalFactory.deploy(ethers.ZeroAddress)
     inbox = await ethers.getContractAt('Inbox', await portal.getAddress())
 
     // deploy prover

--- a/test/TokenSecurityTests.spec.ts
+++ b/test/TokenSecurityTests.spec.ts
@@ -30,7 +30,7 @@ describe('Token Security Tests', () => {
 
     // Deploy Portal (which includes IntentSource and Inbox)
     const portalFactory = await ethers.getContractFactory('Portal')
-    const portal = await portalFactory.deploy()
+    const portal = await portalFactory.deploy(ethers.ZeroAddress)
     // Use the IIntentSource interface with the Portal implementation
     const intentSource = await ethers.getContractAt(
       'IIntentSource',

--- a/test/core/Inbox.t.sol
+++ b/test/core/Inbox.t.sol
@@ -38,7 +38,7 @@ contract InboxTest is BaseTest {
         vm.chainId(validChainId);
 
         // This should not revert
-        Portal newPortal = new Portal();
+        Portal newPortal = new Portal(address(0));
         assertTrue(address(newPortal) != address(0));
     }
 

--- a/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_Arc.t.sol
@@ -38,7 +38,7 @@ contract DepositAddress_CCTPMint_ArcTest is Test {
 
     function setUp() public {
         token = new TestERC20("Test USDC", "USDC");
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         factory = new DepositFactory_CCTPMint_Arc(
             address(token),

--- a/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositAddress_CCTPMint_GatewayERC20.t.sol
@@ -38,7 +38,7 @@ contract DepositAddress_CCTPMint_GatewayERC20Test is Test {
 
     function setUp() public {
         token = new TestERC20("Test USDC", "USDC");
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         factory = new DepositFactory_CCTPMint_GatewayERC20(
             address(token),

--- a/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositAddress_USDCTransfer_Solana.t.sol
@@ -35,7 +35,7 @@ contract DepositAddressTest is Test {
         token = new TestERC20("Test Token", "TEST");
 
         // Deploy Portal
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         // Deploy factory
         factory = new DepositFactory_USDCTransfer_Solana(

--- a/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_Arc.t.sol
@@ -30,7 +30,7 @@ contract DepositFactory_CCTPMint_ArcTest is Test {
     address constant DEPOSITOR_2 = address(0x4444);
 
     function setUp() public {
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         factory = new DepositFactory_CCTPMint_Arc(
             SOURCE_TOKEN,

--- a/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
+++ b/test/deposit/DepositFactory_CCTPMint_GatewayERC20.t.sol
@@ -31,7 +31,7 @@ contract DepositFactory_CCTPMint_GatewayERC20Test is Test {
     address constant DEPOSITOR_2 = address(0x4444);
 
     function setUp() public {
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         factory = new DepositFactory_CCTPMint_GatewayERC20(
             SOURCE_TOKEN,

--- a/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositFactory_USDCTransfer_Solana.t.sol
@@ -29,7 +29,7 @@ contract DepositFactoryTest is Test {
 
     function setUp() public {
         // Deploy Portal
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         // Deploy factory
         factory = new DepositFactory_USDCTransfer_Solana(

--- a/test/deposit/DepositIntegration_CCTPMint.t.sol
+++ b/test/deposit/DepositIntegration_CCTPMint.t.sol
@@ -81,7 +81,7 @@ contract DepositIntegration_CCTPMintTest is Test {
         token = new TestERC20("USD Coin", "USDC");
 
         // Deploy Portal
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         // Deploy LocalProver (for same-chain testing)
         prover = new LocalProver(address(portal));

--- a/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
+++ b/test/deposit/DepositIntegration_USDCTransfer_Solana.t.sol
@@ -52,7 +52,7 @@ contract DepositIntegration_USDCTransfer_SolanaTest is Test {
         token = new TestERC20("Test Token", "TEST");
 
         // Deploy Portal
-        portal = new Portal();
+        portal = new Portal(address(0));
 
         // Deploy prover
         prover = new TestProver(address(portal));

--- a/test/interfaces/OriginSettler.t.sol
+++ b/test/interfaces/OriginSettler.t.sol
@@ -207,7 +207,7 @@ contract OriginSettlerTest is BaseTest {
 
         // The domain separator should be unique to this contract instance
         // Deploy another Portal and verify they have different domain separators
-        Portal portal2 = new Portal();
+        Portal portal2 = new Portal(address(0));
         bytes32 domainSeparator3 = portal2.domainSeparatorV4();
 
         // Domain separators should be different due to different contract addresses
@@ -247,7 +247,7 @@ contract OriginSettlerTest is BaseTest {
 
         // Deploy a new Portal on a different chain ID
         vm.chainId(999);
-        Portal portalDifferentChain = new Portal();
+        Portal portalDifferentChain = new Portal(address(0));
         bytes32 domainSeparator2 = portalDifferentChain.domainSeparatorV4();
 
         // Domain separators should be different on different chains
@@ -255,7 +255,7 @@ contract OriginSettlerTest is BaseTest {
 
         // Deploy another Portal on the original chain
         vm.chainId(1);
-        Portal portalSameChain = new Portal();
+        Portal portalSameChain = new Portal(address(0));
         bytes32 domainSeparator3 = portalSameChain.domainSeparatorV4();
 
         // Domain separator should be different from the first portal due to different addresses

--- a/test/mocks/MockDualInterfaceToken.sol
+++ b/test/mocks/MockDualInterfaceToken.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Vm} from "forge-std/Vm.sol";
+
+/**
+ * @title MockDualInterfaceToken
+ * @notice A test-only ERC20 whose token balance IS the account's native balance — the
+ *         defining property of a chain like Arc, where the native asset is double-counted
+ *         as an ERC20 (USDC). The ERC20 interface and native balance are two views of ONE
+ *         underlying number, not independent balances.
+ *
+ * @dev Why this exists: a normal mock ERC20 keeps its own `_balances` mapping that has nothing
+ *      to do with `account.balance`. Recovering/withdrawing such a mock moves *bookkeeping
+ *      tokens*, so it can only ever prove that a guard "reverts on declaration" — it can never
+ *      prove that, absent the guard, a native reward actually walks out through the ERC20 door.
+ *      This token closes that gap by making the two interfaces share one balance:
+ *
+ *        - `balanceOf(a)` returns `a.balance` (the native balance itself).
+ *        - `transfer` / `transferFrom` move native to mirror the ERC20 move.
+ *
+ *      A contract cannot debit an arbitrary account's native ETH on its own, so the move is
+ *      done with the `vm.deal` cheatcode. `vm.deal` SETS an absolute balance (it is not
+ *      additive), so `_move` reads the current balance and writes the intended new one.
+ *
+ *      Faithfulness: because both interfaces read and write the same `account.balance`, a real
+ *      production native payout (`payable(x).call{value: amt}`) and a cheatcode-driven ERC20
+ *      transfer genuinely contend over one balance — reproducing the Arc double-count.
+ *
+ *      Modeling choices (not verified properties of Arc):
+ *      - Amounts are treated as native-denominated 1:1. A real Arc USDC presents 6 decimals over
+ *        an 18-decimal native asset (a ~1e12 scale factor); this mock omits that scaling because
+ *        the guard under test is amount-independent, so it does not affect any assertion here.
+ *      - Crediting via `vm.deal` does not run the recipient's `receive()`, modeling an ERC20
+ *        credit as a pure balance write rather than a native value transfer. Every payout
+ *        recipient in the suite is an EOA, so this choice is not load-bearing.
+ *
+ *      Limitations (by construction): Forge-only (uses cheatcodes); `vm.deal` can mint/burn
+ *      native, so conservation is enforced by hand in `_move` (debit then credit equal amounts).
+ */
+contract MockDualInterfaceToken {
+    // solhint-disable-next-line max-line-length
+    Vm private constant vm =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 6; // USDC-like
+
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 value
+    );
+
+    error InsufficientBalance(address from, uint256 balance, uint256 needed);
+    error InsufficientAllowance(
+        address owner,
+        address spender,
+        uint256 allowance,
+        uint256 needed
+    );
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    /// @notice The ERC20 balance IS the native balance — one underlying number, two views.
+    function balanceOf(address account) public view returns (uint256) {
+        return account.balance;
+    }
+
+    /// @dev Not a meaningful quantity for a native-aliased token; total native supply is not
+    ///      knowable from a contract. Returned only to complete the ERC20 surface.
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _move(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    ) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            if (allowed < value) {
+                revert InsufficientAllowance(from, msg.sender, allowed, value);
+            }
+            allowance[from][msg.sender] = allowed - value;
+        }
+        _move(from, to, value);
+        return true;
+    }
+
+    /// @dev Moves `value` of native from `from` to `to` to mirror the ERC20 transfer. `vm.deal`
+    ///      sets an absolute balance, so compute each side's new balance by hand. The balance
+    ///      check mimics an ERC20 insufficient-balance revert.
+    function _move(address from, address to, uint256 value) internal {
+        uint256 fromBal = from.balance;
+        if (fromBal < value) {
+            revert InsufficientBalance(from, fromBal, value);
+        }
+        vm.deal(from, fromBal - value);
+        vm.deal(to, to.balance + value);
+        emit Transfer(from, to, value);
+    }
+}

--- a/test/mocks/PortalRecoverHarness.sol
+++ b/test/mocks/PortalRecoverHarness.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {Portal} from "../../contracts/Portal.sol";
+import {IVault} from "../../contracts/interfaces/IVault.sol";
+import {IIntentSource} from "../../contracts/interfaces/IIntentSource.sol";
+import {Reward} from "../../contracts/types/Intent.sol";
+
+/**
+ * @title PortalRecoverHarness
+ * @notice A Portal that additionally exposes {recoverTokenUnsafe} — the PRE-FIX body of
+ *         {IntentSource-recoverToken}, i.e. production `recoverToken` with ONLY the native-alias
+ *         branch of `_validateRecover` removed.
+ *
+ * @dev Kept alongside the fixed portal so a single test can show the drain is OPEN before the fix
+ *      and CLOSED after it (see NativeErc20Dual.t.sol). The delta between this and a stock
+ *      {Portal} is therefore EXACTLY the fix — nothing more. Production `_validateRecover` is:
+ *
+ *          if (token == address(0)) revert InvalidRecoverToken(token);          // kept below
+ *          for (i..) if (reward.tokens[i].token == token) revert ...;           // kept below
+ *          if (token == NATIVE_ERC20 && reward.nativeAmount != 0) revert ...;    // THE FIX — omitted
+ *
+ *      So this harness reproduces recoverToken as it behaved BEFORE the fix for any input: the
+ *      zero-address and reward-token checks still run; only the same-underlying-balance (native
+ *      alias) check is absent.
+ *
+ *      With a {MockDualInterfaceToken} as the configured native alias, `vault.recover` moves the
+ *      vault's native balance out through the ERC20 interface — draining a native reward that a
+ *      solver is owed back to the intent creator. The production guard reverts before reaching
+ *      `vault.recover`; this harness lets a test observe the loss the fix prevents.
+ */
+contract PortalRecoverHarness is Portal {
+    constructor(address nativeErc20) Portal(nativeErc20) {}
+
+    /// @notice Pre-fix {IntentSource-recoverToken}: the eligibility checks that existed before the
+    ///         fix run, but NOT the native-alias branch the fix added.
+    function recoverTokenUnsafe(
+        uint64 destination,
+        bytes32 routeHash,
+        Reward calldata reward,
+        address token
+    ) external {
+        (bytes32 intentHash, , ) = getIntentHash(
+            destination,
+            routeHash,
+            reward
+        );
+
+        // Pre-fix _validateRecover: everything except the native-alias branch (the fix).
+        if (token == address(0)) {
+            revert IIntentSource.InvalidRecoverToken(token);
+        }
+        uint256 rewardsLength = reward.tokens.length;
+        for (uint256 i; i < rewardsLength; ++i) {
+            if (reward.tokens[i].token == token) {
+                revert IIntentSource.InvalidRecoverToken(token);
+            }
+        }
+        // Production adds here: `if (token == NATIVE_ERC20 && reward.nativeAmount != 0) revert;`
+
+        IVault vault = IVault(_getOrDeployVault(intentHash));
+        vault.recover(reward.creator, token);
+    }
+}

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -42,7 +42,7 @@ contract LocalProverTest is Test {
         CHAIN_ID = uint64(block.chainid);
 
         // Deploy contracts
-        portal = new Portal();
+        portal = new Portal(address(0));
         localProver = new LocalProver(address(portal));
         secondaryProver = new TestProver(address(portal));
         token = new TestERC20("Test Token", "TEST");


### PR DESCRIPTION
## Summary
- Adds an optional immutable `NATIVE_ERC20` address to `IntentSource` (threaded through the `Portal`/`PortalTron` constructors as a new `nativeErc20` param). Default deploy value is `address(0)`, which leaves every check below fully inert and preserves existing behavior on every current deployment.
- When configured, a deployment's native asset may be aliased to an ERC20 token (its balance mirrors `address(this).balance` on every vault). Two things follow from treating them as the same underlying funds rather than independent assets:
  - `recoverToken` now also blocks recovery of the alias token whenever the reward still carries a non-zero native amount.
  - A reward may not declare both a non-zero native amount and an explicit token leg for the alias address at the same time — rejected up front via the existing `RewardTokensNotUnique` error, on every entry point that can escrow a reward (`publish`, `fund`, `fundFor` — the latter previously had no reward-leg validation on any entry point).
- Updates every `Portal`/`PortalTron` construction call site for the new constructor parameter, and adds regression tests covering the default inert case and both alias-configured guard paths (including a direct `fundFor` call with no prior `publish`, to confirm the guard isn't bypassable through that entry point).

Supersedes #408, which got closed as a side effect of a branch rename rather than a merge.

## Test plan
- [x] `forge build`
- [x] `forge test` (573 passing)
- [x] `yarn test:hardhat` (112 passing)
- [x] `yarn test:ts` (42 passing)
- [x] `forge build --sizes` — Portal/PortalTron runtime margin 1,554 bytes under EIP-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4pnnevHt2zFJwDqPyJreT