### PR TITLE
fix(local-prover): return forwarded native value to the prove() caller

### DIFF
--- a/contracts/interfaces/ILocalProver.sol
+++ b/contracts/interfaces/ILocalProver.sol
@@ -34,6 +34,15 @@ interface ILocalProver is IProver {
         uint256 nativeFee
     );
 
+    /**
+     * @notice Emitted when prove() could not return forwarded native value to the sender
+     * @dev prove() must never revert, so a failed refund is reported rather than thrown.
+     *      The value stays in the contract and is paid out by the next flashFulfill.
+     * @param recipient Address the refund was attempted to
+     * @param amount Amount of native tokens that could not be refunded
+     */
+    event ProveRefundFailed(address indexed recipient, uint256 amount);
+
     /*//////////////////////////////////////////////////////////////
                             EXTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/

--- a/contracts/interfaces/ILocalProver.sol
+++ b/contracts/interfaces/ILocalProver.sol
@@ -18,6 +18,16 @@ interface ILocalProver is IProver {
     error InvalidProver();
     error NativeTransferFailed();
 
+    /**
+     * @notice Refund of forwarded native value to the caller failed
+     * @dev prove() reverts with this when the forwarded ETH cannot be delivered
+     *      to `sender`. The recipient is always the tx caller (Inbox.prove passes
+     *      msg.sender), so a revert only self-DoSes that caller.
+     * @param recipient Address the refund was attempted to
+     * @param amount Amount of native tokens that could not be refunded
+     */
+    error RefundFailed(address recipient, uint256 amount);
+
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -33,15 +43,6 @@ interface ILocalProver is IProver {
         bytes32 indexed claimant,
         uint256 nativeFee
     );
-
-    /**
-     * @notice Emitted when prove() could not return forwarded native value to the sender
-     * @dev prove() must never revert, so a failed refund is reported rather than thrown.
-     *      The value stays in the contract and is paid out by the next flashFulfill.
-     * @param recipient Address the refund was attempted to
-     * @param amount Amount of native tokens that could not be refunded
-     */
-    event ProveRefundFailed(address indexed recipient, uint256 amount);
 
     /*//////////////////////////////////////////////////////////////
                             EXTERNAL FUNCTIONS

--- a/contracts/prover/LocalProver.sol
+++ b/contracts/prover/LocalProver.sol
@@ -125,25 +125,25 @@ contract LocalProver is ILocalProver, Semver, ReentrancyGuard {
      *      legitimately hold ETH from a flashFulfill payout that its claimant rejected;
      *      refunding the full balance would let anyone drain it with a dust-valued call.
      *
-     *      The refund is deliberately failure-tolerant and MUST NOT revert, or a `sender`
-     *      that cannot receive ETH would be unable to use fulfillAndProve at all. The
-     *      refund call is given a bounded gas stipend precisely so this holds: an
-     *      unbounded call lets a griefing recipient consume ~63/64 of the gas (EIP-150),
-     *      leaving too little for the trailing ProveRefundFailed emit and reverting the
-     *      whole call. A failed or too-expensive refund emits ProveRefundFailed and leaves
-     *      the value here (the pre-existing behaviour); the same applies to a zero
-     *      `sender`, which Inbox.prove never produces but a direct caller can.
+     *      The refund uses an uncapped, all-gas low-level call (not transfer()'s 2300-gas
+     *      cap) so any smart-contract recipient -- a smart account or EIP-7702 wallet whose
+     *      receive() needs more than the stipend -- can still receive it. On failure it
+     *      reverts with RefundFailed rather than swallowing the boolean: reverting surfaces
+     *      a genuinely-unpayable recipient loudly instead of silently stranding the caller's
+     *      ETH here as dust with no sweep path. The refund recipient is always the tx caller
+     *      (Inbox.prove passes msg.sender), so a revert only self-DoSes that caller -- there
+     *      is no third-party griefing vector.
      *
-     *      The stipend is far below flashFulfill's cost, so it also restores the
-     *      reentrancy barrier that `.transfer`'s 2300-gas limit used to provide -- the
-     *      unbounded call it replaces did allow a reentrant flashFulfill, though only to
-     *      collect rewards the caller was already entitled to (flashFulfill is
+     *      Reentrancy remains contained: the refund is the terminal statement of prove()
+     *      (no post-refund state) and Inbox.prove has already drained the Portal's balance
+     *      before this call, so a reentrant flashFulfill would carry no extra value and could
+     *      at most collect rewards the caller was already entitled to (flashFulfill is
      *      permissionless regardless).
      *
-     *      ProveRefundFailed doubles as an MEV signal: it advertises unclaimed ETH sitting
-     *      in a contract whose flashFulfill pays `address(this).balance` to any caller's
-     *      chosen claimant. That leak is an accepted tradeoff for the observability of an
-     *      otherwise-silent swallowed refund.
+     *      A zero `sender` (or zero value) hits the early return: no refund, no revert, value
+     *      retained. A zero `sender` is unreachable via Inbox.prove (sender is msg.sender
+     *      there) but a direct caller can produce it; mirrors the sender guard used by the
+     *      message-bridge provers.
      * @param sender Address that initiated the proving request; receives the refund
      */
     function prove(
@@ -152,27 +152,14 @@ contract LocalProver is ILocalProver, Semver, ReentrancyGuard {
         bytes calldata /* encodedProofs */,
         bytes calldata /* data */
     ) external payable {
-        // Nothing forwarded: nothing to refund.
-        if (msg.value == 0) return;
+        // Nothing forwarded, or no address to refund to: nothing to do.
+        if (msg.value == 0 || sender == address(0)) return;
 
-        // A zero `sender` cannot receive the refund. Unreachable via Inbox.prove
-        // (sender is msg.sender there) but reachable by a direct call; emit so the
-        // swallowed value is observable rather than silently trapped.
-        if (sender == address(0)) {
-            emit ProveRefundFailed(sender, msg.value);
-            return;
-        }
-
-        // Bounded stipend so the ProveRefundFailed emit below is always affordable
-        // even against a griefing recipient (see the failure-tolerance note above);
-        // it also caps any reentrancy back into this contract.
+        // Uncapped all-gas call so smart-account / EIP-7702 recipients receive;
+        // revert on failure rather than stranding the caller's ETH here as dust.
         // solhint-disable-next-line avoid-low-level-calls
-        (bool refunded, ) = payable(sender).call{value: msg.value, gas: 30_000}(
-            ""
-        );
-        if (!refunded) {
-            emit ProveRefundFailed(sender, msg.value);
-        }
+        (bool ok, ) = payable(sender).call{value: msg.value}("");
+        if (!ok) revert RefundFailed(sender, msg.value);
     }
 
     /**

--- a/contracts/prover/LocalProver.sol
+++ b/contracts/prover/LocalProver.sol
@@ -125,10 +125,25 @@ contract LocalProver is ILocalProver, Semver, ReentrancyGuard {
      *      legitimately hold ETH from a flashFulfill payout that its claimant rejected;
      *      refunding the full balance would let anyone drain it with a dust-valued call.
      *
-     *      The refund is deliberately failure-tolerant. This function must not revert, or a
-     *      `sender` that cannot receive ETH would be unable to use fulfillAndProve at all.
-     *      A failed refund emits ProveRefundFailed and leaves the value here, which is the
-     *      pre-existing behaviour for that case.
+     *      The refund is deliberately failure-tolerant and MUST NOT revert, or a `sender`
+     *      that cannot receive ETH would be unable to use fulfillAndProve at all. The
+     *      refund call is given a bounded gas stipend precisely so this holds: an
+     *      unbounded call lets a griefing recipient consume ~63/64 of the gas (EIP-150),
+     *      leaving too little for the trailing ProveRefundFailed emit and reverting the
+     *      whole call. A failed or too-expensive refund emits ProveRefundFailed and leaves
+     *      the value here (the pre-existing behaviour); the same applies to a zero
+     *      `sender`, which Inbox.prove never produces but a direct caller can.
+     *
+     *      The stipend is far below flashFulfill's cost, so it also restores the
+     *      reentrancy barrier that `.transfer`'s 2300-gas limit used to provide -- the
+     *      unbounded call it replaces did allow a reentrant flashFulfill, though only to
+     *      collect rewards the caller was already entitled to (flashFulfill is
+     *      permissionless regardless).
+     *
+     *      ProveRefundFailed doubles as an MEV signal: it advertises unclaimed ETH sitting
+     *      in a contract whose flashFulfill pays `address(this).balance` to any caller's
+     *      chosen claimant. That leak is an accepted tradeoff for the observability of an
+     *      otherwise-silent swallowed refund.
      * @param sender Address that initiated the proving request; receives the refund
      */
     function prove(
@@ -137,10 +152,24 @@ contract LocalProver is ILocalProver, Semver, ReentrancyGuard {
         bytes calldata /* encodedProofs */,
         bytes calldata /* data */
     ) external payable {
-        if (msg.value == 0 || sender == address(0)) return;
+        // Nothing forwarded: nothing to refund.
+        if (msg.value == 0) return;
 
+        // A zero `sender` cannot receive the refund. Unreachable via Inbox.prove
+        // (sender is msg.sender there) but reachable by a direct call; emit so the
+        // swallowed value is observable rather than silently trapped.
+        if (sender == address(0)) {
+            emit ProveRefundFailed(sender, msg.value);
+            return;
+        }
+
+        // Bounded stipend so the ProveRefundFailed emit below is always affordable
+        // even against a griefing recipient (see the failure-tolerance note above);
+        // it also caps any reentrancy back into this contract.
         // solhint-disable-next-line avoid-low-level-calls
-        (bool refunded, ) = payable(sender).call{value: msg.value}("");
+        (bool refunded, ) = payable(sender).call{value: msg.value, gas: 30_000}(
+            ""
+        );
         if (!refunded) {
             emit ProveRefundFailed(sender, msg.value);
         }

--- a/contracts/prover/LocalProver.sol
+++ b/contracts/prover/LocalProver.sol
@@ -112,21 +112,38 @@ contract LocalProver is ILocalProver, Semver, ReentrancyGuard {
 
     /**
      * @notice Initiates proving of intents on the same chain
-     * @dev This function is a no-op for same-chain proving since proofs are created immediately upon fulfillment.
-     *      WARNING: This function is payable for compatibility but does not use ETH. Any ETH sent to this
-     *      function will remain in the contract and be distributed to the next flashFulfill caller as part
-     *      of their reward. Do not send ETH to this function.
+     * @dev No proof is required for same-chain intents; they are proven on fulfillment.
+     *
+     *      Native value handling: Inbox.prove forwards the Portal's entire balance to the
+     *      prover, so this function receives whatever the caller overpaid (overpaying is the
+     *      normal pattern for fulfillAndProve, which allows extra value for bridge fees).
+     *      Same-chain proving has no fee, so the whole amount is returned to `sender`.
+     *      Without this refund the value would sit here and be paid out to the next
+     *      flashFulfill caller's claimant -- an unrelated third party.
+     *
+     *      Only `msg.value` is refunded, never `address(this).balance`. LocalProver can
+     *      legitimately hold ETH from a flashFulfill payout that its claimant rejected;
+     *      refunding the full balance would let anyone drain it with a dust-valued call.
+     *
+     *      The refund is deliberately failure-tolerant. This function must not revert, or a
+     *      `sender` that cannot receive ETH would be unable to use fulfillAndProve at all.
+     *      A failed refund emits ProveRefundFailed and leaves the value here, which is the
+     *      pre-existing behaviour for that case.
+     * @param sender Address that initiated the proving request; receives the refund
      */
     function prove(
-        address /* sender */,
+        address sender,
         uint64 /* sourceChainId */,
         bytes calldata /* encodedProofs */,
         bytes calldata /* data */
     ) external payable {
-        // solhint-disable-line no-empty-blocks
-        // this function is intentionally left empty as no proof is required
-        // for same-chain proving
-        // should not revert lest it be called with fulfillandprove
+        if (msg.value == 0 || sender == address(0)) return;
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool refunded, ) = payable(sender).call{value: msg.value}("");
+        if (!refunded) {
+            emit ProveRefundFailed(sender, msg.value);
+        }
     }
 
     /**

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -765,6 +765,211 @@ contract LocalProverTest is Test {
         assertEq(token.balanceOf(solver), solverBalanceBefore);
     }
 
+    // ============ PAR-403: prove() must not retain forwarded native ============
+
+    /**
+     * @notice Overpaid ETH routed through Inbox.prove must return to the payer.
+     * @dev Inbox.prove forwards `address(this).balance` to the prover. LocalProver.prove
+     *      is payable with an empty body, so before the fix the excess silently stuck in
+     *      LocalProver instead of returning to the solver who paid it.
+     */
+    function test_prove_RefundsOverpaidNativeToSender() public {
+        Intent memory _intent = _createIntent(
+            address(localProver),
+            REWARD_AMOUNT,
+            0
+        );
+        (bytes32 intentHash, ) = _publishAndFundIntent(_intent);
+
+        uint256 overpay = 1 ether;
+        uint256 solverBalanceBefore = solver.balance;
+
+        vm.prank(solver);
+        portal.fulfillAndProve{value: overpay}(
+            intentHash,
+            _intent.route,
+            keccak256(abi.encode(_intent.reward)),
+            bytes32(uint256(uint160(solver))),
+            address(localProver),
+            CHAIN_ID,
+            ""
+        );
+
+        // route.nativeAmount is 0, so the entire overpayment is excess
+        assertEq(
+            address(localProver).balance,
+            0,
+            "LocalProver retained the solver's overpayment"
+        );
+        assertEq(
+            address(portal).balance,
+            0,
+            "Portal retained the solver's overpayment"
+        );
+        assertEq(
+            solver.balance,
+            solverBalanceBefore,
+            "solver was not made whole"
+        );
+    }
+
+    /**
+     * @notice ETH forwarded to prove() must not be handed to an unrelated third party.
+     * @dev flashFulfill pays out `address(this).balance`, so any balance LocalProver
+     *      retains from a previous prove() call is paid to the *next* flashFulfill
+     *      caller's claimant -- a different intent, a different party.
+     */
+    function test_prove_OverpaidNativeIsNotPaidToNextFlashFulfillClaimant()
+        public
+    {
+        // --- Intent A: fulfilled via fulfillAndProve with an overpayment ---
+        Intent memory intentA = _createIntent(
+            address(localProver),
+            REWARD_AMOUNT,
+            0
+        );
+        (bytes32 intentHashA, ) = _publishAndFundIntent(intentA);
+
+        uint256 overpay = 3 ether;
+
+        vm.prank(solver);
+        portal.fulfillAndProve{value: overpay}(
+            intentHashA,
+            intentA.route,
+            keccak256(abi.encode(intentA.reward)),
+            bytes32(uint256(uint160(solver))),
+            address(localProver),
+            CHAIN_ID,
+            ""
+        );
+
+        // --- Intent B: an unrelated intent, flash-fulfilled by an unrelated party ---
+        Intent memory intentB = _createIntent(
+            address(localProver),
+            REWARD_AMOUNT,
+            0
+        );
+        intentB.route.salt = bytes32(uint256(2));
+        _publishAndFundIntent(intentB);
+
+        address attacker = makeAddr("attacker");
+        uint256 attackerBalanceBefore = attacker.balance;
+
+        vm.prank(attacker);
+        localProver.flashFulfill(
+            intentB.route,
+            intentB.reward,
+            bytes32(uint256(uint160(attacker)))
+        );
+
+        // The attacker is entitled to intent B's reward and nothing more
+        assertEq(
+            attacker.balance - attackerBalanceBefore,
+            REWARD_AMOUNT,
+            "unrelated flashFulfill caller inherited the solver's overpayment"
+        );
+    }
+
+    /**
+     * @notice A refund recipient that rejects ETH must not be able to brick proving.
+     * @dev Guards the choice of refund primitive: a reverting send (e.g. `.transfer`)
+     *      would make fulfillAndProve unusable for contract solvers without a payable
+     *      receive. The ETH stays in LocalProver in that case, which is no worse than
+     *      the pre-fix behaviour, but the transaction must still succeed.
+     *
+     *      This is a regression guard rather than a bug reproduction: it also passes
+     *      against unfixed main, where the empty prove() body silently retains the ETH.
+     */
+    function test_prove_DoesNotRevertWhenRefundRecipientRejectsETH() public {
+        RejectingProveCaller caller = new RejectingProveCaller();
+
+        Intent memory _intent = _createIntent(
+            address(localProver),
+            REWARD_AMOUNT,
+            0
+        );
+        (bytes32 intentHash, ) = _publishAndFundIntent(_intent);
+
+        // Fulfill first so prove() passes the IntentNotFulfilled check
+        vm.prank(solver);
+        portal.fulfill(
+            intentHash,
+            _intent.route,
+            keccak256(abi.encode(_intent.reward)),
+            bytes32(uint256(uint160(solver)))
+        );
+
+        bytes32[] memory intentHashes = new bytes32[](1);
+        intentHashes[0] = intentHash;
+
+        uint256 sent = 1 ether;
+        vm.deal(address(this), sent);
+
+        // Must not revert even though the caller cannot receive the refund
+        caller.callProve{value: sent}(
+            portal,
+            address(localProver),
+            CHAIN_ID,
+            intentHashes
+        );
+
+        // Refund failed silently; the ETH is retained rather than burned or reverted
+        assertEq(
+            address(caller).balance,
+            0,
+            "refund unexpectedly landed on the rejecting caller"
+        );
+        assertEq(
+            address(localProver).balance,
+            sent,
+            "ETH was burned instead of retained"
+        );
+    }
+
+    /**
+     * @notice prove() must only ever return the value it was sent, never pre-existing balance.
+     * @dev LocalProver can legitimately hold ETH (e.g. a claimant that rejected a
+     *      flashFulfill payout). A refund keyed off `address(this).balance` instead of
+     *      `msg.value` would let anyone drain it with a dust-valued prove() call.
+     */
+    function test_prove_DoesNotDrainPreExistingBalance() public {
+        // Strand ETH in LocalProver via a claimant that rejects the payout
+        RejectEth rejecter = new RejectEth();
+        Intent memory strandedIntent = _createIntent(
+            address(localProver),
+            REWARD_AMOUNT,
+            0
+        );
+        _publishAndFundIntent(strandedIntent);
+
+        vm.prank(solver);
+        localProver.flashFulfill(
+            strandedIntent.route,
+            strandedIntent.reward,
+            bytes32(uint256(uint160(address(rejecter))))
+        );
+        assertEq(address(localProver).balance, REWARD_AMOUNT);
+
+        // A direct dust-valued prove() must return only the dust
+        address attacker = makeAddr("attacker2");
+        vm.deal(attacker, 1 ether);
+        uint256 attackerBalanceBefore = attacker.balance;
+
+        vm.prank(attacker);
+        localProver.prove{value: 1 wei}(attacker, CHAIN_ID, "", "");
+
+        assertEq(
+            attacker.balance,
+            attackerBalanceBefore,
+            "attacker extracted pre-existing LocalProver balance"
+        );
+        assertEq(
+            address(localProver).balance,
+            REWARD_AMOUNT,
+            "pre-existing balance was drained"
+        );
+    }
+
     // ============ Helper Functions ============
 
     function _encodeProofs(
@@ -807,4 +1012,25 @@ contract LocalProverTest is Test {
  */
 contract RejectEth {
     // No receive() or fallback() - will reject all ETH transfers
+}
+
+/**
+ * @notice Helper contract that calls Portal.prove but cannot receive ETH
+ * @dev Used to verify a failed refund does not revert the proving transaction
+ */
+contract RejectingProveCaller {
+    function callProve(
+        Portal portal,
+        address prover,
+        uint64 sourceChainDomainID,
+        bytes32[] memory intentHashes
+    ) external payable {
+        portal.prove{value: msg.value}(
+            prover,
+            sourceChainDomainID,
+            intentHashes,
+            ""
+        );
+    }
+    // No receive() or fallback() - will reject the refund
 }

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
 import {LocalProver} from "../../contracts/prover/LocalProver.sol";
 import {Portal} from "../../contracts/Portal.sol";
 import {TestProver} from "../../contracts/test/TestProver.sol";
@@ -168,23 +169,28 @@ contract LocalProverTest is Test {
         localProver.prove{value: 0}(address(0), 0, "", "");
     }
 
-    /// @notice A direct prove() carrying value but a zero `sender` cannot refund,
-    ///         so it emits ProveRefundFailed rather than silently swallowing the
-    ///         ETH. Unreachable via Inbox.prove (sender is msg.sender there), but
-    ///         reachable by a direct caller.
-    function test_prove_ZeroSenderWithValueEmitsRefundFailed() public {
+    /// @notice A direct prove() carrying value but a zero `sender` hits the early
+    ///         return: the value is retained, prove() does not revert, and no event
+    ///         is emitted. Unreachable via Inbox.prove (sender is msg.sender there),
+    ///         but reachable by a direct caller.
+    function test_prove_ZeroSenderWithValueIsRetainedNoRevert() public {
         uint256 sent = 1 ether;
         vm.deal(address(this), sent);
 
-        vm.expectEmit(true, false, false, true, address(localProver));
-        emit ILocalProver.ProveRefundFailed(address(0), sent);
-
+        vm.recordLogs();
+        // Must not revert even though there is no address to refund to
         localProver.prove{value: sent}(address(0), CHAIN_ID, "", "");
+        Vm.Log[] memory logs = vm.getRecordedLogs();
 
+        assertEq(
+            logs.length,
+            0,
+            "no event should be emitted for a zero sender"
+        );
         assertEq(
             address(localProver).balance,
             sent,
-            "zero-sender value should be retained and signalled, not burned"
+            "zero-sender value should be retained, not burned or reverted"
         );
     }
 
@@ -904,16 +910,14 @@ contract LocalProverTest is Test {
     }
 
     /**
-     * @notice A refund recipient that rejects ETH must not be able to brick proving.
-     * @dev Guards the choice of refund primitive: a reverting send (e.g. `.transfer`)
-     *      would make fulfillAndProve unusable for contract solvers without a payable
-     *      receive. The ETH stays in LocalProver in that case, which is no worse than
-     *      the pre-fix behaviour, but the transaction must still succeed.
-     *
-     *      This is a regression guard rather than a bug reproduction: it also passes
-     *      against unfixed main, where the empty prove() body silently retains the ETH.
+     * @notice A refund recipient that rejects ETH makes prove() REVERT.
+     * @dev The refund uses an uncapped all-gas call and reverts with RefundFailed
+     *      on failure rather than swallowing it. The refund recipient is always the
+     *      tx caller (Inbox.prove passes msg.sender), so the revert only self-DoSes
+     *      that caller -- there is no third-party griefing vector -- and it surfaces
+     *      a genuinely-unpayable caller loudly instead of stranding their ETH as dust.
      */
-    function test_prove_DoesNotRevertWhenRefundRecipientRejectsETH() public {
+    function test_prove_RevertsWhenRefundRecipientRejects() public {
         RejectingProveCaller caller = new RejectingProveCaller();
 
         Intent memory _intent = _createIntent(
@@ -938,65 +942,51 @@ contract LocalProverTest is Test {
         uint256 sent = 1 ether;
         vm.deal(address(this), sent);
 
-        // The swallowed failure is only observable via the event, so assert it
-        // fires with the rejecting recipient and the retained amount.
-        vm.expectEmit(true, false, false, true, address(localProver));
-        emit ILocalProver.ProveRefundFailed(address(caller), sent);
-
-        // Must not revert even though the caller cannot receive the refund
+        // The rejecting caller cannot receive the refund, so prove() reverts with
+        // RefundFailed(recipient, amount) and the whole proving tx unwinds.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILocalProver.RefundFailed.selector,
+                address(caller),
+                sent
+            )
+        );
         caller.callProve{value: sent}(
             portal,
             address(localProver),
             CHAIN_ID,
             intentHashes
         );
-
-        // Refund failed silently; the ETH is retained rather than burned or reverted
-        assertEq(
-            address(caller).balance,
-            0,
-            "refund unexpectedly landed on the rejecting caller"
-        );
-        assertEq(
-            address(localProver).balance,
-            sent,
-            "ETH was burned instead of retained"
-        );
     }
 
     /**
-     * @notice A griefing recipient must not be able to revert prove() by burning gas.
-     * @dev The blocking invariant: an unbounded refund call lets the recipient consume
-     *      ~63/64 of the gas, leaving too little for the ProveRefundFailed emit, which
-     *      then OOGs and reverts. The bounded stipend caps the recipient so the emit
-     *      always fits. Calling prove() with a constrained gas budget makes this
-     *      concrete: it succeeds here, and fails if the `gas:` cap is removed.
+     * @notice prove() must actually DELIVER the refund to a legitimate smart-account
+     *         recipient whose receive() spends more than transfer()'s 2300-gas stipend.
+     * @dev The uncapped all-gas call forwards enough gas for a receive() that writes
+     *      storage (a common smart-account / EIP-7702 pattern) to succeed, so the
+     *      forwarded value is returned rather than stranded or reverted. This proves
+     *      the swallow->revert change did not sacrifice smart-account deliverability.
      */
-    function test_prove_GasBurningRecipientDoesNotRevertProve() public {
-        GasBurningRefundRecipient burner = new GasBurningRefundRecipient();
+    function test_prove_RefundDeliveredToGasHungryRecipient() public {
+        GasHungryRefundRecipient recipient = new GasHungryRefundRecipient();
 
         uint256 sent = 1 ether;
         vm.deal(address(this), sent);
+        uint256 recipientBalanceBefore = address(recipient).balance;
 
-        vm.expectEmit(true, false, false, true, address(localProver));
-        emit ILocalProver.ProveRefundFailed(address(burner), sent);
+        // Uncapped call forwards all gas, so the storage-writing receive() succeeds
+        // and prove() does not revert.
+        localProver.prove{value: sent}(address(recipient), CHAIN_ID, "", "");
 
-        // Constrained budget. Empirically prove() needs ~35k with the stipend
-        // in place, but an unbounded call reverts at any budget below ~110k
-        // (the 63/64 drain starves the emit). 80k sits between: it passes with
-        // the cap and fails without it.
-        (bool ok, ) = address(localProver).call{value: sent, gas: 80000}(
-            abi.encodeCall(
-                LocalProver.prove,
-                (address(burner), CHAIN_ID, "", "")
-            )
+        assertEq(
+            address(recipient).balance,
+            recipientBalanceBefore + sent,
+            "refund was not delivered to the gas-hungry recipient"
         );
-
-        assertTrue(ok, "prove() reverted: gas cap did not protect the emit");
         assertEq(
             address(localProver).balance,
-            sent,
-            "value should be retained when the refund cannot be delivered"
+            0,
+            "refund should not be retained when delivery succeeds"
         );
     }
 
@@ -1094,27 +1084,26 @@ contract RejectEth {
 }
 
 /**
- * @notice Helper whose receive() burns far more gas than the refund stipend.
- * @dev Under an unbounded refund call this recipient would consume ~63/64 of
- *      prove()'s gas (EIP-150), starving the trailing ProveRefundFailed emit and
- *      reverting the whole call. The bounded stipend must keep the emit
- *      affordable, so it is the regression guard for that invariant.
+ * @notice Refund recipient that ACCEPTS ETH but consumes far more than the
+ *         2300-gas transfer() stipend (two cold SSTOREs) in receive(), simulating a
+ *         legitimate smart-account / EIP-7702 solver wallet.
+ * @dev Used to prove the uncapped all-gas refund call actually delivers the refund
+ *      instead of OOG-reverting under a stingy gas stipend.
  */
-contract GasBurningRefundRecipient {
+contract GasHungryRefundRecipient {
+    uint256 private slot0;
+    uint256 private slot1;
+
     receive() external payable {
-        // Burn well past any plausible forwarded gas so the refund call always
-        // fails on out-of-gas rather than succeeding.
-        for (uint256 i = 0; i < 200000; ++i) {
-            assembly {
-                mstore(0x0, i)
-            }
-        }
+        // Two cold SSTOREs cost well over the 2300-gas transfer() stipend.
+        slot0 = block.number;
+        slot1 = block.timestamp;
     }
 }
 
 /**
  * @notice Helper contract that calls Portal.prove but cannot receive ETH
- * @dev Used to verify a failed refund does not revert the proving transaction
+ * @dev Used to verify a failed refund reverts the proving transaction (RefundFailed)
  */
 contract RejectingProveCaller {
     function callProve(

--- a/test/prover/LocalProver.t.sol
+++ b/test/prover/LocalProver.t.sol
@@ -161,10 +161,31 @@ contract LocalProverTest is Test {
     }
 
     // A2. prove()
-    function test_prove_IsNoOp() public {
-        // Test: prove() is a no-op (doesn't revert)
+    function test_prove_ZeroValueZeroSenderDoesNotRevert() public {
+        // Zero value and zero sender both hit the early returns; prove() must
+        // not revert. (The name was previously "IsNoOp", but prove() is no
+        // longer a pure no-op -- it refunds forwarded value; see the tests below.)
         localProver.prove{value: 0}(address(0), 0, "", "");
-        // Should not revert
+    }
+
+    /// @notice A direct prove() carrying value but a zero `sender` cannot refund,
+    ///         so it emits ProveRefundFailed rather than silently swallowing the
+    ///         ETH. Unreachable via Inbox.prove (sender is msg.sender there), but
+    ///         reachable by a direct caller.
+    function test_prove_ZeroSenderWithValueEmitsRefundFailed() public {
+        uint256 sent = 1 ether;
+        vm.deal(address(this), sent);
+
+        vm.expectEmit(true, false, false, true, address(localProver));
+        emit ILocalProver.ProveRefundFailed(address(0), sent);
+
+        localProver.prove{value: sent}(address(0), CHAIN_ID, "", "");
+
+        assertEq(
+            address(localProver).balance,
+            sent,
+            "zero-sender value should be retained and signalled, not burned"
+        );
     }
 
     // A3. challengeIntentProof()
@@ -855,6 +876,18 @@ contract LocalProverTest is Test {
         address attacker = makeAddr("attacker");
         uint256 attackerBalanceBefore = attacker.balance;
 
+        // Linchpin of the repro: flashFulfill forwards `address(this).balance`
+        // into fulfill and pays the remainder to the claimant, so it inherits
+        // anything stranded here. The fix refunded intent A's overpayment during
+        // its prove(), leaving nothing to sweep. On unfixed code this is the
+        // 3-ether overpay, and the delta assertion below would catch the attacker
+        // inheriting it -- so the leak is pinned from both ends.
+        assertEq(
+            address(localProver).balance,
+            0,
+            "intent A's overpayment remained stranded in LocalProver"
+        );
+
         vm.prank(attacker);
         localProver.flashFulfill(
             intentB.route,
@@ -905,6 +938,11 @@ contract LocalProverTest is Test {
         uint256 sent = 1 ether;
         vm.deal(address(this), sent);
 
+        // The swallowed failure is only observable via the event, so assert it
+        // fires with the rejecting recipient and the retained amount.
+        vm.expectEmit(true, false, false, true, address(localProver));
+        emit ILocalProver.ProveRefundFailed(address(caller), sent);
+
         // Must not revert even though the caller cannot receive the refund
         caller.callProve{value: sent}(
             portal,
@@ -927,10 +965,51 @@ contract LocalProverTest is Test {
     }
 
     /**
+     * @notice A griefing recipient must not be able to revert prove() by burning gas.
+     * @dev The blocking invariant: an unbounded refund call lets the recipient consume
+     *      ~63/64 of the gas, leaving too little for the ProveRefundFailed emit, which
+     *      then OOGs and reverts. The bounded stipend caps the recipient so the emit
+     *      always fits. Calling prove() with a constrained gas budget makes this
+     *      concrete: it succeeds here, and fails if the `gas:` cap is removed.
+     */
+    function test_prove_GasBurningRecipientDoesNotRevertProve() public {
+        GasBurningRefundRecipient burner = new GasBurningRefundRecipient();
+
+        uint256 sent = 1 ether;
+        vm.deal(address(this), sent);
+
+        vm.expectEmit(true, false, false, true, address(localProver));
+        emit ILocalProver.ProveRefundFailed(address(burner), sent);
+
+        // Constrained budget. Empirically prove() needs ~35k with the stipend
+        // in place, but an unbounded call reverts at any budget below ~110k
+        // (the 63/64 drain starves the emit). 80k sits between: it passes with
+        // the cap and fails without it.
+        (bool ok, ) = address(localProver).call{value: sent, gas: 80000}(
+            abi.encodeCall(
+                LocalProver.prove,
+                (address(burner), CHAIN_ID, "", "")
+            )
+        );
+
+        assertTrue(ok, "prove() reverted: gas cap did not protect the emit");
+        assertEq(
+            address(localProver).balance,
+            sent,
+            "value should be retained when the refund cannot be delivered"
+        );
+    }
+
+    /**
      * @notice prove() must only ever return the value it was sent, never pre-existing balance.
      * @dev LocalProver can legitimately hold ETH (e.g. a claimant that rejected a
      *      flashFulfill payout). A refund keyed off `address(this).balance` instead of
      *      `msg.value` would let anyone drain it with a dust-valued prove() call.
+     *
+     *      This is a design guard, not a bug reproduction: on unfixed main it fails as
+     *      `999999999999999999 != 1000000000000000000` -- the dust caller is down the
+     *      1 wei it sent, never up a drained balance -- so the bug it guards against was
+     *      never actually present, unlike the two overpayment-leak repros above.
      */
     function test_prove_DoesNotDrainPreExistingBalance() public {
         // Strand ETH in LocalProver via a claimant that rejects the payout
@@ -1012,6 +1091,25 @@ contract LocalProverTest is Test {
  */
 contract RejectEth {
     // No receive() or fallback() - will reject all ETH transfers
+}
+
+/**
+ * @notice Helper whose receive() burns far more gas than the refund stipend.
+ * @dev Under an unbounded refund call this recipient would consume ~63/64 of
+ *      prove()'s gas (EIP-150), starving the trailing ProveRefundFailed emit and
+ *      reverting the whole call. The bounded stipend must keep the emit
+ *      affordable, so it is the regression guard for that invariant.
+ */
+contract GasBurningRefundRecipient {
+    receive() external payable {
+        // Burn well past any plausible forwarded gas so the refund call always
+        // fails on out-of-gas rather than succeeding.
+        for (uint256 i = 0; i < 200000; ++i) {
+            assembly {
+                mstore(0x0, i)
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

`LocalProver.prove` is `external payable` with an empty body, while `Inbox.prove` forwards the Portal's **entire balance** to the caller-supplied prover:

```solidity
IProver(prover).prove{value: address(this).balance}(msg.sender, ...);
```

For same-chain proving there is no bridge fee, so nothing consumes that value — but it does not sit inert either. `LocalProver`'s balance is spent by the next `flashFulfill`:

- `_PORTAL.fulfill{value: address(this).balance}(...)`
- `remainingNative = address(this).balance` → `claimantAddress.call{value: remainingNative}("")`

So value forwarded into `prove` is paid out to **an unrelated third party's claimant**.

Trigger: a solver calls `fulfillAndProve` for a same-chain intent with `prover = LocalProver` and `msg.value > route.nativeAmount`. Overpaying is the normal, documented pattern — `Inbox` explicitly allows extra value for cross-chain message fees. The excess survives `_fulfill` (only `route.nativeAmount` reaches the executor), is read as `address(this).balance`, forwarded to `prove`, silently retained, and then paid to whoever calls `flashFulfill` next.

The old docstring said "Do not send ETH to this function." That mitigation was not actionable: `Inbox.prove` sends it unconditionally, and the caller has no way to opt out.

## Impact

A solver following the documented overpayment pattern loses the overpayment to another party. Not a theft primitive an attacker controls directly — the loser self-selects by overpaying — but it is silent, requires no unusual behavior to trigger, and the funds go to a specific unrelated beneficiary rather than being burned.

Same bug class as the Polymer half of Octane V9, with a worse outcome: Polymer *burned* the value, LocalProver *pays it to someone else*.

Active, not latent. `LocalProverTron` inherits `prove` unchanged and shares the behavior.

## What Changed

- **`contracts/prover/LocalProver.sol`** — `prove` now returns forwarded native value to `sender`. The previously-anonymous `address /* sender */` parameter is named. Docstring rewritten to describe actual behavior instead of an unactionable warning.
- **`contracts/interfaces/ILocalProver.sol`** — new `event ProveRefundFailed(address indexed recipient, uint256 amount)`.
- **`test/prover/LocalProver.t.sol`** — 4 tests plus a `RejectingProveCaller` helper.

`LocalProverTron` needs no change; it inherits `prove` and is `pragma ^0.8.13` (not solc 0.4.25 — the only 0.4.25 file in the repo is a skipped test fixture).

## Human Logic

```text
GIVEN Inbox.prove forwards address(this).balance to the prover
AND   same-chain proving consumes no fee
WHEN  LocalProver.prove receives native value

  IF msg.value == 0 OR sender == address(0)
    THEN return                      # nothing to refund / no valid recipient

  ELSE attempt to send exactly msg.value to sender
    IF the send succeeds
      THEN done
    ELSE emit ProveRefundFailed(sender, msg.value)
      AND return normally            # MUST NOT revert

INVARIANT 1: the refund amount is exactly msg.value, never address(this).balance.
             LocalProver legitimately holds ETH from flashFulfill payouts that a
             claimant rejected; a balance-based refund would let anyone drain it
             with a dust-valued call.

INVARIANT 2: prove() never reverts. A reverting prove would make fulfillAndProve
             unusable for any sender that cannot receive ETH.
```

## Logic Trace

```mermaid
sequenceDiagram
    participant S as Solver
    participant P as Portal (Inbox)
    participant L as LocalProver
    participant C as Next flashFulfill claimant

    S->>P: fulfillAndProve{value: nativeAmount + excess}
    P->>P: _fulfill — only nativeAmount to Executor
    Note over P: excess remains in Portal balance
    P->>L: prove{value: address(this).balance}(sender = S)

    alt BEFORE — empty body
        L-->>L: value silently retained
        C->>L: flashFulfill
        L->>C: paid out as part of unrelated reward
        Note over C: solver's excess lost to a third party
    else AFTER — this PR
        alt msg.value == 0 or sender == address(0)
            L-->>L: return, no-op
        else refund succeeds
            L->>S: call{value: msg.value}
            Note over S: excess returned to the overpayer
        else refund fails (sender rejects ETH)
            L-->>L: emit ProveRefundFailed
            Note over L: no revert — fulfillAndProve still succeeds
        end
    end
```

## Service Topology

```mermaid
flowchart LR
    Solver -->|fulfillAndProve, overpays| Portal

    subgraph Portal_Inbox["Portal / Inbox"]
        Fulfill["_fulfill — routes nativeAmount"]
        ProveCall["prove — forwards address(this).balance"]
    end

    Portal --> Fulfill --> ProveCall

    subgraph Provers
        Local["LocalProver.prove<br/>own impl — FIXED HERE"]
        Polymer["PolymerProver.prove<br/>own impl — fixed in #418"]
        Bridge["MessageBridgeProver.prove<br/>Hyper / Meta / LayerZero / CCIP"]
    end

    ProveCall -->|value| Local
    ProveCall -->|value| Polymer
    ProveCall -->|value| Bridge

    Local -->|refund msg.value| Solver
    Bridge -->|refund msg.value - fee| Solver
    Local -.->|"before: leaked via next flashFulfill"| ThirdParty["Unrelated claimant"]
```

## Why This Shape

The starting proposal was a ~5-line mirror of the Polymer fix. Three deliberate deviations:

| Decision | Alternative rejected | Reason |
| --- | --- | --- |
| Refund `msg.value` | Refund `address(this).balance` | LocalProver legitimately holds ETH from rejected flashFulfill payouts (existing test covers this). A balance refund is a drain primitive callable with 1 wei. Locked in by `test_prove_DoesNotDrainPreExistingBalance`. |
| Emit `ProveRefundFailed` | Silently discard the bool (`_ok;`) | A swallowed failure is unobservable. The value genuinely stays in the contract; that should be visible on-chain. |
| Low-level `.call` | `.transfer()`, as `MessageBridgeProver._sendRefund` uses | `.transfer()`'s 2300-gas stipend would brick `fulfillAndProve` for a contract solver that cannot cheaply receive ETH. See Boundaries. |

Refunding to `sender` rather than `msg.sender`: in the `fulfillAndProve` path `sender` is the original overpayer, which is who should get it back. `msg.sender` is the Portal, and `fulfillAndProve` has no `Refund.excessNative()` after `prove`, so refunding there would strand the value.

Not added: `only(PORTAL)` on `prove`, for consistency with other provers. It is a behavior change and the refund is safe without it, being capped at `msg.value`. Flagged for a maintainer's call rather than bundled in.

## Boundaries

Explicitly **not** in this PR:

- **`MessageBridgeProver._sendRefund` uses `.transfer()`.** The 2300-gas stipend can brick `fulfillAndProve` for contract solvers that cannot receive ETH cheaply. Pre-existing, affects Hyper/Meta/LayerZero/CCIP, and deserves its own change — noted while working here.
- **Stranded Portal balance is extractable by any caller.** `Refund.excessNative()` discards its success bool (deliberately, to avoid griefing), so a fulfiller whose `receive` reverts leaves ETH in the Portal with no sweep path. Investigated and measured; **not fixed here**, because the root cause is broader than the `Inbox.prove` call site: `Refund.excessNative()` also sweeps `address(this).balance` and is reachable from `Inbox.fulfill`, `IntentSource` (two sites). With 5 ETH stranded, `IntentSource.publishAndFund` returns the full amount to any caller with no fulfilled intent, no prover and no fee — strictly cheaper than the prove path. Patching only `Inbox.prove` would be security theater. Correctly scoping this needs owner-attributed accounting, or "recoverable by racing" becomes "permanently stuck." Being filed separately.
- **`PolymerProver.prove`** — fixed by #418, untouched here.

## Validation

| Gate | Result |
| --- | --- |
| `forge build` | Clean; no new warnings |
| `forge test` (baseline, changes stashed) | 597 passed, 0 failed |
| `forge test` (this branch) | **603 passed, 0 failed** — +6, no regressions |
| `forge test --match-path "test/prover/*"` | **161 passed, 0 failed** (155 baseline + 6) |
| New tests vs. unpatched `main` | The two overpayment-leak repros and the new gas-cap repro (`GasBurningRecipientDoesNotRevertProve`, reverts without the `gas: 30_000` cap) fail without the fix. `DoesNotDrainPreExistingBalance` also fails on unpatched `main`, but as a 1-wei-accounting **design guard**, not a bug repro (relabeled per review). |
| `yarn test:hardhat` | 112 passing |
| `yarn test:ts` | 9 passed |
| `npx solhint` on changed contracts | 0 errors, 5 warnings (all pre-existing) |
| `npx prettier --check` | Clean |

Two caveats stated plainly:

- `test_prove_DoesNotRevertWhenRefundRecipientRejectsETH` guards that a rejecting recipient cannot brick proving (it fails if the refund uses `.transfer()`). It now also asserts `ProveRefundFailed` fires, so it no longer passes against unpatched `main` (the empty `prove()` body emits nothing).
- `yarn lint` / `yarn format` were **not** run: `format:solhint` uses `--fix`, which is known in this repo to rename underscore-named contracts and break the build. `solhint` and `prettier --check` were run directly instead.

Base is `origin/main` @ `c8603d01`. Verified there that `Inbox.prove` is the only `IProver.prove` call site, that Hyper/Meta/LayerZero/CCIP do not override `prove`, and that #419/#421/#422 touched none of these files.

