### PR TITLE
fix(deploy): left-pad prover self-reference whitelist entries

### DIFF
--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -293,7 +293,11 @@ contract Deploy is Script {
         bytes32[] memory provers = new bytes32[](
             1 + ctx.hyperCrossVmProvers.length
         );
-        provers[0] = bytes32(bytes20(hyperProverPreviewAddr)); // Self-reference for EVM
+        provers[0] = selfReference(hyperProverPreviewAddr); // Self-reference for EVM
+        require(
+            uint256(provers[0]) >> 160 == 0,
+            "self-reference must be left-padded"
+        );
         for (uint256 i = 0; i < ctx.hyperCrossVmProvers.length; i++) {
             provers[i + 1] = ctx.hyperCrossVmProvers[i]; // Cross-VM prover addresses
         }
@@ -333,7 +337,11 @@ contract Deploy is Script {
         bytes32[] memory provers = new bytes32[](
             1 + ctx.metaCrossVmProvers.length
         );
-        provers[0] = bytes32(bytes20(metaProverPreviewAddr)); // Self-reference for EVM
+        provers[0] = selfReference(metaProverPreviewAddr); // Self-reference for EVM
+        require(
+            uint256(provers[0]) >> 160 == 0,
+            "self-reference must be left-padded"
+        );
         for (uint256 i = 0; i < ctx.metaCrossVmProvers.length; i++) {
             provers[i + 1] = ctx.metaCrossVmProvers[i]; // Cross-VM prover addresses
         }
@@ -377,7 +385,11 @@ contract Deploy is Script {
         bytes32[] memory provers = new bytes32[](
             1 + ctx.layerZeroCrossVmProvers.length
         );
-        provers[0] = bytes32(bytes20(layerZeroProverPreviewAddr)); // Self-reference for EVM
+        provers[0] = selfReference(layerZeroProverPreviewAddr); // Self-reference for EVM
+        require(
+            uint256(provers[0]) >> 160 == 0,
+            "self-reference must be left-padded"
+        );
         for (uint256 i = 0; i < ctx.layerZeroCrossVmProvers.length; i++) {
             provers[i + 1] = ctx.layerZeroCrossVmProvers[i]; // Cross-VM prover addresses
         }
@@ -494,6 +506,22 @@ contract Deploy is Script {
             keccak256(
                 abi.encode(rootSalt, keccak256(abi.encodePacked(contractName)))
             );
+    }
+
+    /**
+     * @notice Encodes an EVM address as a `Whitelist` entry
+     * @dev MUST left-pad. `Whitelist.isWhitelisted` is raw equality with no
+     *      normalization, and every runtime producer of this word left-pads:
+     *      Hyperlane's `TypeCasts.addressToBytes32`, LayerZero's
+     *      `origin.sender`, and this repo's `AddressConverter.toBytes32`.
+     *      `bytes32(bytes20(addr))` pads on the RIGHT (`addr << 96`) and can
+     *      never match an incoming EVM peer, which would make every inbound
+     *      cross-chain proof revert `UnauthorizedIncomingProof`.
+     * @param addr Address to encode
+     * @return The left-padded `bytes32` form
+     */
+    function selfReference(address addr) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(addr)));
     }
 
     function getCreate3Address(

--- a/test/scripts/DeployProverWhitelist.t.sol
+++ b/test/scripts/DeployProverWhitelist.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "forge-std/Test.sol";
+import {Deploy} from "../../scripts/Deploy.s.sol";
+import {TypeCasts} from "@hyperlane-xyz/core/contracts/libs/TypeCasts.sol";
+import {AddressConverter} from "../../contracts/libs/AddressConverter.sol";
+
+/**
+ * @notice Exposes `Deploy.selfReference` for direct testing
+ */
+contract DeployHarness is Deploy {
+    function exposedSelfReference(
+        address addr
+    ) external pure returns (bytes32) {
+        return selfReference(addr);
+    }
+}
+
+contract DeployProverWhitelistTest is Test {
+    using AddressConverter for address;
+    using AddressConverter for bytes32;
+
+    DeployHarness internal harness;
+
+    address internal constant ADDR_ONE =
+        0x1111111111111111111111111111111111111111;
+    address internal constant ADDR_TWO =
+        0x2222222222222222222222222222222222222222;
+
+    function setUp() public {
+        harness = new DeployHarness();
+    }
+
+    function testSelfReferenceMatchesHyperlaneTypeCasts() public view {
+        assertEq(
+            harness.exposedSelfReference(ADDR_ONE),
+            TypeCasts.addressToBytes32(ADDR_ONE)
+        );
+        assertEq(
+            harness.exposedSelfReference(ADDR_TWO),
+            TypeCasts.addressToBytes32(ADDR_TWO)
+        );
+    }
+
+    function testSelfReferenceMatchesAddressConverter() public view {
+        assertEq(
+            harness.exposedSelfReference(ADDR_ONE),
+            AddressConverter.toBytes32(ADDR_ONE)
+        );
+        assertEq(
+            harness.exposedSelfReference(ADDR_TWO),
+            AddressConverter.toBytes32(ADDR_TWO)
+        );
+    }
+
+    function testSelfReferenceIsValidAddress() public view {
+        assertTrue(
+            AddressConverter.isValidAddress(
+                harness.exposedSelfReference(ADDR_ONE)
+            )
+        );
+        assertTrue(
+            AddressConverter.isValidAddress(
+                harness.exposedSelfReference(ADDR_TWO)
+            )
+        );
+    }
+
+    /**
+     * @notice Regression pin: the old right-padded form must NOT match the
+     *         fixed helper, and must fail the repo's own validity check.
+     *         This is what fails if someone reintroduces `bytes32(bytes20(addr))`.
+     */
+    function testRegressionRightPaddedFormIsRejected() public view {
+        bytes32 rightPadded = bytes32(bytes20(ADDR_ONE));
+        assertTrue(rightPadded != harness.exposedSelfReference(ADDR_ONE));
+        assertFalse(AddressConverter.isValidAddress(rightPadded));
+
+        bytes32 rightPaddedTwo = bytes32(bytes20(ADDR_TWO));
+        assertTrue(rightPaddedTwo != harness.exposedSelfReference(ADDR_TWO));
+        assertFalse(AddressConverter.isValidAddress(rightPaddedTwo));
+    }
+
+    function testSelfReferenceRoundTrips() public view {
+        assertEq(
+            AddressConverter.toAddress(harness.exposedSelfReference(ADDR_ONE)),
+            ADDR_ONE
+        );
+        assertEq(
+            AddressConverter.toAddress(harness.exposedSelfReference(ADDR_TWO)),
+            ADDR_TWO
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`scripts/Deploy.s.sol` writes each message-bridge prover's self-reference `Whitelist` entry as:

```solidity
provers[0] = bytes32(bytes20(hyperProverPreviewAddr)); // Self-reference for EVM
```

That entry is how a prover trusts its own CREATE3 counterpart on other chains — same address, different
chain. **Solidity pads `bytesNN` → `bytes32` on the RIGHT**, so this produces `addr << 96`: the 20
address bytes in the *high* positions.

Every runtime producer of that word **left**-pads:

| Producer | Form |
| --- | --- |
| Hyperlane `TypeCasts.addressToBytes32` | `bytes32(uint256(uint160(addr)))` |
| LayerZero `origin.sender` | arrives left-padded |
| This repo, `AddressConverter.toBytes32` (`contracts/libs/AddressConverter.sol:19-21`) | `bytes32(uint256(uint160(addr)))` |

`Whitelist.isWhitelisted` is raw equality with no normalization, and
`MessageBridgeProver._handleCrossChainMessage` compares the raw bridge sender word against it.

The repo's own validity predicate already disagrees with the written form:
`AddressConverter.isValidAddress(b)` is `uint256(b) >> 160 == 0`, which a right-padded value fails.

## Impact

**Latent. No live prover is affected — verified on chain, see below.**

A prover deployed by *this script* could not recognise its own EVM peer, so every inbound cross-chain
proof would revert `UnauthorizedIncomingProof` and no intent proven through that lane could ever be
settled. `Whitelist` is immutable, so the only remedy would be redeploying under a new salt.

Introduced in `452f4ba2` (2025-09-16, #237). Affects `HyperProver`, `MetaProver`, and
`LayerZeroProver`. `PolymerProver` is unaffected — it builds its whitelist purely from
`POLYMER_CROSS_VM_PROVERS` with no self-reference.

**Why it is latent:** live deployments went through the TypeScript `routes-deployer` path, not this
script. `getWhitelist()` on chain returns correctly left-padded entry 0 everywhere checked:

| Chain | Prover | Entry 0 |
| --- | --- | --- |
| 1 | HyperProver `0x926ee8cf…` | `0x000000000000000000000000926ee8cf1ab25c0538a24ca933eda71a67b2bc69` |
| 10 | HyperProver `0x926ee8cf…` | same |
| 8453 | HyperProver `0x926ee8cf…` | same |
| 8453 | MetaProver `0x3d529eFA…` | `0x0000000000000000000000003d529efaedb3b999a404c1b8543441ae616cb914` |

Entry 1 on each HyperProver is `0x3c8071b37face7d1…` — full-width entropy, i.e. a genuine non-EVM
cross-VM prover. That contrast is what makes the check conclusive: a mis-aligned EVM self-reference
would occupy the high bytes like a cross-VM entry while still being a recognisable address.

## What Changed

- **`scripts/Deploy.s.sol`** — new `selfReference(address) internal pure returns (bytes32)` helper
  returning the left-padded form, with NatSpec recording why right-padding breaks inbound proofs.
  Used at all three sites (`:296`, `:340`, `:388`), each followed by
  `require(uint256(provers[0]) >> 160 == 0, "self-reference must be left-padded")`.
- **`test/scripts/DeployProverWhitelist.t.sol`** (new, 5 tests) — the first test coverage this script
  has had.

## Human Logic

```text
GIVEN a prover P deployed at address A via CREATE3
AND P's counterpart on every other chain is also at address A
WHEN a cross-chain proof arrives at P from its counterpart
THEN MessageBridgeProver._handleCrossChainMessage compares the raw bridge
     sender word against Whitelist entries by exact equality
AND the bridge always supplies the sender LEFT-padded
SO   entry 0 MUST equal bytes32(uint256(uint160(A)))
ELSE isWhitelisted returns false and the proof reverts
     UnauthorizedIncomingProof, permanently, for every retry

INVARIANT: uint256(entry0) >> 160 == 0  -- asserted at every write site
```

## Logic Trace

```mermaid
flowchart TD
  A[deployHyperProver] --> B["provers[0] = selfReference(previewAddr)"]
  B --> C{"uint256 >> 160 == 0?"}
  C -- no --> D[revert: deploy aborts]
  C -- yes --> E[construct prover with whitelist]
  E --> F[counterpart on chain B dispatches proof]
  F --> G["_handleCrossChainMessage: isWhitelisted(sender)?"]
  G -- "left-padded, matches" --> H[proof recorded]
  G -- "right-padded, never matches" --> I["revert UnauthorizedIncomingProof"]
```

## Service Topology

```mermaid
flowchart LR
  subgraph script["Deploy.s.sol"]
    SR["selfReference(addr)"] -->|left-padded bytes32| WL["Whitelist entry 0"]
  end
  subgraph runtime["Runtime producers"]
    TC["Hyperlane TypeCasts.addressToBytes32"] -->|left-padded| CMP
    LZ["LayerZero origin.sender"] -->|left-padded| CMP
    AC["AddressConverter.toBytes32"] -->|left-padded| CMP
  end
  WL -->|raw equality, no normalization| CMP{"isWhitelisted"}
  CMP -->|match| OK["proof accepted"]
  CMP -->|mismatch| REV["UnauthorizedIncomingProof"]
```

## Why This Shape

**A named helper rather than three inline casts.** The correct form now exists in one place with the
rationale attached, so the next person to add a prover copies something correct. Three identical
inline expressions is how this bug reached three call sites in the first place.

**An assertion at each write site, not only in the helper.** The helper could be bypassed by a future
inline cast; the `require` catches that at deploy time, before an immutable `Whitelist` is fixed.

**The test pins against Hyperlane's real library, not a reimplementation.** `testSelfReferenceMatchesHyperlaneTypeCasts`
asserts `selfReference(addr) == TypeCasts.addressToBytes32(addr)` using
`@hyperlane-xyz/core/contracts/libs/TypeCasts.sol` — already a dependency of `HyperProver`. A test that
compared against a hand-written left-pad would pin nothing, because it would compare the same
assumption to itself. If Hyperlane ever changes its encoding, this test fails and says so.

**Plus a regression pin.** `testRegressionRightPaddedFormIsRejected` asserts the old
`bytes32(bytes20(addr))` form both differs from the helper output and fails
`AddressConverter.isValidAddress`, so reintroducing it breaks the build rather than a mainnet lane.

## Boundaries

- **`PolymerProver` is not changed** — no self-reference in its whitelist construction, so no bug.
- **No live-state migration.** Verified latent, so there is nothing on chain to correct. If a future
  audit finds a right-padded entry 0 on a live prover, that is a separate incident and goes through
  `SECURITY.md`'s private advisory path, not this PR.
- **The TypeScript `routes-deployer` path is not audited here.** Live entries are correct, which is
  evidence it left-pads properly, but this PR does not touch or verify that codebase.
- **`Deploy.s.sol` still has no end-to-end coverage.** These 5 tests cover the encoding helper only;
  the CREATE3 deploy path remains compile-verified and forked/testnet-unexercised. Called out
  separately as a standing gap.
- **No other cleanup.** Deliberately minimal so it is easy to review and easy to revert.

## Validation

| Gate | Result |
| --- | --- |
| `forge test` | 662 passed / 0 failed (657 before, 5 new) |
| `forge build` | clean |
| Old form eliminated | `grep 'bytes32(bytes20('` in `scripts/` returns only the explanatory NatSpec |
| Scope | 2 files; `PolymerProver` construction untouched (0 polymer lines in the diff) |
| On-chain latency check | `cast call getWhitelist()` on 4 live provers across chains 1/10/8453 — all left-padded |
